### PR TITLE
Fix allocator initialize issue on Windows

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -3037,7 +3037,7 @@ enum xnn_status xnn_initialize(const struct xnn_allocator* allocator) {
     allocator = &xnn_default_allocator;
   }
   #ifdef _MSC_VER
-    _InterlockedCompareExchangePointer(&init_allocator, NULL, allocator);
+    _InterlockedCompareExchangePointer(&init_allocator, allocator, NULL);
   #else
     __sync_bool_compare_and_swap(&init_allocator, NULL, allocator);
   #endif


### PR DESCRIPTION
The arguments are flipped, according to https://docs.microsoft.com/en-us/windows/win32/api/winnt/nf-winnt-interlockedcompareexchangepointer. Correcting it so that `init_allocator` is not NULL.