### PR TITLE
Workaround -Wincompatible-pointer-types

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -3432,7 +3432,7 @@ enum xnn_status xnn_initialize(const struct xnn_allocator* allocator) {
     allocator = &xnn_default_allocator;
   }
   #ifdef _MSC_VER
-    _InterlockedCompareExchangePointer(&init_allocator, allocator, NULL);
+    _InterlockedCompareExchangePointer((void* volatile)(&init_allocator), allocator, NULL);
   #else
     __sync_bool_compare_and_swap(&init_allocator, NULL, allocator);
   #endif

--- a/src/init.c
+++ b/src/init.c
@@ -3432,7 +3432,7 @@ enum xnn_status xnn_initialize(const struct xnn_allocator* allocator) {
     allocator = &xnn_default_allocator;
   }
   #ifdef _MSC_VER
-    _InterlockedCompareExchangePointer((void* volatile)(&init_allocator), allocator, NULL);
+    _InterlockedCompareExchangePointer((void* volatile*) &init_allocator, allocator, NULL);
   #else
     __sync_bool_compare_and_swap(&init_allocator, NULL, allocator);
   #endif


### PR DESCRIPTION
The first operand of `InterlockedCompareExchangePointer` has type `void* volatile* Destination`, thus triggering the warning under clang-cl.

This PR adds explicit type casting to workaround this.