### PR TITLE
Fix WIN32_LEAN_AND_MEAN redefined warning for Chromium Windows build

### DIFF
--- a/src/memory.c
+++ b/src/memory.c
@@ -7,7 +7,9 @@
 #include "xnnpack/common.h"
 
 #if XNN_PLATFORM_WINDOWS
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
 #else
 #include <errno.h>

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -11,7 +11,9 @@
 #include <xnnpack/mutex.h>
 
 #if XNN_PLATFORM_WINDOWS
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
 #elif XNN_PLATFORM_MACOS || XNN_PLATFORM_IOS
 #include <dispatch/dispatch.h>

--- a/src/xnnpack/mutex.h
+++ b/src/xnnpack/mutex.h
@@ -9,7 +9,9 @@
 #include <xnnpack/common.h>
 
 #if XNN_PLATFORM_WINDOWS
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
 #elif XNN_PLATFORM_MACOS || XNN_PLATFORM_IOS
 #include <dispatch/dispatch.h>


### PR DESCRIPTION
This issue can be reproduced by building Chromium on Windows with following two flags in args.gn
```
build_with_tflite_lib=true
build_tflite_with_xnnpack=true
```