### PR TITLE
Fix for XNN_ENABLE_ARMFP16_VECTOR Flag

### DIFF
--- a/src/configs/unary-elementwise-config.c
+++ b/src/configs/unary-elementwise-config.c
@@ -594,18 +594,18 @@ static void init_f16_to_f32_cvt_config(void) {
 }
 
 static void init_f16_to_qs8_cvt_config(void) {
-  #if XNN_ARCH_ARM || XNN_ARCH_ARM64
+  #if (XNN_ARCH_ARM || XNN_ARCH_ARM64) && XNN_ENABLE_ARM_FP16_VECTOR && XNN_ENABLE_ARM_FP16_SCALAR
     const struct xnn_hardware_config* hardware_config = xnn_init_hardware_config();
     assert(hardware_config != NULL);
     if (hardware_config->use_arm_neon_fp16_arith) {
       f16_to_qs8_cvt_config.ukernel = (xnn_vunary_ukernel_fn) xnn_f16_qs8_vcvt_ukernel__neonfp16arith_u32;
       f16_to_qs8_cvt_config.init.f16_qs8_cvt = xnn_init_f16_qs8_cvt_neonfp16arith_params;
       f16_to_qs8_cvt_config.element_tile = 64;
-    } else {
-      f16_to_qs8_cvt_config.ukernel = (xnn_vunary_ukernel_fn) xnn_f16_qs8_vcvt_ukernel__scalar_imagic_u4;
-      f16_to_qs8_cvt_config.init.f16_qs8_cvt = xnn_init_f16_qs8_cvt_scalar_imagic_params;
-      f16_to_qs8_cvt_config.element_tile = 4;
     }
+  #elif XNN_ARCH_ARM || XNN_ARCH_ARM64
+    f16_to_qs8_cvt_config.ukernel = (xnn_vunary_ukernel_fn) xnn_f16_qs8_vcvt_ukernel__scalar_imagic_u4;
+    f16_to_qs8_cvt_config.init.f16_qs8_cvt = xnn_init_f16_qs8_cvt_scalar_imagic_params;
+    f16_to_qs8_cvt_config.element_tile = 4;
   #else
     f16_to_qs8_cvt_config.ukernel = (xnn_vunary_ukernel_fn) xnn_f16_qs8_vcvt_ukernel__scalar_imagic_u4;
     f16_to_qs8_cvt_config.init.f16_qs8_cvt = xnn_init_f16_qs8_cvt_scalar_imagic_params;


### PR DESCRIPTION
Was having trouble building and XNNPACK in PyTorch with 
```
set(XNNPACK_ENABLE_ARM_FP16_VECTOR OFF CACHE BOOL "")
```

Specifically, I was seeing the following error with the above flag being set:

```
Undefined symbols for architecture arm64:
  "_xnn_f16_qs8_vcvt_ukernel__neonfp16arith_u32", referenced from:
      _init_f16_to_qs8_cvt_config in libXNNPACK.a(unary-elementwise-config.c.o)
ld: symbol(s) not found for architecture arm64
```

The change introduced seems to fix this for me.