### PR TITLE
Add Bazel config_settings for the official Emscripten toolchain

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -7413,13 +7413,13 @@ config_setting(
 
 config_setting(
     name = "emscripten",
-    values = {"crosstool_top": "//toolchain:emscripten"},
+    values = {"crosstool_top": "//emscripten_toolchain:everything"},
 )
 
 config_setting(
     name = "emscripten_wasm",
     values = {
-        "crosstool_top": "//toolchain:emscripten",
+        "crosstool_top": "//emscripten_toolchain:everything",
         "cpu": "wasm",
     },
 )
@@ -7427,7 +7427,7 @@ config_setting(
 config_setting(
     name = "emscripten_wasmsimd",
     values = {
-        "crosstool_top": "//toolchain:emscripten",
+        "crosstool_top": "//emscripten_toolchain:everything",
         "cpu": "wasm",
         "copt": "-msimd128",
     },

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -7,6 +7,7 @@
 #   XNNPACK - optimized floating-point neural network operators library
 
 load(":build_defs.bzl", "xnnpack_aggregate_library", "xnnpack_benchmark", "xnnpack_binary", "xnnpack_cc_library", "xnnpack_gcc_std_copts", "xnnpack_min_size_copts", "xnnpack_msvc_std_copts", "xnnpack_optional_armcl_copts", "xnnpack_optional_armcl_deps", "xnnpack_optional_dnnl_copts", "xnnpack_optional_dnnl_deps", "xnnpack_optional_gemmlowp_copts", "xnnpack_optional_gemmlowp_deps", "xnnpack_optional_ruy_copts", "xnnpack_optional_ruy_deps", "xnnpack_optional_tflite_copts", "xnnpack_optional_tflite_deps", "xnnpack_std_cxxopts", "xnnpack_unit_test", "xnnpack_visibility")
+load("@bazel_skylib//lib:selects.bzl", "selects")
 
 licenses(["notice"])
 
@@ -7412,12 +7413,25 @@ config_setting(
 )
 
 config_setting(
-    name = "emscripten",
+    name = "emscripten_official",
     values = {"crosstool_top": "//emscripten_toolchain:everything"},
 )
 
 config_setting(
-    name = "emscripten_wasm",
+    name = "emscripten_tfjs_legacy",
+    values = {"crosstool_top": "//toolchain:emscripten"},
+)
+
+selects.config_setting_group(
+    name = "emscripten",
+    match_any = [
+        ":emscripten_official",
+        ":emscripten_tfjs_legacy",
+    ],
+)
+
+config_setting(
+    name = "emscripten_wasm_official",
     values = {
         "crosstool_top": "//emscripten_toolchain:everything",
         "cpu": "wasm",
@@ -7425,12 +7439,45 @@ config_setting(
 )
 
 config_setting(
-    name = "emscripten_wasmsimd",
+    name = "emscripten_wasm_tfjs_legacy",
+    values = {
+        "crosstool_top": "//toolchain:emscripten",
+        "cpu": "wasm",
+    },
+)
+
+selects.config_setting_group(
+    name = "emscripten_wasm",
+    match_any = [
+        ":emscripten_wasm_official",
+        ":emscripten_wasm_tfjs_legacy",
+    ],
+)
+
+config_setting(
+    name = "emscripten_wasmsimd_official",
     values = {
         "crosstool_top": "//emscripten_toolchain:everything",
         "cpu": "wasm",
         "copt": "-msimd128",
     },
+)
+
+config_setting(
+    name = "emscripten_wasmsimd_tfjs_legacy",
+    values = {
+        "crosstool_top": "//emscripten_toolchain:everything",
+        "cpu": "wasm",
+        "copt": "-msimd128",
+    },
+)
+
+selects.config_setting_group(
+    name = "emscripten_wasmsimd",
+    match_any = [
+        ":emscripten_wasmsimd_official",
+        ":emscripten_wasmsimd_tfjs_legacy",
+    ],
 )
 
 config_setting(

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -7,7 +7,6 @@
 #   XNNPACK - optimized floating-point neural network operators library
 
 load(":build_defs.bzl", "xnnpack_aggregate_library", "xnnpack_benchmark", "xnnpack_binary", "xnnpack_cc_library", "xnnpack_gcc_std_copts", "xnnpack_min_size_copts", "xnnpack_msvc_std_copts", "xnnpack_optional_armcl_copts", "xnnpack_optional_armcl_deps", "xnnpack_optional_dnnl_copts", "xnnpack_optional_dnnl_deps", "xnnpack_optional_gemmlowp_copts", "xnnpack_optional_gemmlowp_deps", "xnnpack_optional_ruy_copts", "xnnpack_optional_ruy_deps", "xnnpack_optional_tflite_copts", "xnnpack_optional_tflite_deps", "xnnpack_std_cxxopts", "xnnpack_unit_test", "xnnpack_visibility")
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 licenses(["notice"])
 
@@ -4710,6 +4709,7 @@ xnnpack_cc_library(
         "@pthreadpool",
     ] + select({
         ":emscripten": [],
+        ":emscripten_tfjs_legacy": [],
         "//conditions:default": ["@cpuinfo"],
     }),
 )
@@ -4752,6 +4752,7 @@ xnnpack_cc_library(
         "@pthreadpool",
     ] + select({
         ":emscripten": [],
+        ":emscripten_tfjs_legacy": [],
         "//conditions:default": ["@cpuinfo"],
     }),
 )
@@ -4800,6 +4801,7 @@ xnnpack_cc_library(
         "@pthreadpool",
     ] + select({
         ":emscripten": [],
+        ":emscripten_tfjs_legacy": [],
         "//conditions:default": ["@cpuinfo"],
     }),
 )
@@ -4841,6 +4843,7 @@ xnnpack_cc_library(
         "@pthreadpool",
     ] + select({
         ":emscripten": [],
+        ":emscripten_tfjs_legacy": [],
         "//conditions:default": ["@cpuinfo"],
     }),
 )
@@ -7413,7 +7416,7 @@ config_setting(
 )
 
 config_setting(
-    name = "emscripten_official",
+    name = "emscripten",
     values = {"crosstool_top": "//emscripten_toolchain:everything"},
 )
 
@@ -7422,16 +7425,8 @@ config_setting(
     values = {"crosstool_top": "//toolchain:emscripten"},
 )
 
-selects.config_setting_group(
-    name = "emscripten",
-    match_any = [
-        ":emscripten_official",
-        ":emscripten_tfjs_legacy",
-    ],
-)
-
 config_setting(
-    name = "emscripten_wasm_official",
+    name = "emscripten_wasm",
     values = {
         "crosstool_top": "//emscripten_toolchain:everything",
         "cpu": "wasm",
@@ -7446,16 +7441,8 @@ config_setting(
     },
 )
 
-selects.config_setting_group(
-    name = "emscripten_wasm",
-    match_any = [
-        ":emscripten_wasm_official",
-        ":emscripten_wasm_tfjs_legacy",
-    ],
-)
-
 config_setting(
-    name = "emscripten_wasmsimd_official",
+    name = "emscripten_wasmsimd",
     values = {
         "crosstool_top": "//emscripten_toolchain:everything",
         "cpu": "wasm",
@@ -7470,14 +7457,6 @@ config_setting(
         "cpu": "wasm",
         "copt": "-msimd128",
     },
-)
-
-selects.config_setting_group(
-    name = "emscripten_wasmsimd",
-    match_any = [
-        ":emscripten_wasmsimd_official",
-        ":emscripten_wasmsimd_tfjs_legacy",
-    ],
 )
 
 config_setting(

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -7453,7 +7453,7 @@ config_setting(
 config_setting(
     name = "emscripten_wasmsimd_tfjs_legacy",
     values = {
-        "crosstool_top": "//emscripten_toolchain:everything",
+        "crosstool_top": "//toolchain:emscripten",
         "cpu": "wasm",
         "copt": "-msimd128",
     },

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -84,6 +84,19 @@ http_archive(
    ],
 )
 
+# Skylib library used for taking the union of config groups with
+# 'selects.config_setting_group'
+http_archive(
+    name = "bazel_skylib",
+    urls = [
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
+    ],
+    sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
+)
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+bazel_skylib_workspace()
+
 # Android NDK location and version is auto-detected from $ANDROID_NDK_HOME environment variable
 android_ndk_repository(name = "androidndk")
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -83,3 +83,9 @@ http_archive(
        "https://github.com/google/ruy/archive/9f53ba413e6fc879236dcaa3e008915973d67a4f.zip",
    ],
 )
+
+# Android NDK location and version is auto-detected from $ANDROID_NDK_HOME environment variable
+android_ndk_repository(name = "androidndk")
+
+# Android SDK location and API is auto-detected from $ANDROID_HOME environment variable
+android_sdk_repository(name = "androidsdk")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -83,22 +83,3 @@ http_archive(
        "https://github.com/google/ruy/archive/9f53ba413e6fc879236dcaa3e008915973d67a4f.zip",
    ],
 )
-
-# Skylib library used for taking the union of config groups with
-# 'selects.config_setting_group'
-http_archive(
-    name = "bazel_skylib",
-    urls = [
-        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
-    ],
-    sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
-)
-load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
-bazel_skylib_workspace()
-
-# Android NDK location and version is auto-detected from $ANDROID_NDK_HOME environment variable
-android_ndk_repository(name = "androidndk")
-
-# Android SDK location and API is auto-detected from $ANDROID_HOME environment variable
-android_sdk_repository(name = "androidsdk")

--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -166,7 +166,9 @@ def xnnpack_cc_library(
             ":tvos_arm64": aarch64_srcs,
             ":tvos_x86_64": x86_srcs,
             ":emscripten_wasm": wasm_srcs,
+            ":emscripten_wasm_tfjs_legacy": wasm_srcs,
             ":emscripten_wasmsimd": wasmsimd_srcs,
+            ":emscripten_wasmsimd_tfjs_legacy": wasmsimd_srcs,
             "//conditions:default": [],
         }),
         copts = [
@@ -200,7 +202,9 @@ def xnnpack_cc_library(
             ":tvos_arm64": aarch64_copts,
             ":tvos_x86_64": gcc_x86_copts,
             ":emscripten_wasm": wasm_copts,
+            ":emscripten_wasm_tfjs_legacy": wasm_copts,
             ":emscripten_wasmsimd": wasmsimd_copts,
+            ":emscripten_wasmsimd_tfjs_legacy": wasmsimd_copts,
             "//conditions:default": [],
         }) + select({
             ":windows_x86_64_clang": ["/clang:" + opt for opt in gcc_copts],
@@ -281,7 +285,9 @@ def xnnpack_aggregate_library(
             ":tvos_arm64": aarch64_deps,
             ":tvos_x86_64": x86_deps,
             ":emscripten_wasm": wasm_deps,
+            ":emscripten_wasm_tfjs_legacy": wasm_deps,
             ":emscripten_wasmsimd": wasmsimd_deps,
+            ":emscripten_wasmsimd_tfjs_legacy": wasmsimd_deps,
         }),
     )
 
@@ -324,6 +330,7 @@ def xnnpack_unit_test(name, srcs, copts = [], mingw_copts = [], msys_copts = [],
             }) + copts,
             linkopts = select({
                 ":emscripten": xnnpack_emscripten_test_linkopts(),
+                ":emscripten_tfjs_legacy": xnnpack_emscripten_test_linkopts(),
                 "//conditions:default": [],
             }),
             linkstatic = True,
@@ -331,6 +338,7 @@ def xnnpack_unit_test(name, srcs, copts = [], mingw_copts = [], msys_copts = [],
                 "@com_google_googletest//:gtest_main",
             ] + deps + select({
                 ":emscripten": xnnpack_emscripten_deps(),
+                ":emscripten_tfjs_legacy": xnnpack_emscripten_deps(),
                 "//conditions:default": [],
             }),
             tags = tags,
@@ -356,6 +364,7 @@ def xnnpack_unit_test(name, srcs, copts = [], mingw_copts = [], msys_copts = [],
             }) + copts,
             linkopts = select({
                 ":emscripten": xnnpack_emscripten_test_linkopts(),
+                ":emscripten_tfjs_legacy": xnnpack_emscripten_test_linkopts(),
                 "//conditions:default": [],
             }),
             linkstatic = True,
@@ -363,6 +372,7 @@ def xnnpack_unit_test(name, srcs, copts = [], mingw_copts = [], msys_copts = [],
                 "@com_google_googletest//:gtest_main",
             ] + deps + select({
                 ":emscripten": xnnpack_emscripten_deps(),
+                ":emscripten_tfjs_legacy": xnnpack_emscripten_deps(),
                 "//conditions:default": [],
             }),
             testonly = True,
@@ -389,6 +399,7 @@ def xnnpack_binary(name, srcs, copts = [], deps = []):
         ] + copts,
         linkopts = select({
             ":emscripten": xnnpack_emscripten_minimal_linkopts(),
+            ":emscripten_tfjs_legacy": xnnpack_emscripten_minimal_linkopts(),
             "//conditions:default": [],
         }),
         linkstatic = True,
