### PR TITLE
Add patch for MSVC intrinsics

### DIFF
--- a/src/xnnpack/intrinsics-polyfill.h
+++ b/src/xnnpack/intrinsics-polyfill.h
@@ -38,7 +38,8 @@ void _mm_storeu_si32(const void* address, __m128i v) {
     (defined(__clang__) && !defined(__apple_build_version__) && (__clang_major__ < 8)) || \
     (defined(__clang__) && defined(__ANDROID__) && (__clang_major__ == 8) && (__clang_minor__ == 0) && (__clang_patchlevel__ < 7)) || \
     (defined(__clang__) && defined(__apple_build_version__) && (__apple_build_version__ < 11000000)) || \
-    (defined(__INTEL_COMPILER) && (__INTEL_COMPILER < 1800))
+    (defined(__INTEL_COMPILER) && (__INTEL_COMPILER < 1800)) || \
+    (defined(_MSC_VER) && !defined(__clang__) && !defined(__GNUC__))
 
 static XNN_INTRINSIC
 __mmask16 _cvtu32_mask16(unsigned int mask) {


### PR DESCRIPTION
When building XNNPACK with MSVC, I get warnings about undefined intrinsic functions, which eventually turn into link errors:

```
up32x4-minmax-avx512f.c(153): warning C4013: '_cvtu32_mask16' undefined; assuming extern returning int

...

lld-link: error: undefined symbol: _cvtu32_mask16
```

Adding this patch properly defines these symbols and causes the warnings to go away.