### PR TITLE
[Dynamic Shapes] Fully-connected op

### DIFF
--- a/src/subgraph/fully-connected.c
+++ b/src/subgraph/fully-connected.c
@@ -322,6 +322,63 @@ static enum xnn_status create_fully_connected_operator(
   return status;
 }
 
+static enum xnn_status resize_fully_connected_output_tensor(
+  const struct xnn_operator_data* opdata,
+  struct xnn_value* values,
+  size_t num_values,
+  size_t old_workspace_size,
+  pthreadpool_t threadpool)
+{
+  const uint32_t filter_id = opdata->inputs[1];
+  const struct xnn_value* filter = &values[filter_id];
+
+  const uint32_t output_id = opdata->outputs[0];
+  struct xnn_value* output = (struct xnn_value*) &values[output_id];
+
+  const uint32_t input_id = opdata->inputs[0];
+  const struct xnn_value* input = &values[input_id];
+
+  // Infer output channels.
+  const uint32_t filter_output_channel_index = (opdata->flags & XNN_FLAG_TRANSPOSE_WEIGHTS) ? 1 : 0;
+  enum xnn_shape_inference_status status =
+    xnn_tensor_propagate_dimension(output, output->shape.num_dims - 1, filter->shape.dim[filter_output_channel_index]);
+  if (status == xnn_shape_inference_status_error) {
+    return xnn_status_invalid_parameter;
+  }
+
+  if (opdata->flags & XNN_FLAG_TENSORFLOW_RESHAPE_2D) {
+    const uint32_t filter_input_channel_index = (opdata->flags & XNN_FLAG_TRANSPOSE_WEIGHTS) ? 0 : 1;
+    const size_t num_input_elements = xnn_shape_multiply_all_dims(&input->shape);
+    assert(output->shape.num_dims == 2);
+    // propogate the input shape to output.
+    status =
+      xnn_tensor_propagate_dimension(output, 0, num_input_elements / filter->shape.dim[filter_input_channel_index]);
+    if (status == xnn_shape_inference_status_error) {
+      return xnn_status_invalid_parameter;
+    }
+  }
+  else {
+    // Make sure the input and output tensors have same number of dimensions.
+    assert(input->shape.num_dims == output->shape.num_dims);
+
+    // Propagate input shape to output.
+    for (size_t cur_dim = 0; cur_dim < input->shape.num_dims - 1; cur_dim++) {
+      status = xnn_tensor_propagate_dimension(output, cur_dim, input->shape.dim[cur_dim]);
+      if (status == xnn_shape_inference_status_error) {
+        return xnn_status_invalid_parameter;
+      }
+    }
+  }
+
+  const size_t new_size = xnn_tensor_get_size(output);
+  if (new_size > output->size || old_workspace_size < opdata->workspace_size) {
+    output->size = new_size;
+    return xnn_status_reallocation_required;
+  }
+
+  return xnn_status_success;
+}
+
 static enum xnn_status reshape_fully_connected_operator(
   struct xnn_operator_data* opdata,
   struct xnn_value* values,
@@ -342,82 +399,102 @@ static enum xnn_status reshape_fully_connected_operator(
     input_channels = values[filter_id].shape.dim[1];
   }
   const size_t batch_size = num_input_elements / input_channels;
+  const size_t old_workspace_size = opdata->workspace_size;
+  enum xnn_status status = xnn_status_invalid_state;
 
   switch (opdata->operator_objects[0]->type) {
     case xnn_operator_type_dynamic_fully_connected_nc_f16:
-      return xnn_reshape_dynamic_fully_connected_nc_f16(
+      status = xnn_reshape_dynamic_fully_connected_nc_f16(
         opdata->operator_objects[0],
         batch_size,
         input_channels, output_channels,
         input_channels, output_channels,
         &opdata->workspace_size, &opdata->workspace_alignment,
         threadpool);
+      break;
     case xnn_operator_type_dynamic_fully_connected_nc_f32:
-      return xnn_reshape_dynamic_fully_connected_nc_f32(
+      status = xnn_reshape_dynamic_fully_connected_nc_f32(
         opdata->operator_objects[0],
         batch_size,
         input_channels, output_channels,
         input_channels, output_channels,
         &opdata->workspace_size, &opdata->workspace_alignment,
         threadpool);
+      break;
     case xnn_operator_type_fully_connected_nc_f16:
-      return xnn_reshape_fully_connected_nc_f16(
+      status = xnn_reshape_fully_connected_nc_f16(
         opdata->operator_objects[0],
         batch_size,
         threadpool);
+      break;
     case xnn_operator_type_fully_connected_nc_f32:
-      return xnn_reshape_fully_connected_nc_f32(
+      status = xnn_reshape_fully_connected_nc_f32(
         opdata->operator_objects[0],
         batch_size,
         threadpool);
+      break;
     case xnn_operator_type_fully_connected_nc_f32_qc4w:
-      return xnn_reshape_fully_connected_nc_f32_qc4w(
+      status = xnn_reshape_fully_connected_nc_f32_qc4w(
         opdata->operator_objects[0],
         batch_size,
         threadpool);
+      break;
     case xnn_operator_type_fully_connected_nc_f32_qc8w:
-      return xnn_reshape_fully_connected_nc_f32_qc8w(
+      status = xnn_reshape_fully_connected_nc_f32_qc8w(
         opdata->operator_objects[0],
         batch_size,
         threadpool);
+      break;
     case xnn_operator_type_fully_connected_nc_qd8_f32_qc4w:
-      return xnn_reshape_fully_connected_nc_qd8_f32_qc4w(
+      status = xnn_reshape_fully_connected_nc_qd8_f32_qc4w(
         opdata->operator_objects[0],
         batch_size,
         threadpool);
+      break;
     case xnn_operator_type_fully_connected_nc_qd8_f16_qc4w:
-      return xnn_reshape_fully_connected_nc_qd8_f16_qc4w(
+      status = xnn_reshape_fully_connected_nc_qd8_f16_qc4w(
         opdata->operator_objects[0],
         batch_size,
         threadpool);
+      break;
     case xnn_operator_type_fully_connected_nc_qd8_f16_qc8w:
-      return xnn_reshape_fully_connected_nc_qd8_f16_qc8w(
+      status = xnn_reshape_fully_connected_nc_qd8_f16_qc8w(
         opdata->operator_objects[0],
         batch_size,
         threadpool);
+      break;
     case xnn_operator_type_fully_connected_nc_qd8_f32_qc8w:
-      return xnn_reshape_fully_connected_nc_qd8_f32_qc8w(
+      status = xnn_reshape_fully_connected_nc_qd8_f32_qc8w(
         opdata->operator_objects[0],
         batch_size,
         threadpool);
+      break;
     case xnn_operator_type_fully_connected_nc_qs8:
-      return xnn_reshape_fully_connected_nc_qs8(
+      status = xnn_reshape_fully_connected_nc_qs8(
         opdata->operator_objects[0],
         batch_size,
         threadpool);
+      break;
     case xnn_operator_type_fully_connected_nc_qs8_qc8w:
-      return xnn_reshape_fully_connected_nc_qs8_qc8w(
+      status = xnn_reshape_fully_connected_nc_qs8_qc8w(
         opdata->operator_objects[0],
         batch_size,
         threadpool);
+      break;
     case xnn_operator_type_fully_connected_nc_qu8:
-      return xnn_reshape_fully_connected_nc_qu8(
+      status = xnn_reshape_fully_connected_nc_qu8(
         opdata->operator_objects[0],
         batch_size,
         threadpool);
+      break;
     default:
       XNN_UNREACHABLE;
   }
+
+  if (status != xnn_status_success) {
+    return status;
+  }
+  return resize_fully_connected_output_tensor(opdata, values, num_values, old_workspace_size, threadpool);
 }
 
 static enum xnn_status setup_fully_connected_operator(

--- a/test/fully-connected.cc
+++ b/test/fully-connected.cc
@@ -2582,7 +2582,7 @@ TEST_F(FullyConnectedTestQD8F32QC4W, internally_allocated_dynamic_quantization_p
   ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
   ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
 
-  ASSERT_EQ(subgraph_output, operator_output);
+  EXPECT_THAT(subgraph_output, operator_output);
 }
 
 TEST_F(FullyConnectedTestQD8F32QC4W, internally_allocated_dynamic_quantization_parameters_transposed_weights)


### PR DESCRIPTION
Changes for dynamic shape support:
* Add output resize support for fully-connected op
* Remove shape_inference methods, no change in the subgraph file yet
* Add support for `XNN_FLAG_TENSORFLOW_RESHAPE_2D`. Not sure if this is used, so haven't added any tests
  
Other changes:
* Some of the QD tests were not setting the output rank correctly, fix that
* There is a flaky test - not sure if this fix is sufficient but should be in the right direction