### PR TITLE
Fix missing braces around initializer warning

### DIFF
--- a/src/xnnpack/params.h
+++ b/src/xnnpack/params.h
@@ -1943,7 +1943,7 @@ struct xnn_hmp_gemm_ukernel {
 };
 
 static inline struct xnn_hmp_gemm_ukernel xnn_init_hmp_gemm_ukernel(xnn_gemm_ukernel_function function) {
-  struct xnn_hmp_gemm_ukernel ukernel = { function };
+  struct xnn_hmp_gemm_ukernel ukernel = {{ function }};
   for (size_t i = 1; i < XNN_MAX_UARCH_TYPES; i++) {
     ukernel.function[i] = function;
   }
@@ -1968,7 +1968,7 @@ struct xnn_hmp_igemm_ukernel {
 };
 
 static inline struct xnn_hmp_igemm_ukernel xnn_init_hmp_igemm_ukernel(xnn_igemm_ukernel_function function) {
-  struct xnn_hmp_igemm_ukernel ukernel = { function };
+  struct xnn_hmp_igemm_ukernel ukernel = {{ function }};
   for (size_t i = 1; i < XNN_MAX_UARCH_TYPES; i++) {
     ukernel.function[i] = function;
   }


### PR DESCRIPTION
As `xnn_hmp_igemm_ukernel` is a struct containing array, it should be initialized as `{{element}}`, otherwise compiler warns about missing braces, as shown in  https://godbolt.org/z/77dsc88T4