### PR TITLE
[subgraph][sdpa] Add dynamic shape support

### DIFF
--- a/src/runtime.c
+++ b/src/runtime.c
@@ -55,7 +55,8 @@ enum xnn_status xnn_reshape_external_value(
     return xnn_status_invalid_parameter;
   }
   if (num_dims != value->shape.num_dims) {
-    xnn_log_error("failed to reshape runtime: new rank (%zu) is not equal to current rank (%zu)", num_dims, value->shape.num_dims);
+    xnn_log_error("failed to reshape external value (%d): new rank (%zu) is not equal to current rank (%zu)",
+            external_id, num_dims, value->shape.num_dims);
     return xnn_status_invalid_parameter;
   }
   struct xnn_shape* shape = &value->shape;

--- a/test/scaled-dot-product-attention.cc
+++ b/test/scaled-dot-product-attention.cc
@@ -88,6 +88,55 @@ class ScaledDotProductAttentionTestBase : public ::testing::Test {
     subgraph_output = std::vector<T>(operator_output.size());
   };
 
+  /*
+   * Resize internal member vectors to match new shapes.
+   * Also update other private variables to reflect new shapes.
+   */
+  void ResizeTensors(
+      std::vector<size_t>& query_dims,
+      std::vector<size_t>& key_dims,
+      std::vector<size_t>& value_dims,
+      std::vector<size_t>& mask_dims,
+      std::vector<size_t>& scale_dims,
+      std::vector<size_t>& output_dims,
+      bool resize_operator_output = true,
+      bool multi_query = false){
+
+    // Make sure of our assumptions
+    assert (query_dims.size() == 4);
+    assert (key_dims.size() == 4 || key_dims.size() == 3);
+    assert (value_dims.size() == 4 || value_dims.size() == 3);
+    assert (mask_dims.size() == 2);
+    assert (scale_dims.size() == 1);
+    assert (output_dims.size() == 4);
+
+    batch_size = 1;
+    for (size_t i = 0; i + 3 < query_dims.size(); ++i) {
+      batch_size *= query_dims[i];
+    }
+    query_heads = query_dims[query_dims.size() - 3];
+    query_tokens = query_dims[query_dims.size() - 2];
+    channels = query_dims[query_dims.size() - 1];
+
+    key_value_heads = (multi_query) ? 1 : key_dims[key_dims.size() - 3];
+
+    key_value_tokens = key_dims[key_dims.size() - 2];
+
+    value_channels = value_dims[value_dims.size() - 1];
+
+    query.resize(XNN_EXTRA_BYTES / sizeof(T) + NumElements(query_dims));
+    key.resize(XNN_EXTRA_BYTES / sizeof(T) + NumElements(key_dims));
+    value.resize(XNN_EXTRA_BYTES / sizeof(T) + NumElements(value_dims));
+    scale.resize(XNN_EXTRA_BYTES / sizeof(T) + NumElements(scale_dims));
+    mask.resize(XNN_EXTRA_BYTES / sizeof(T) + NumElements(mask_dims));
+    subgraph_output.resize(NumElements(output_dims));
+
+    // Resize operator output tensor only if explicitly requested.
+    if (resize_operator_output) {
+      operator_output.resize(NumElements(output_dims));
+    }
+  }
+
   std::vector<size_t> RandomShape(size_t num_dims)
   {
     std::vector<size_t> dims(num_dims);
@@ -323,6 +372,385 @@ TEST_F(ScaledDotProductAttentionTestF32, matches_operator_api) {
     xnn_external_value{scale_id, scale.data()},
     xnn_external_value{mask_id, mask.data()},
     xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  // Check outputs match.
+  for (size_t i = 0; i < operator_output.size(); i++) {
+    EXPECT_EQ(subgraph_output[i], operator_output[i]) << i;
+  }
+}
+
+TEST_F(ScaledDotProductAttentionTestF32, matches_operator_api_dynamic_shape_no_reallocation)
+{
+  /*
+   * This test makes sure the subgraph is able to match the operator API's with dynamically changing shapes.
+   * In this test, we will
+   *   1. Prepare a set of input tensors for the operator API.
+   *   2. Run the operator API, and save the output tensor.
+   *   3. Prepare an equivalent single node subgraph but with larger input shapes than ones used for the operator API in
+   * step 1.
+   *   4. Run the subgraph, and make sure it works.
+   *   5. Reshape the external inputs to match shapes in step 1.
+   *   6. Run the subgraph again, and make sure it produces similar output as the operator API, without requiring any
+   * reallocation after step 4.
+   */
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  size_t N = 2;    // batch size
+  size_t H = 2;    // num heads
+  size_t Tok = 4;  // tokens
+  size_t C = 5;    // channels
+  size_t U = Tok;  // tokens (self attention)
+  size_t D = 11;   // value channels
+
+  std::vector<size_t> op_query_dims = {N, H, Tok, C};
+  std::vector<size_t> op_key_dims = {N, H, U, C};
+  std::vector<size_t> op_value_dims = {N, H, U, D};
+  std::vector<size_t> op_scale_dims = {C};
+  std::vector<size_t> op_mask_dims = {Tok, U};
+  std::vector<size_t> op_output_dims = {N, H, Tok, D};
+
+  // Prepare the inputs and outputs for the operator API.
+  ResizeTensors(op_query_dims, op_key_dims, op_value_dims, op_mask_dims, op_scale_dims, op_output_dims);
+
+  std::generate(query.begin(), query.end(), [&]() { return f32dist(rng); });
+  std::generate(key.begin(), key.end(), [&]() { return f32dist(rng); });
+  std::generate(value.begin(), value.end(), [&]() { return f32dist(rng); });
+  std::generate(scale.begin(), scale.end(), [&]() { return f32dist(rng); });
+  std::generate(mask.begin(), mask.end(), [&]() { return f32dist(rng); });
+  std::fill(operator_output.begin(), operator_output.end(), nanf(""));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), nanf(""));
+
+  // Call operator API.
+  xnn_operator_t op = nullptr;
+  const xnn_status status = xnn_create_scaled_dot_product_attention_nhtc_f32(cap_type, &cap_params, /*flags=*/0, &op);
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+
+  size_t workspace_size = 0;
+  size_t workspace_alignment = 0;
+  ASSERT_EQ(
+    xnn_status_success, xnn_reshape_scaled_dot_product_attention_nhtc_f32(
+                          op, batch_size, query_heads, query_tokens, key_value_heads, key_value_tokens, channels,
+                          value_channels, &workspace_size, &workspace_alignment, /*threadpool=*/nullptr));
+  ASSERT_NE(workspace_size, 0);
+  ASSERT_LE(workspace_alignment, XNN_ALLOCATION_ALIGNMENT);
+
+  std::vector<char, AlignedAllocator<char, XNN_ALLOCATION_ALIGNMENT>> workspace(workspace_size);
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_setup_scaled_dot_product_attention_nhtc_f32(
+      op, workspace.data(), query.data(), key.data(), value.data(), scale.data(), mask.data(), operator_output.data()));
+
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Prepare input shapes for the Subgraph API.
+  // Make the input/output tensors shapes to be larger than the actual input/output tensors used for the operator API.
+  size_t N2 = N + 1;      // batch size
+  size_t H2 = H + 1;      // num heads
+  size_t Tok2 = Tok + 2;  // tokens
+  size_t C2 = C + 3;      // channels
+  size_t U2 = Tok2;       // tokens (self attention)
+  size_t D2 = D + 2;      // value channels
+
+  std::vector<size_t> subgraph_query_dims = {N2, H2, Tok2, C2};
+  std::vector<size_t> subgraph_key_dims = {N2, H2, U2, C2};
+  std::vector<size_t> subgraph_value_dims = {N2, H2, U2, D2};
+  std::vector<size_t> subgraph_scale_dims = {C2};
+  std::vector<size_t> subgraph_mask_dims = {Tok2, U2};
+  std::vector<size_t> subgraph_output_dims = {N2, H2, Tok2, D2};
+
+  // Resize the internal member tensors to match the new larger shapes (padding zeros).
+  // We don't want to modify the operator output tensor anymore.
+  ResizeTensors(
+    subgraph_query_dims, subgraph_key_dims, subgraph_value_dims, subgraph_mask_dims, subgraph_scale_dims,
+    subgraph_output_dims, /*resize_operator_output=*/false);
+
+  xnn_subgraph_t subgraph = nullptr;
+
+  // Call subgraph API.
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(6, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  uint32_t query_id = XNN_INVALID_VALUE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp32, subgraph_query_dims.size(), subgraph_query_dims.data(), nullptr,
+                          /*external_id=*/0, XNN_VALUE_FLAG_EXTERNAL_INPUT, &query_id));
+  ASSERT_NE(query_id, XNN_INVALID_VALUE_ID);
+
+  uint32_t key_id = XNN_INVALID_VALUE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp32, subgraph_key_dims.size(), subgraph_key_dims.data(), nullptr,
+                          /*external_id=*/1, XNN_VALUE_FLAG_EXTERNAL_INPUT, &key_id));
+  ASSERT_NE(key_id, XNN_INVALID_VALUE_ID);
+
+  uint32_t value_id = XNN_INVALID_VALUE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp32, subgraph_value_dims.size(), subgraph_value_dims.data(), nullptr,
+                          /*external_id=*/2, XNN_VALUE_FLAG_EXTERNAL_INPUT, &value_id));
+  ASSERT_NE(value_id, XNN_INVALID_VALUE_ID);
+
+  uint32_t scale_id = XNN_INVALID_VALUE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp32, subgraph_scale_dims.size(), subgraph_scale_dims.data(), nullptr,
+                          /*external_id=*/3, XNN_VALUE_FLAG_EXTERNAL_INPUT, &scale_id));
+  ASSERT_NE(scale_id, XNN_INVALID_VALUE_ID);
+
+  uint32_t mask_id = XNN_INVALID_VALUE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp32, subgraph_mask_dims.size(), subgraph_mask_dims.data(), nullptr,
+                          /*external_id=*/4, XNN_VALUE_FLAG_EXTERNAL_INPUT, &mask_id));
+  ASSERT_NE(mask_id, XNN_INVALID_VALUE_ID);
+
+  uint32_t output_id = XNN_INVALID_VALUE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp32, subgraph_output_dims.size(), subgraph_output_dims.data(),
+                          nullptr, /*external_id=*/5, XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_VALUE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_scaled_dot_product_attention(
+      subgraph, cap_type, &cap_params, query_id, key_id, value_id, scale_id, mask_id, output_id, /*flags=*/0));
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+
+  std::array<xnn_external_value, 6> external = {
+    xnn_external_value{query_id, query.data()}, xnn_external_value{key_id, key.data()},
+    xnn_external_value{value_id, value.data()}, xnn_external_value{scale_id, scale.data()},
+    xnn_external_value{mask_id, mask.data()},   xnn_external_value{output_id, subgraph_output.data()}};
+
+  const struct xnn_node* node = &subgraph->nodes[0];
+  // Since this is before setup, expect it to require reallocation
+  ASSERT_EQ(
+    xnn_status_reallocation_required,
+    node->reshape(&runtime->opdata[0], runtime->values, runtime->num_values, nullptr /* thradpool*/));
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  // Reshape the external tensors to the subgraph with the same shape as the ones used in the
+  // operator API, which are smaller than the ones supplied at subgraph creation time.
+  ASSERT_EQ(
+    xnn_status_success, xnn_reshape_external_value(runtime, query_id, op_query_dims.size(), op_query_dims.data()));
+  ASSERT_EQ(xnn_status_success, xnn_reshape_external_value(runtime, key_id, op_key_dims.size(), op_key_dims.data()));
+  ASSERT_EQ(
+    xnn_status_success, xnn_reshape_external_value(runtime, value_id, op_value_dims.size(), op_value_dims.data()));
+  ASSERT_EQ(
+    xnn_status_success, xnn_reshape_external_value(runtime, scale_id, op_scale_dims.size(), op_scale_dims.data()));
+  ASSERT_EQ(xnn_status_success, xnn_reshape_external_value(runtime, mask_id, op_mask_dims.size(), op_mask_dims.data()));
+  ASSERT_EQ(
+    xnn_status_success, xnn_reshape_external_value(runtime, output_id, op_output_dims.size(), op_output_dims.data()));
+
+  // Resize again to remove those extra elements we added earlier
+  ResizeTensors(
+    op_query_dims, op_key_dims, op_value_dims, op_mask_dims, op_scale_dims, op_output_dims,
+    /*resize_output_tensor*/ false);
+
+  // No reallocation since we should require less memory
+  ASSERT_EQ(
+    xnn_status_success,
+    node->reshape(&runtime->opdata[0], runtime->values, runtime->num_values, nullptr /* thradpool*/));
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  // Check outputs match.
+  for (size_t i = 0; i < operator_output.size(); i++) {
+    EXPECT_EQ(subgraph_output[i], operator_output[i]) << i;
+  }
+}
+
+TEST_F(ScaledDotProductAttentionTestF32, matches_operator_api_dynamic_shape_requires_reallocation)
+{
+  /*
+   * This test makes sure the subgraph is able to match the operator API's with dynamically changing shapes.
+   * In this test, we will
+   *   1. Prepare a set of input tensors for the operator API.
+   *   2. Run the operator API, and save the output tensor.
+   *   3. Prepare an equivalent single node subgraph but with smaller shapes than the ones used for the operator API in
+   * step 1.
+   *   4. Run the subgraph, and make sure it works.
+   *   5. Reshape the external inputs to match shapes in step 1.
+   *   6. Run the subgraph again, and make sure it produces similar output as the operator API, with requiring memory
+   * reallocation.
+   */
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  size_t N = 2;    // batch size
+  size_t H = 2;    // num heads
+  size_t Tok = 4;  // tokens
+  size_t C = 5;    // channels
+  size_t U = Tok;  // tokens (self attention)
+  size_t D = 11;   // value channels
+
+  std::vector<size_t> op_query_dims = {N, H, Tok, C};
+  std::vector<size_t> op_key_dims = {N, H, U, C};
+  std::vector<size_t> op_value_dims = {N, H, U, D};
+  std::vector<size_t> op_scale_dims = {C};
+  std::vector<size_t> op_mask_dims = {Tok, U};
+  std::vector<size_t> op_output_dims = {N, H, Tok, D};
+
+  // Prepare the inputs and outputs for both operator and subgraph
+  ResizeTensors(op_query_dims, op_key_dims, op_value_dims, op_mask_dims, op_scale_dims, op_output_dims);
+
+  std::generate(query.begin(), query.end(), [&]() { return f32dist(rng); });
+  std::generate(key.begin(), key.end(), [&]() { return f32dist(rng); });
+  std::generate(value.begin(), value.end(), [&]() { return f32dist(rng); });
+  std::generate(scale.begin(), scale.end(), [&]() { return f32dist(rng); });
+  std::generate(mask.begin(), mask.end(), [&]() { return f32dist(rng); });
+  std::fill(operator_output.begin(), operator_output.end(), nanf(""));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), nanf(""));
+
+  // Call operator API.
+  xnn_operator_t op = nullptr;
+  const xnn_status status = xnn_create_scaled_dot_product_attention_nhtc_f32(cap_type, &cap_params, /*flags=*/0, &op);
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+
+  size_t workspace_size = 0;
+  size_t workspace_alignment = 0;
+  ASSERT_EQ(
+    xnn_status_success, xnn_reshape_scaled_dot_product_attention_nhtc_f32(
+                          op, batch_size, query_heads, query_tokens, key_value_heads, key_value_tokens, channels,
+                          value_channels, &workspace_size, &workspace_alignment, /*threadpool=*/nullptr));
+  ASSERT_NE(workspace_size, 0);
+  ASSERT_LE(workspace_alignment, XNN_ALLOCATION_ALIGNMENT);
+
+  std::vector<char, AlignedAllocator<char, XNN_ALLOCATION_ALIGNMENT>> workspace(workspace_size);
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_setup_scaled_dot_product_attention_nhtc_f32(
+      op, workspace.data(), query.data(), key.data(), value.data(), scale.data(), mask.data(), operator_output.data()));
+
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Prepare for Subgraph API
+  // Input and Output external tensors are smaller than the actual input/output tensors used
+  size_t N2 = N - 1;      // batch size
+  size_t H2 = H - 1;      // num heads
+  size_t Tok2 = Tok - 2;  // tokens
+  size_t C2 = C - 3;      // channels
+  size_t U2 = Tok2;       // tokens (self attention)
+  size_t D2 = D - 2;      // value channels
+
+  std::vector<size_t> subgraph_query_dims = {N2, H2, Tok2, C2};
+  std::vector<size_t> subgraph_key_dims = {N2, H2, U2, C2};
+  std::vector<size_t> subgraph_value_dims = {N2, H2, U2, D2};
+  std::vector<size_t> subgraph_scale_dims = {C2};
+  std::vector<size_t> subgraph_mask_dims = {Tok2, U2};
+  std::vector<size_t> subgraph_output_dims = {N2, H2, Tok2, D2};
+
+  xnn_subgraph_t subgraph = nullptr;
+
+  // Call subgraph API.
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(6, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  uint32_t query_id = XNN_INVALID_VALUE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp32, subgraph_query_dims.size(), subgraph_query_dims.data(), nullptr,
+                          /*external_id=*/0, XNN_VALUE_FLAG_EXTERNAL_INPUT, &query_id));
+  ASSERT_NE(query_id, XNN_INVALID_VALUE_ID);
+
+  uint32_t key_id = XNN_INVALID_VALUE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp32, subgraph_key_dims.size(), subgraph_key_dims.data(), nullptr,
+                          /*external_id=*/1, XNN_VALUE_FLAG_EXTERNAL_INPUT, &key_id));
+  ASSERT_NE(key_id, XNN_INVALID_VALUE_ID);
+
+  uint32_t value_id = XNN_INVALID_VALUE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp32, subgraph_value_dims.size(), subgraph_value_dims.data(), nullptr,
+                          /*external_id=*/2, XNN_VALUE_FLAG_EXTERNAL_INPUT, &value_id));
+  ASSERT_NE(value_id, XNN_INVALID_VALUE_ID);
+
+  uint32_t scale_id = XNN_INVALID_VALUE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp32, subgraph_scale_dims.size(), subgraph_scale_dims.data(), nullptr,
+                          /*external_id=*/3, XNN_VALUE_FLAG_EXTERNAL_INPUT, &scale_id));
+  ASSERT_NE(scale_id, XNN_INVALID_VALUE_ID);
+
+  uint32_t mask_id = XNN_INVALID_VALUE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp32, subgraph_mask_dims.size(), subgraph_mask_dims.data(), nullptr,
+                          /*external_id=*/4, XNN_VALUE_FLAG_EXTERNAL_INPUT, &mask_id));
+  ASSERT_NE(mask_id, XNN_INVALID_VALUE_ID);
+
+  uint32_t output_id = XNN_INVALID_VALUE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp32, subgraph_output_dims.size(), subgraph_output_dims.data(),
+                          nullptr, /*external_id=*/5, XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_VALUE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_scaled_dot_product_attention(
+      subgraph, cap_type, &cap_params, query_id, key_id, value_id, scale_id, mask_id, output_id, /*flags=*/0));
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+
+  std::array<xnn_external_value, 6> external = {
+    xnn_external_value{query_id, query.data()}, xnn_external_value{key_id, key.data()},
+    xnn_external_value{value_id, value.data()}, xnn_external_value{scale_id, scale.data()},
+    xnn_external_value{mask_id, mask.data()},   xnn_external_value{output_id, subgraph_output.data()}};
+
+  const struct xnn_node* node = &subgraph->nodes[0];
+  // Since this is before setup, expect it to require reallocation
+  ASSERT_EQ(
+    xnn_status_reallocation_required,
+    node->reshape(&runtime->opdata[0], runtime->values, runtime->num_values, nullptr /* thradpool*/));
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  // Reshape the external tensors to the subgraph with the same shape as the ones used in the
+  // operator API, which are larger than the ones supplied at subgraph creation time.
+  ASSERT_EQ(
+    xnn_status_success, xnn_reshape_external_value(runtime, query_id, op_query_dims.size(), op_query_dims.data()));
+  ASSERT_EQ(xnn_status_success, xnn_reshape_external_value(runtime, key_id, op_key_dims.size(), op_key_dims.data()));
+  ASSERT_EQ(
+    xnn_status_success, xnn_reshape_external_value(runtime, value_id, op_value_dims.size(), op_value_dims.data()));
+  ASSERT_EQ(
+    xnn_status_success, xnn_reshape_external_value(runtime, scale_id, op_scale_dims.size(), op_scale_dims.data()));
+  ASSERT_EQ(xnn_status_success, xnn_reshape_external_value(runtime, mask_id, op_mask_dims.size(), op_mask_dims.data()));
+  ASSERT_EQ(
+    xnn_status_success, xnn_reshape_external_value(runtime, output_id, op_output_dims.size(), op_output_dims.data()));
+
+  // We will need more memory to run with the larger shape.
+  ASSERT_EQ(
+    xnn_status_reallocation_required,
+    node->reshape(&runtime->opdata[0], runtime->values, runtime->num_values, nullptr /* thradpool*/));
   ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
   ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
 


### PR DESCRIPTION
* Add output resize function.
* Add tests for no resize required and resize required similar to
  `matches_operator_api`.
    * Rationale to add such tests is to make sure shape change works
      correctly end-to-end with the intermediate buffers on the
      workspace.
    * Add a `Resize()` helper function to better manage of input tensors
      for user provided shapes and changes in them.