### PR TITLE
Add missing src in PROD_AARCH64_NEONFP16ARITH_MICROKERNEL_SRCS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3182,6 +3182,7 @@ SET(PROD_AARCH64_NEONFP16ARITH_MICROKERNEL_SRCS
   src/f16-gavgpool/gen/7x-minmax-neonfp16arith-c8.c
   src/f16-gemm/gen/1x16-minmax-neonfp16arith-ld64.c
   src/f16-gemm/gen/6x16-minmax-neonfp16arith-ld64.c
+  src/f16-ibilinear/gen/neonfp16arith-c8.c
   src/f16-igemm/gen/1x16-minmax-neonfp16arith-ld64.c
   src/f16-igemm/gen/6x16-minmax-neonfp16arith-ld64.c
   src/f16-maxpool/9p8x-minmax-neonfp16arith-c8.c


### PR DESCRIPTION
fn xnn_f16_ibilinear_ukernel__neonfp16arith_c8 referenced by init()