### PR TITLE
Aligned memory incorrectly being deallocated by free()

### DIFF
--- a/src/runtime.c
+++ b/src/runtime.c
@@ -545,7 +545,7 @@ enum xnn_status xnn_delete_runtime(
       xnn_release_memory(runtime->ops);
 
       xnn_release_memory(runtime->blobs);
-      xnn_release_memory(runtime->workspace);
+      xnn_release_simd_memory(runtime->workspace);
     }
     xnn_release_memory(runtime);
   }


### PR DESCRIPTION
`runtime->workspace` is allocated as aligned memory here:

https://github.com/google/XNNPACK/blob/05b98308e59b9abfc8c1206fefc9bebf19d7df4e/src/runtime.c#L332

But it is being deallocated by a non-aligned free operation. This causes an exception when compiled with MSVC and run on windows.