### PR TITLE
Fix building operator-size-test and subgraph-size-test using cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1631,17 +1631,19 @@ IF(XNNPACK_BUILD_TESTS)
 
   # ---[ Build size tests
 
-  ADD_EXECUTABLE(operator-size-test test/size.c)
+  ADD_EXECUTABLE(operator-size-test test/operator-size.c)
   SET_TARGET_PROPERTIES(operator-size-test PROPERTIES
     C_STANDARD 99
     C_EXTENSIONS NO)
   TARGET_LINK_LIBRARIES(operator-size-test PRIVATE XNNPACK)
+  TARGET_LINK_LIBRARIES(operator-size-test PUBLIC m)
 
-  ADD_EXECUTABLE(subgraph-size-test test/size.c)
+  ADD_EXECUTABLE(subgraph-size-test test/subgraph-size.c)
   SET_TARGET_PROPERTIES(subgraph-size-test PROPERTIES
     C_STANDARD 99
     C_EXTENSIONS NO)
   TARGET_LINK_LIBRARIES(subgraph-size-test PRIVATE XNNPACK)
+  TARGET_LINK_LIBRARIES(subgraph-size-test PUBLIC m)
 
   # ---[ Build operator-level unit tests
   ADD_EXECUTABLE(add-nc-test test/add-nc.cc)


### PR DESCRIPTION
Support building `operator-size-test` and `subgraph-size-test`  using cmake.

But running these tests will crash due to the variable assignment to null pointer address: 

https://github.com/google/XNNPACK/blob/master/test/subgraph-size.c#L23

https://github.com/google/XNNPACK/blob/b7dd29e2b63c699e62a3955dbc1d3db1cb204c13/src/subgraph.c#L53

