### PR TITLE
Use scripts to build project in Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install ninja
         run: sudo apt-get install ninja-build
-      - name: Configure CMake
-        run: cmake -S . -B build -G Ninja
-        working-directory: ${{ github.workspace }}
-      - name: Build
-        run: cmake --build build -j
+      - name: Configure CMake and build
+        run: scripts/build-local.sh
         working-directory: ${{ github.workspace }}


### PR DESCRIPTION
Instead of calling CMake ourselves, use build scripts we already have in scripts/ to build project.