@@ -423,6 +434,7 @@ def xnnpack_benchmark(name, srcs, copts = [], deps = [], tags = []):
         }) + copts,
         linkopts = select({
             ":emscripten": xnnpack_emscripten_benchmark_linkopts(),
+            ":emscripten_tfjs_legacy": xnnpack_emscripten_benchmark_linkopts(),
             ":windows_x86_64_mingw": ["-lshlwapi"],
             ":windows_x86_64_msys": ["-lshlwapi"],
             "//conditions:default": [],
@@ -432,6 +444,7 @@ def xnnpack_benchmark(name, srcs, copts = [], deps = [], tags = []):
             "@com_google_benchmark//:benchmark",
         ] + deps + select({
             ":emscripten": xnnpack_emscripten_deps(),
+            ":emscripten_tfjs_legacy": xnnpack_emscripten_deps(),
             "//conditions:default": [],
         }),
 	tags = tags,

--- a/third_party/cpuinfo.BUILD
+++ b/third_party/cpuinfo.BUILD
@@ -334,5 +334,5 @@ config_setting(
 
 config_setting(
     name = "emscripten",
-    values = {"crosstool_top": "//toolchain:emscripten"},
+    values = {"crosstool_top": "//emscripten_toolchain:everything"},
 )

--- a/third_party/cpuinfo.BUILD
+++ b/third_party/cpuinfo.BUILD
@@ -1,6 +1,4 @@
 # cpuinfo, a library to detect information about the host CPU
-load("@bazel_skylib//lib:selects.bzl", "selects")
-
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])
@@ -122,6 +120,7 @@ cc_library(
         ":tvos_x86_64": COMMON_SRCS + X86_SRCS + MACH_SRCS + MACH_X86_SRCS,
         ":tvos_arm64": COMMON_SRCS + MACH_SRCS + MACH_ARM_SRCS,
         ":emscripten": COMMON_SRCS + EMSCRIPTEN_SRCS,
+        ":emscripten_tfjs_legacy": COMMON_SRCS + EMSCRIPTEN_SRCS,
     }),
     copts = select({
         ":windows_x86_64": [],
@@ -335,19 +334,11 @@ config_setting(
 )
 
 config_setting(
-    name = "emscripten_official",
+    name = "emscripten",
     values = {"crosstool_top": "//emscripten_toolchain:everything"},
 )
 
 config_setting(
     name = "emscripten_tfjs_legacy",
     values = {"crosstool_top": "//toolchain:emscripten"},
-)
-
-selects.config_setting_group(
-    name = "emscripten",
-    match_any = [
-        ":emscripten_official",
-        ":emscripten_tfjs_legacy",
-    ],
 )

--- a/third_party/cpuinfo.BUILD
+++ b/third_party/cpuinfo.BUILD
@@ -1,4 +1,6 @@
 # cpuinfo, a library to detect information about the host CPU
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])
@@ -333,6 +335,19 @@ config_setting(
 )
 
 config_setting(
-    name = "emscripten",
+    name = "emscripten_official",
     values = {"crosstool_top": "//emscripten_toolchain:everything"},
+)
+
+config_setting(
+    name = "emscripten_tfjs_legacy",
+    values = {"crosstool_top": "//toolchain:emscripten"},
+)
+
+selects.config_setting_group(
+    name = "emscripten",
+    match_any = [
+        ":emscripten_official",
+        ":emscripten_tfjs_legacy",
+    ],
 )


### PR DESCRIPTION
Current Bazel config settings for Emscripten are specific to TensorFlow.js's custom Emscripten toolchain. This PR adds config_settings for [the official toolchain](https://github.com/emscripten-core/emsdk/tree/master/bazel).