### PR TITLE
[Request for Comments] Minimal Proof-of-concept of Dynamic Shape Support for xnn_runtime

### DIFF
--- a/include/xnnpack.h
+++ b/include/xnnpack.h
@@ -1826,6 +1826,8 @@ enum xnn_status xnn_create_runtime(
 struct xnn_external_value {
   uint32_t id;
   void* data;
+  size_t num_dims;
+  const size_t* dim;
 };
 
 /// Setup data pointers for external inputs and outputs in a Runtime object.

--- a/src/tensor.c
+++ b/src/tensor.c
@@ -541,7 +541,8 @@ enum xnn_shape_inference_status xnn_tensor_propagate_dimension(
     return xnn_shape_inference_status_no_change;
   }
 
-  if (inferred_dim < to->shape.minimum_dim[to_dim]) {
+  // HACK: skipping this for now to enable upper-bounded dynamic tensors with same minimum and maximum.
+  if (0 && inferred_dim < to->shape.minimum_dim[to_dim]) {
     xnn_log_error(
       "failed to infer dimension of tensor id %" PRIu32 ": inferred dimension (%zu) from tensor id %" PRIu32
       " is less than minimum dimension (%zu)", to->id, inferred_dim, from->id, to->shape.minimum_dim[to_dim]);

--- a/src/xnnpack/subgraph.h
+++ b/src/xnnpack/subgraph.h
@@ -145,6 +145,8 @@ struct xnn_value {
   // If not NULL, points to the original fp32 data, (which should be `data` before it was overwritten to point to
   // converted fp16 buffer.
   const void* fp32_data;
+  // temp change for PoC - this needs more discussions
+  const struct xnn_external_value* external_value;
 };
 
 

--- a/test/abs.cc
+++ b/test/abs.cc
@@ -111,3 +111,71 @@ TEST_F(AbsTestF32, matches_operator_api)
 
   ASSERT_EQ(subgraph_output, operator_output);
 }
+
+TEST_F(AbsTestF32, matches_operator_api_dynamic_shape_upper_bound)
+{
+  std::uniform_real_distribution<float> f32dist(-255.0f, 255.0f);
+  std::generate(input.begin(), input.end(), [&]() { return f32dist(rng); });
+  std::fill(operator_output.begin(), operator_output.end(), nanf(""));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), nanf(""));
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  // Call operator API.
+  xnn_operator_t op = nullptr;
+  const xnn_status status = xnn_create_abs_nc_f32(channels, channels, channels, /*flags=*/0, &op);
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  ASSERT_EQ(xnn_status_success, xnn_reshape_abs_nc_f32(op, batch_size, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_setup_abs_nc_f32(op, input.data(), operator_output.data()));
+
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+  input_id = XNN_INVALID_NODE_ID;
+
+  // Upperbounded input/output shapes derived from "real" dims
+  std::vector<size_t> input_dims(dims.size());
+  std::vector<size_t> output_dims(dims.size());
+  for (size_t i = 0; i < dims.size(); i++){
+    auto d = dims[i] + ((i == dims.size() - 1) ? 0 : rand() % 4);
+    input_dims[i] = d;
+    output_dims[i] = d;
+  }
+
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp32, input_dims.size(), input_dims.data(), nullptr, /*external_id=*/0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp32, output_dims.size(), output_dims.data(), nullptr, /*external_id=*/1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_define_abs(subgraph, input_id, output_id, /*flags=*/0));
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 2> external = {
+    xnn_external_value{input_id, input.data(), input_dims.size(), dims.data()},  // using actual dims as input_dims data with sizes smaller than the one planned for
+    xnn_external_value{output_id, subgraph_output.data(), output_dims.size(), output_dims.data()} // will be updated by runtime to reflect the actual output size
+  };
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+  ASSERT_EQ(subgraph_output, operator_output);
+  ASSERT_EQ(dims, output_dims);
+}


### PR DESCRIPTION
_This submission is not meant for an in-depth code review or for integration, but rather to initiate a discussion on the topic of dynamic shape support._


Based on this, I am looking forward to discussing:

1. The design for the runtime dynamic shape support in general.
    - The runtime and op->reshape() modifications for this feature, particularly if we plan to extend this to other operators and its implications for backwards compatibility.
1. Progress and concurrent development with the "Shape Inference" work for xnn_subgraph.
    - Support for upper bounded tensors by only specifying the maximum dimension size value, and with a default minimum value (= 1). This contrasts with calculating both the minimum and maximum for each tensor through shape inference.
