### PR TITLE
Older GCC friendly std::array init

### DIFF
--- a/src/xnnpack/assembler.h
+++ b/src/xnnpack/assembler.h
@@ -46,7 +46,7 @@ struct Label {
   // A label can only be bound once, binding it again leads to an error.
   bool bound = (offset != nullptr);
   // All users of this label, recorded by their offset in the Assembler buffer.
-  std::array<byte*, max_label_users> users = {0};
+  std::array<byte*, max_label_users> users{{0}};
   size_t num_users = 0;
 
   // Records a user (e.g. branch instruction) of this label.


### PR DESCRIPTION
Without this an older gcc e.g. 5.4.0 w/ c++11, generates "error: array
must be initialized with a brace-enclosed initializer"