### PR TITLE
Reduce RVV test time for f32-vclamp-test

### DIFF
--- a/test/f32-vclamp.cc
+++ b/test/f32-vclamp.cc
@@ -191,7 +191,7 @@
   TEST(F32_VCLAMP__RVV_U1V, qmin) {
     TEST_REQUIRES_RISCV_VECTOR;
     for (uint8_t qmin = 1; qmin < 255; qmin++) {
-      for (size_t batch_size = 1; batch_size <= 5 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size += 1) {
+      for (size_t batch_size = 1; batch_size <= 5 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size += 9) {
         VUnaryMicrokernelTester()
           .batch_size(batch_size)
           .qmin(qmin)
@@ -203,7 +203,7 @@
   TEST(F32_VCLAMP__RVV_U1V, qmax) {
     TEST_REQUIRES_RISCV_VECTOR;
     for (uint8_t qmax = 1; qmax < 255; qmax++) {
-      for (size_t batch_size = 1; batch_size <= 5 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size += 1) {
+      for (size_t batch_size = 1; batch_size <= 5 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size += 9) {
         VUnaryMicrokernelTester()
           .batch_size(batch_size)
           .qmax(qmax)
@@ -262,7 +262,7 @@
   TEST(F32_VCLAMP__RVV_U2V, qmin) {
     TEST_REQUIRES_RISCV_VECTOR;
     for (uint8_t qmin = 1; qmin < 255; qmin++) {
-      for (size_t batch_size = 1; batch_size <= 10 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size += 1) {
+      for (size_t batch_size = 1; batch_size <= 10 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size += 19) {
         VUnaryMicrokernelTester()
           .batch_size(batch_size)
           .qmin(qmin)
@@ -274,7 +274,7 @@
   TEST(F32_VCLAMP__RVV_U2V, qmax) {
     TEST_REQUIRES_RISCV_VECTOR;
     for (uint8_t qmax = 1; qmax < 255; qmax++) {
-      for (size_t batch_size = 1; batch_size <= 10 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size += 1) {
+      for (size_t batch_size = 1; batch_size <= 10 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size += 19) {
         VUnaryMicrokernelTester()
           .batch_size(batch_size)
           .qmax(qmax)
@@ -333,7 +333,7 @@
   TEST(F32_VCLAMP__RVV_U4V, qmin) {
     TEST_REQUIRES_RISCV_VECTOR;
     for (uint8_t qmin = 1; qmin < 255; qmin++) {
-      for (size_t batch_size = 1; batch_size <= 20 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size += 3) {
+      for (size_t batch_size = 1; batch_size <= 20 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size += 39) {
         VUnaryMicrokernelTester()
           .batch_size(batch_size)
           .qmin(qmin)
@@ -345,7 +345,7 @@
   TEST(F32_VCLAMP__RVV_U4V, qmax) {
     TEST_REQUIRES_RISCV_VECTOR;
     for (uint8_t qmax = 1; qmax < 255; qmax++) {
-      for (size_t batch_size = 1; batch_size <= 20 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size += 3) {
+      for (size_t batch_size = 1; batch_size <= 20 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size += 39) {
         VUnaryMicrokernelTester()
           .batch_size(batch_size)
           .qmax(qmax)
@@ -404,7 +404,7 @@
   TEST(F32_VCLAMP__RVV_U8V, qmin) {
     TEST_REQUIRES_RISCV_VECTOR;
     for (uint8_t qmin = 1; qmin < 255; qmin++) {
-      for (size_t batch_size = 1; batch_size <= 40 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size += 7) {
+      for (size_t batch_size = 1; batch_size <= 40 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size += 79) {
         VUnaryMicrokernelTester()
           .batch_size(batch_size)
           .qmin(qmin)
@@ -416,7 +416,7 @@
   TEST(F32_VCLAMP__RVV_U8V, qmax) {
     TEST_REQUIRES_RISCV_VECTOR;
     for (uint8_t qmax = 1; qmax < 255; qmax++) {
-      for (size_t batch_size = 1; batch_size <= 40 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size += 7) {
+      for (size_t batch_size = 1; batch_size <= 40 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size += 79) {
         VUnaryMicrokernelTester()
           .batch_size(batch_size)
           .qmax(qmax)

--- a/tools/generate-vunary-test.py
+++ b/tools/generate-vunary-test.py
@@ -112,7 +112,7 @@ $if OP_TYPE == "Clamp":
     $if ISA_CHECK:
       ${ISA_CHECK};
     for (uint8_t qmin = 1; qmin < 255; qmin++) {
-      for (size_t batch_size = 1; batch_size <= ${BATCH_TILE*5}${BATCH_SCALE}; batch_size += ${max(1, BATCH_TILE-1)}) {
+      for (size_t batch_size = 1; batch_size <= ${BATCH_TILE*5}${BATCH_SCALE}; batch_size += ${max(1, BATCH_TILE-1 if BATCH_SCALE == "" else (BATCH_TILE * 10 - 1))}) {
         VUnaryMicrokernelTester()
           .batch_size(batch_size)
           .qmin(qmin)
@@ -125,7 +125,7 @@ $if OP_TYPE == "Clamp":
     $if ISA_CHECK:
       ${ISA_CHECK};
     for (uint8_t qmax = 1; qmax < 255; qmax++) {
-      for (size_t batch_size = 1; batch_size <= ${BATCH_TILE*5}${BATCH_SCALE}; batch_size += ${max(1, BATCH_TILE-1)}) {
+      for (size_t batch_size = 1; batch_size <= ${BATCH_TILE*5}${BATCH_SCALE}; batch_size += ${max(1, BATCH_TILE-1 if BATCH_SCALE == "" else (BATCH_TILE * 10 - 1))}) {
         VUnaryMicrokernelTester()
           .batch_size(batch_size)
           .qmax(qmax)


### PR DESCRIPTION
This commit aims to reduce rvv test time for RVV test for `f32-vclamp-test`.
Iterations/Time to run qmin/qmax test increase dramatically when VLEN increases.

This commit adds a scale factor(*10) to step.
The testing time reduces hugely in QEMU.

F32_VCLAMP__RVV_U8V.batch_gt_4v: 784 sec -> 82 sec
Before:
<img width="445" alt="image" src="https://github.com/google/XNNPACK/assets/55973122/711b7c8d-a613-40d5-af16-88847e457da7">
After:
![image](https://github.com/google/XNNPACK/assets/55973122/cedadb59-9a61-4ec1-9d1f-d814cf075220)
