### PR TITLE
Remove non-trivial designated initializers.

### DIFF
--- a/bench/f32-dwconv-e2e.cc
+++ b/bench/f32-dwconv-e2e.cc
@@ -38,11 +38,12 @@ static void DWConvEnd2EndBenchmark(
   for (size_t i = 0; i < XNN_MAX_F32_DWCONV_UKERNELS; i++) {
     // Replace only the microkernel the matching kernel size.
     if (xnn_params.f32.dwconv[i].mr == mr) {
-      xnn_params.f32.dwconv[i] = (struct dwconv_parameters) {
-        .up = (xnn_dwconv_up_ukernel_function) dwconv,
-        .cr = cr,
-        .mr = mr,
-      };
+      struct dwconv_parameters param;
+      param.up = (xnn_dwconv_up_ukernel_function) dwconv;
+      param.cr = cr;
+      param.mr = mr;
+      param.qr = 0;
+      xnn_params.f32.dwconv[i] = param;
       break;
     }
   }


### PR DESCRIPTION
gcc(confirmed with gcc 7.5.0) fails to compile some benchmark code due to this:

https://stackoverflow.com/questions/31215971/non-trivial-designated-initializers-not-supported

This PR fixes it.