### PR TITLE
Fix GTest linkage for new tests from commits 576ba7b and 06ae300

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1489,7 +1489,7 @@ IF(XNNPACK_BUILD_TESTS)
 
     ADD_EXECUTABLE(abs-reshape-test test/abs-reshape.cc)
     TARGET_INCLUDE_DIRECTORIES(abs-reshape-test PRIVATE src test)
-    TARGET_LINK_LIBRARIES(abs-reshape-test PRIVATE XNNPACK gtest gtest_main fp16)
+    TARGET_LINK_LIBRARIES(abs-reshape-test PRIVATE XNNPACK GTest::gtest GTest::gtest_main fp16)
     ADD_TEST(NAME abs-reshape-test COMMAND abs-reshape-test)
 
     ADD_EXECUTABLE(add2-test test/add2.cc)
@@ -1499,7 +1499,7 @@ IF(XNNPACK_BUILD_TESTS)
 
     ADD_EXECUTABLE(add2-reshape-test test/add2-reshape.cc)
     TARGET_INCLUDE_DIRECTORIES(add2-reshape-test PRIVATE src test)
-    TARGET_LINK_LIBRARIES(add2-reshape-test PRIVATE XNNPACK gtest gtest_main)
+    TARGET_LINK_LIBRARIES(add2-reshape-test PRIVATE XNNPACK GTest::gtest GTest::gtest_main)
     ADD_TEST(NAME add2-reshape-test COMMAND add2-reshape-test)
 
     ADD_EXECUTABLE(argmax-pooling-2d-test test/argmax-pooling-2d.cc)


### PR DESCRIPTION
Tried building the current codebase in my environment now that #5812 is merged, but a couple regressions found their way in:
```
[ 89%] Building CXX object CMakeFiles/add2-reshape-test.dir/test/add2-reshape.cc.o
/home/src/xnnpack/git20231226.9547e12/test/add2-reshape.cc:21:10: fatal error: 'gtest/gtest.h' file not found
   21 | #include <gtest/gtest.h>
      |          ^~~~~~~~~~~~~~~
1 error generated.

[ 93%] Building CXX object CMakeFiles/abs-reshape-test.dir/test/abs-reshape.cc.o
/home/src/xnnpack/git20231226.9547e12/test/abs-reshape.cc:21:10: fatal error: 'gtest/gtest.h' file not found
   21 | #include <gtest/gtest.h>
      |          ^~~~~~~~~~~~~~~
1 error generated.
```

This patch gets things working again, but some kind of regression test is needed for this (even if it's just a script grepping through the file) since it's all too easy to forget that the `GTest::` prefix is needed now.