### PR TITLE
Support xN-transpose benchmarking for problem sizes HW128, 256, and 512.

### DIFF
--- a/bench/x16-transpose.cc
+++ b/bench/x16-transpose.cc
@@ -62,6 +62,9 @@ static void BenchmarkKernelSize(benchmark::internal::Benchmark* b)
   b->Args({32, 32});
   b->Args({64, 64});
   b->Args({117, 117});
+  b->Args({128, 128});
+  b->Args({256, 256});
+  b->Args({512, 512});
   b->Args({1024, 1024});
 }
 

--- a/bench/x32-transpose.cc
+++ b/bench/x32-transpose.cc
@@ -62,6 +62,8 @@ static void BenchmarkKernelSize(benchmark::internal::Benchmark* b)
   b->Args({32, 32});
   b->Args({64, 64});
   b->Args({128, 128});
+  b->Args({256, 256});
+  b->Args({512, 512});
   b->Args({1024, 1024});
 }
 

--- a/bench/x64-transpose.cc
+++ b/bench/x64-transpose.cc
@@ -62,6 +62,9 @@ static void BenchmarkKernelSize(benchmark::internal::Benchmark* b)
   b->Args({32, 32});
   b->Args({64, 64});
   b->Args({117, 117});
+  b->Args({128, 128});
+  b->Args({256, 256});
+  b->Args({512, 512});
   b->Args({1024, 1024});
 }
 

--- a/bench/x8-transpose.cc
+++ b/bench/x8-transpose.cc
@@ -62,6 +62,9 @@ static void BenchmarkKernelSize(benchmark::internal::Benchmark* b)
   b->Args({32, 32});
   b->Args({64, 64});
   b->Args({117, 117});
+  b->Args({128, 128});
+  b->Args({256, 256});
+  b->Args({512, 512});
   b->Args({1024, 1024});
 }
 


### PR DESCRIPTION
Add support for different problem sizes in the xN transpose benchmark. The current benchmarking process addresses problem sizes in the 1xx range, leaving a notable gap before transitioning to a problem size of 1024. This gap impedes a comprehensive evaluation of the correlation between tile size and problem size. This commit incorporates problem sizes HW 128, 256, and 512 to offer a more nuanced exploration of the relationship between tile size and a broader spectrum of problem sizes.