### PR TITLE
Add vcpkg installition instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ XNNPACK implements the following neural network operators:
 
 All operators in XNNPACK support NHWC layout, but additionally allow custom stride along the **C**hannel dimension. Thus, operators can consume a subset of channels in the input tensor, and produce a subset of channels in the output tensor, providing a zero-cost Channel Split and Channel Concatenation operations.
 
+## Building using vcpkg
+
+You can build and install xnnpack using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+- git clone https://github.com/Microsoft/vcpkg.git
+- cd vcpkg
+- ./bootstrap-vcpkg.sh  # ./bootstrap-vcpkg.bat for Windows
+- ./vcpkg integrate install
+- ./vcpkg install xnnpack
+
+The xnnpack port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## Performance
 
 ### Mobile phones


### PR DESCRIPTION
Xnnpack is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for xnnpack and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build xnnpack, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/xnnpack/portfile.cmake). We try to keep the library maintained as close as possible to the original library.