### PR TITLE
Select MSVC runtime library for cmake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,10 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-CMAKE_MINIMUM_REQUIRED(VERSION 3.12 FATAL_ERROR)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.15 FATAL_ERROR)
+
+# MSVC runtime library flags are selected by an abstraction.
+CMAKE_POLICY(SET CMP0091 NEW)
 
 # ---[ Project and semantic versioning.
 PROJECT(XNNPACK C CXX ASM)


### PR DESCRIPTION
Enable CMP0091 [1] that allows MSVC runtime library flags to be
selected by an abstraction. It is available in CMake 3.15 and later.

The CMAKE_MSVC_RUNTIME_LIBRARY variable and MSVC_RUNTIME_LIBRARY
target property may be set to select the MSVC runtime library.

For example, supplying

-DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreaded$<$<CONFIG:Debug>:Debug>"

selects the static MSVC runtime library.

[1]: https://cmake.org/cmake/help/latest/policy/CMP0091.html#policy:CMP0091