### PR TITLE
Add darwin_x86_64 CPU handling

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -11312,10 +11312,18 @@ config_setting(
 )
 
 config_setting(
-    name = "macos_x86_64",
+    name = "macos_x86_64_legacy",
     values = {
         "apple_platform_type": "macos",
         "cpu": "darwin",
+    },
+)
+
+config_setting(
+    name = "macos_x86_64",
+    values = {
+        "apple_platform_type": "macos",
+        "cpu": "darwin_x86_64",
     },
 )
 
@@ -11457,6 +11465,7 @@ selects.config_setting_group(
         ":ios_x86_64",
         ":linux_k8",
         ":macos_x86_64",
+        ":macos_x86_64_legacy",
         ":tvos_x86_64",
         ":watchos_x86_64",
         ":windows_x86_64",


### PR DESCRIPTION
Currently bazel supports `darwin` and `darwin_x86_64` as meaning the same thing. The fully qualified version is normally used if you're cross compiling from M1 machines to intel machines. I'm also hoping to remove the unqualified version to reduce confusion. This change makes it compatible with both for now.