### PR TITLE
Polyfill missing AVX512 intrinsics on MSVC

### DIFF
--- a/src/xnnpack/intrinsics-polyfill.h
+++ b/src/xnnpack/intrinsics-polyfill.h
@@ -33,7 +33,7 @@ void _mm_storeu_si32(const void* address, __m128i v) {
 #ifdef __AVX512F__
 #include <immintrin.h>
 
-// GCC pre-7, Clang pre-8, Android NDK Clang pre-8.0.7, Apple Clang pre-11, and ICC pre-18
+// GCC pre-7, Clang pre-8, Android NDK Clang pre-8.0.7, Apple Clang pre-11, ICC pre-18, and MSVC
 #if (defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER) && (__GNUC__ < 7)) || \
     (defined(__clang__) && !defined(__apple_build_version__) && (__clang_major__ < 8)) || \
     (defined(__clang__) && defined(__ANDROID__) && (__clang_major__ == 8) && (__clang_minor__ == 0) && (__clang_patchlevel__ < 7)) || \

--- a/src/xnnpack/intrinsics-polyfill.h
+++ b/src/xnnpack/intrinsics-polyfill.h
@@ -33,13 +33,13 @@ void _mm_storeu_si32(const void* address, __m128i v) {
 #ifdef __AVX512F__
 #include <immintrin.h>
 
-// GCC pre-7, Clang pre-8, Android NDK Clang pre-8.0.7, Apple Clang pre-11, ICC pre-18, and MSVC
+// GCC pre-7, Clang pre-8, Android NDK Clang pre-8.0.7, Apple Clang pre-11, ICC pre-18, and MSVC pre-2019
 #if (defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER) && (__GNUC__ < 7)) || \
     (defined(__clang__) && !defined(__apple_build_version__) && (__clang_major__ < 8)) || \
     (defined(__clang__) && defined(__ANDROID__) && (__clang_major__ == 8) && (__clang_minor__ == 0) && (__clang_patchlevel__ < 7)) || \
     (defined(__clang__) && defined(__apple_build_version__) && (__apple_build_version__ < 11000000)) || \
     (defined(__INTEL_COMPILER) && (__INTEL_COMPILER < 1800)) || \
-    (defined(_MSC_VER) && !defined(__clang__) && !defined(__GNUC__))
+    (defined(_MSC_VER) && !defined(__clang__) && !defined(__GNUC__) && (_MSC_VER <= 1916))
 
 static XNN_INTRINSIC
 __mmask16 _cvtu32_mask16(unsigned int mask) {

--- a/src/xnnpack/intrinsics-polyfill.h
+++ b/src/xnnpack/intrinsics-polyfill.h
@@ -38,7 +38,8 @@ void _mm_storeu_si32(const void* address, __m128i v) {
     (defined(__clang__) && !defined(__apple_build_version__) && (__clang_major__ < 8)) || \
     (defined(__clang__) && defined(__ANDROID__) && (__clang_major__ == 8) && (__clang_minor__ == 0) && (__clang_patchlevel__ < 7)) || \
     (defined(__clang__) && defined(__apple_build_version__) && (__apple_build_version__ < 11000000)) || \
-    (defined(__INTEL_COMPILER) && (__INTEL_COMPILER < 1800))
+    (defined(__INTEL_COMPILER) && (__INTEL_COMPILER < 1800)) || \
+    (defined(_MSC_VER) && !defined(__clang__) && !defined(__GNUC__))
 
 static XNN_INTRINSIC
 __mmask16 _cvtu32_mask16(unsigned int mask) {


### PR DESCRIPTION
When building XNNPACK with MSVC, I got many warnings about missing intrinsics that turned into link errors:

```
f32-dwconv\gen\up32x4-minmax-avx512f.c(153): warning C4013: '_cvtu32_mask16' undefined; assuming extern returning int

...

lld-link: error: undefined symbol: _cvtu32_mask16
```

Adding this patch to correctly define the polyfill for MSVC solved this error.