### PR TITLE
Add subgraph support for FP16 tensors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1568,22 +1568,22 @@ IF(XNNPACK_BUILD_TESTS)
 
     ADD_EXECUTABLE(concatenate2-test test/concatenate2.cc)
     TARGET_INCLUDE_DIRECTORIES(concatenate2-test PRIVATE src test)
-    TARGET_LINK_LIBRARIES(concatenate2-test PRIVATE XNNPACK GTest::gtest GTest::gtest_main subgraph)
+    TARGET_LINK_LIBRARIES(concatenate2-test PRIVATE XNNPACK GTest::gtest GTest::gtest_main subgraph fp16)
     ADD_TEST(NAME concatenate2-test COMMAND concatenate2-test)
 
     ADD_EXECUTABLE(concatenate3-test test/concatenate3.cc)
     TARGET_INCLUDE_DIRECTORIES(concatenate3-test PRIVATE src test)
-    TARGET_LINK_LIBRARIES(concatenate3-test PRIVATE XNNPACK GTest::gtest GTest::gtest_main subgraph)
+    TARGET_LINK_LIBRARIES(concatenate3-test PRIVATE XNNPACK GTest::gtest GTest::gtest_main subgraph fp16)
     ADD_TEST(NAME concatenate3-test COMMAND concatenate3-test)
 
     ADD_EXECUTABLE(concatenate4-test test/concatenate4.cc)
     TARGET_INCLUDE_DIRECTORIES(concatenate4-test PRIVATE src test)
-    TARGET_LINK_LIBRARIES(concatenate4-test PRIVATE XNNPACK GTest::gtest GTest::gtest_main subgraph)
+    TARGET_LINK_LIBRARIES(concatenate4-test PRIVATE XNNPACK GTest::gtest GTest::gtest_main subgraph fp16)
     ADD_TEST(NAME concatenate4-test COMMAND concatenate4-test)
 
     ADD_EXECUTABLE(concatenate5-test test/concatenate5.cc)
     TARGET_INCLUDE_DIRECTORIES(concatenate5-test PRIVATE src test)
-    TARGET_LINK_LIBRARIES(concatenate5-test PRIVATE XNNPACK GTest::gtest GTest::gtest_main subgraph)
+    TARGET_LINK_LIBRARIES(concatenate5-test PRIVATE XNNPACK GTest::gtest GTest::gtest_main subgraph fp16)
     ADD_TEST(NAME concatenate5-test COMMAND concatenate5-test)
 
     ADD_EXECUTABLE(convert-test test/convert.cc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1523,7 +1523,7 @@ IF(XNNPACK_BUILD_TESTS)
 
     ADD_EXECUTABLE(add2-test test/add2.cc)
     TARGET_INCLUDE_DIRECTORIES(add2-test PRIVATE src test)
-    TARGET_LINK_LIBRARIES(add2-test PRIVATE XNNPACK GTest::gtest GTest::gtest_main)
+    TARGET_LINK_LIBRARIES(add2-test PRIVATE fp16 XNNPACK GTest::gtest GTest::gtest_main)
     ADD_TEST(NAME add2-test COMMAND add2-test)
 
     ADD_EXECUTABLE(add2-reshape-test test/add2-reshape.cc)

--- a/src/subgraph/abs.c
+++ b/src/subgraph/abs.c
@@ -142,6 +142,7 @@ enum xnn_status xnn_define_abs(
   }
 
   switch (input_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
       break;
     default:
@@ -168,8 +169,13 @@ enum xnn_status xnn_define_abs(
     return status;
   }
 
+  enum xnn_compute_type compute_type = xnn_compute_type_invalid;
   switch (output_value->datatype) {
+    case xnn_datatype_fp16:
+      compute_type = xnn_compute_type_fp16;
+      break;
     case xnn_datatype_fp32:
+      compute_type = xnn_compute_type_fp32;
       break;
     default:
       xnn_log_error(
@@ -185,7 +191,7 @@ enum xnn_status xnn_define_abs(
   }
 
   node->type = xnn_node_type_abs;
-  node->compute_type = xnn_compute_type_fp32;
+  node->compute_type = compute_type;
   node->num_inputs = 1;
   node->inputs[0] = input_id;
   node->num_outputs = 1;

--- a/src/subgraph/add2.c
+++ b/src/subgraph/add2.c
@@ -262,6 +262,7 @@ enum xnn_status xnn_define_add2(
 
   switch (input1_value->datatype) {
     case xnn_datatype_fp32:
+    case xnn_datatype_fp16:
     case xnn_datatype_qint8:
     case xnn_datatype_quint8:
       break;
@@ -286,6 +287,7 @@ enum xnn_status xnn_define_add2(
 
   switch (input2_value->datatype) {
     case xnn_datatype_fp32:
+    case xnn_datatype_fp16:
     case xnn_datatype_qint8:
     case xnn_datatype_quint8:
       break;
@@ -312,6 +314,9 @@ enum xnn_status xnn_define_add2(
   switch (output_value->datatype) {
     case xnn_datatype_fp32:
       compute_type = xnn_compute_type_fp32;
+      break;
+    case xnn_datatype_fp16:
+      compute_type = xnn_compute_type_fp16;
       break;
     case xnn_datatype_qint8:
       compute_type = xnn_compute_type_qs8;

--- a/src/subgraph/average-pooling-2d.c
+++ b/src/subgraph/average-pooling-2d.c
@@ -264,6 +264,7 @@ enum xnn_status xnn_define_average_pooling_2d(
   }
 
   switch (input_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
       break;
     default:
@@ -285,8 +286,13 @@ enum xnn_status xnn_define_average_pooling_2d(
     return status;
   }
 
+  enum xnn_compute_type compute_type = xnn_compute_type_invalid;
   switch (output_value->datatype) {
+    case xnn_datatype_fp16:
+      compute_type = xnn_compute_type_fp16;
+      break;
     case xnn_datatype_fp32:
+      compute_type = xnn_compute_type_fp32;
       break;
     default:
       xnn_log_error(
@@ -302,7 +308,7 @@ enum xnn_status xnn_define_average_pooling_2d(
   }
 
   node->type = xnn_node_type_average_pooling_2d;
-  node->compute_type = xnn_compute_type_fp32;
+  node->compute_type = compute_type;
   node->params.pooling_2d.padding_top = input_padding_top;
   node->params.pooling_2d.padding_right = input_padding_right;
   node->params.pooling_2d.padding_bottom = input_padding_bottom;

--- a/src/subgraph/bankers-rounding.c
+++ b/src/subgraph/bankers-rounding.c
@@ -145,6 +145,7 @@ enum xnn_status xnn_define_bankers_rounding(
   }
 
   switch (input_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
       break;
     default:
@@ -171,8 +172,13 @@ enum xnn_status xnn_define_bankers_rounding(
     return status;
   }
 
+  enum xnn_compute_type compute_type = xnn_compute_type_invalid;
   switch (output_value->datatype) {
+    case xnn_datatype_fp16:
+      compute_type = xnn_compute_type_fp16;
+      break;
     case xnn_datatype_fp32:
+      compute_type = xnn_compute_type_fp32;
       break;
     default:
       xnn_log_error(
@@ -188,7 +194,7 @@ enum xnn_status xnn_define_bankers_rounding(
   }
 
   node->type = xnn_node_type_bankers_rounding;
-  node->compute_type = xnn_compute_type_fp32;
+  node->compute_type = compute_type;
   node->num_inputs = 1;
   node->inputs[0] = input_id;
   node->num_outputs = 1;

--- a/src/subgraph/ceiling.c
+++ b/src/subgraph/ceiling.c
@@ -145,6 +145,7 @@ enum xnn_status xnn_define_ceiling(
   }
 
   switch (input_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
       break;
     default:
@@ -171,8 +172,13 @@ enum xnn_status xnn_define_ceiling(
     return status;
   }
 
+  enum xnn_compute_type compute_type = xnn_compute_type_invalid;
   switch (output_value->datatype) {
+    case xnn_datatype_fp16:
+      compute_type = xnn_compute_type_fp16;
+      break;
     case xnn_datatype_fp32:
+      compute_type = xnn_compute_type_fp32;
       break;
     default:
       xnn_log_error(
@@ -188,7 +194,7 @@ enum xnn_status xnn_define_ceiling(
   }
 
   node->type = xnn_node_type_ceiling;
-  node->compute_type = xnn_compute_type_fp32;
+  node->compute_type = compute_type;
   node->num_inputs = 1;
   node->inputs[0] = input_id;
   node->num_outputs = 1;

--- a/src/subgraph/clamp.c
+++ b/src/subgraph/clamp.c
@@ -206,6 +206,7 @@ enum xnn_status xnn_define_clamp(
   }
 
   switch (input_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
     case xnn_datatype_qint8:
     case xnn_datatype_quint8:
@@ -236,6 +237,9 @@ enum xnn_status xnn_define_clamp(
 
   enum xnn_compute_type compute_type = xnn_compute_type_invalid;
   switch (output_value->datatype) {
+    case xnn_datatype_fp16:
+      compute_type = xnn_compute_type_fp16;
+      break;
     case xnn_datatype_fp32:
       compute_type = xnn_compute_type_fp32;
       break;

--- a/src/subgraph/convert.c
+++ b/src/subgraph/convert.c
@@ -362,6 +362,8 @@ static inline enum xnn_compute_type validate_datatypes(
       break;
     case xnn_datatype_qint8:
       switch (output_datatype) {
+        case xnn_datatype_fp16:
+          return xnn_compute_type_qs8_to_fp16;
         case xnn_datatype_fp32:
           return xnn_compute_type_qs8_to_fp32;
         case xnn_datatype_qint8:

--- a/src/subgraph/convolution-2d.c
+++ b/src/subgraph/convolution-2d.c
@@ -597,6 +597,11 @@ static inline enum xnn_compute_type validate_datatypes_with_bias(
           output_datatype == xnn_datatype_fp32)
       {
         return xnn_compute_type_fp32;
+      } else if (input_datatype == xnn_datatype_fp16 &&
+          bias_datatype == xnn_datatype_fp32 &&
+          output_datatype == xnn_datatype_fp16) {
+        // Flag: XNN_FLAG_FP32_STATIC_WEIGHTS
+        return xnn_compute_type_fp16;
       }
       break;
     case xnn_datatype_qint8:
@@ -648,6 +653,9 @@ static inline enum xnn_compute_type validate_datatypes_without_bias(
     case xnn_datatype_fp32:
       if (input_datatype == xnn_datatype_fp32 && output_datatype == xnn_datatype_fp32) {
         return xnn_compute_type_fp32;
+      } else if (input_datatype == xnn_datatype_fp16 && output_datatype == xnn_datatype_fp16) {
+        // Flag: XNN_FLAG_FP32_STATIC_WEIGHTS
+        return xnn_compute_type_fp16;
       }
       break;
     case xnn_datatype_qint8:
@@ -792,6 +800,7 @@ enum xnn_status xnn_define_convolution_2d(
   }
 
   switch (input_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
     case xnn_datatype_qint8:
     case xnn_datatype_quint8:
@@ -838,6 +847,7 @@ enum xnn_status xnn_define_convolution_2d(
 
   switch (filter_value->datatype) {
     case xnn_datatype_fp32:
+    case xnn_datatype_fp16:
       break;
     case xnn_datatype_qint8:
       if (filter_value->quantization.zero_point != 0) {
@@ -885,6 +895,7 @@ enum xnn_status xnn_define_convolution_2d(
     }
 
     switch (bias_value->datatype) {
+      case xnn_datatype_fp16:
       case xnn_datatype_fp32:
       case xnn_datatype_qint32:
       case xnn_datatype_qcint32:
@@ -918,9 +929,9 @@ enum xnn_status xnn_define_convolution_2d(
   }
 
   switch (output_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
     case xnn_datatype_qint8:
-    case xnn_datatype_fp16:
     case xnn_datatype_quint8:
       break;
     default:

--- a/src/subgraph/copy.c
+++ b/src/subgraph/copy.c
@@ -159,6 +159,7 @@ enum xnn_status xnn_define_copy(
   }
 
   switch (input_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
     case xnn_datatype_qint8:
     case xnn_datatype_quint8:
@@ -209,6 +210,9 @@ enum xnn_status xnn_define_copy(
 
   enum xnn_compute_type compute_type = xnn_compute_type_invalid;
   switch (output_value->datatype) {
+    case xnn_datatype_fp16:
+      compute_type = xnn_compute_type_fp16;
+      break;
     case xnn_datatype_fp32:
       compute_type = xnn_compute_type_fp32;
       break;

--- a/src/subgraph/deconvolution-2d.c
+++ b/src/subgraph/deconvolution-2d.c
@@ -345,6 +345,11 @@ static inline enum xnn_compute_type validate_datatypes_with_bias(
           output_datatype == xnn_datatype_fp32)
       {
         return xnn_compute_type_fp32;
+      } else if (input_datatype == xnn_datatype_fp16 &&
+          bias_datatype == xnn_datatype_fp32 &&
+          output_datatype == xnn_datatype_fp16) {
+        // Flag: XNN_FLAG_FP32_STATIC_WEIGHTS
+        return xnn_compute_type_fp16;
       }
       break;
     case xnn_datatype_qint8:
@@ -378,6 +383,9 @@ static inline enum xnn_compute_type validate_datatypes_without_bias(
     case xnn_datatype_fp32:
       if (input_datatype == xnn_datatype_fp32 && output_datatype == xnn_datatype_fp32) {
         return xnn_compute_type_fp32;
+      } else if (input_datatype == xnn_datatype_fp16 && output_datatype == xnn_datatype_fp16) {
+        // Flag: XNN_FLAG_FP32_STATIC_WEIGHTS
+        return xnn_compute_type_fp16;
       }
       break;
     case xnn_datatype_qint8:
@@ -485,6 +493,7 @@ enum xnn_status xnn_define_deconvolution_2d(
   }
 
   switch (input_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
     case xnn_datatype_qint8:
     case xnn_datatype_quint8:
@@ -520,6 +529,7 @@ enum xnn_status xnn_define_deconvolution_2d(
   }
 
   switch (filter_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
       break;
     case xnn_datatype_qint8:
@@ -566,6 +576,7 @@ enum xnn_status xnn_define_deconvolution_2d(
     }
 
     switch (bias_value->datatype) {
+      case xnn_datatype_fp16:
       case xnn_datatype_fp32:
       case xnn_datatype_qint32:
         break;
@@ -590,6 +601,7 @@ enum xnn_status xnn_define_deconvolution_2d(
   }
 
   switch (output_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
     case xnn_datatype_qint8:
     case xnn_datatype_quint8:

--- a/src/subgraph/depth-to-space-2d.c
+++ b/src/subgraph/depth-to-space-2d.c
@@ -256,6 +256,7 @@ enum xnn_status xnn_define_depth_to_space_2d(
   }
 
   switch (input_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
     case xnn_datatype_qint8:
     case xnn_datatype_quint8:
@@ -281,6 +282,9 @@ enum xnn_status xnn_define_depth_to_space_2d(
 
   enum xnn_compute_type compute_type = xnn_compute_type_invalid;
   switch (output_value->datatype) {
+    case xnn_datatype_fp16:
+      compute_type = xnn_compute_type_fp16;
+      break;
     case xnn_datatype_fp32:
       compute_type = xnn_compute_type_fp32;
       break;

--- a/src/subgraph/depthwise-convolution-2d.c
+++ b/src/subgraph/depthwise-convolution-2d.c
@@ -483,6 +483,11 @@ static inline enum xnn_compute_type validate_datatypes_with_bias(
           output_datatype == xnn_datatype_fp32)
       {
         return xnn_compute_type_fp32;
+      } else if (input_datatype == xnn_datatype_fp16 &&
+          bias_datatype == xnn_datatype_fp32 &&
+          output_datatype == xnn_datatype_fp16) {
+        // Flag: XNN_FLAG_FP32_STATIC_WEIGHTS
+        return xnn_compute_type_fp16;
       }
       break;
     case xnn_datatype_qint8:
@@ -524,6 +529,9 @@ static inline enum xnn_compute_type validate_datatypes_without_bias(
     case xnn_datatype_fp32:
       if (input_datatype == xnn_datatype_fp32 && output_datatype == xnn_datatype_fp32) {
         return xnn_compute_type_fp32;
+      } else if (input_datatype == xnn_datatype_fp16 && output_datatype == xnn_datatype_fp16) {
+        // Flag: XNN_FLAG_FP32_STATIC_WEIGHTS
+        return xnn_compute_type_fp16;
       }
       break;
     case xnn_datatype_qint8:
@@ -656,6 +664,7 @@ enum xnn_status xnn_define_depthwise_convolution_2d(
   }
 
   switch (input_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
     case xnn_datatype_qint8:
     case xnn_datatype_quint8:
@@ -691,6 +700,7 @@ enum xnn_status xnn_define_depthwise_convolution_2d(
   }
 
   switch (filter_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
       break;
     case xnn_datatype_qint8:
@@ -739,6 +749,7 @@ enum xnn_status xnn_define_depthwise_convolution_2d(
     }
 
     switch (bias_value->datatype) {
+      case xnn_datatype_fp16:
       case xnn_datatype_fp32:
       case xnn_datatype_qint32:
       case xnn_datatype_qcint32:
@@ -764,6 +775,7 @@ enum xnn_status xnn_define_depthwise_convolution_2d(
   }
 
   switch (output_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
     case xnn_datatype_qint8:
     case xnn_datatype_quint8:

--- a/src/subgraph/divide.c
+++ b/src/subgraph/divide.c
@@ -191,6 +191,7 @@ enum xnn_status xnn_define_divide(
   }
 
   switch (input1_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
       break;
     default:
@@ -213,6 +214,7 @@ enum xnn_status xnn_define_divide(
   }
 
   switch (input2_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
       break;
     default:
@@ -234,8 +236,13 @@ enum xnn_status xnn_define_divide(
     return status;
   }
 
+  enum xnn_compute_type compute_type = xnn_compute_type_invalid;
   switch (output_value->datatype) {
+    case xnn_datatype_fp16:
+      compute_type = xnn_compute_type_fp16;
+      break;
     case xnn_datatype_fp32:
+      compute_type = xnn_compute_type_fp32;
       break;
     default:
       xnn_log_error(
@@ -251,7 +258,7 @@ enum xnn_status xnn_define_divide(
   }
 
   node->type = xnn_node_type_divide;
-  node->compute_type = xnn_compute_type_fp32;
+  node->compute_type = compute_type;
   node->activation.output_min = output_min;
   node->activation.output_max = output_max;
   node->num_inputs = 2;

--- a/src/subgraph/elu.c
+++ b/src/subgraph/elu.c
@@ -183,6 +183,7 @@ enum xnn_status xnn_define_elu(
   }
 
   switch (input_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
     case xnn_datatype_qint8:
       break;
@@ -212,6 +213,9 @@ enum xnn_status xnn_define_elu(
 
   enum xnn_compute_type compute_type = xnn_compute_type_invalid;
   switch (output_value->datatype) {
+    case xnn_datatype_fp16:
+      compute_type = xnn_compute_type_fp16;
+      break;
     case xnn_datatype_fp32:
       compute_type = xnn_compute_type_fp32;
       break;

--- a/src/subgraph/floor.c
+++ b/src/subgraph/floor.c
@@ -144,6 +144,7 @@ enum xnn_status xnn_define_floor(
   }
 
   switch (input_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
       break;
     default:
@@ -170,8 +171,13 @@ enum xnn_status xnn_define_floor(
     return status;
   }
 
+  enum xnn_compute_type compute_type = xnn_compute_type_invalid;
   switch (output_value->datatype) {
+    case xnn_datatype_fp16:
+      compute_type = xnn_compute_type_fp16;
+      break;
     case xnn_datatype_fp32:
+      compute_type = xnn_compute_type_fp32;
       break;
     default:
       xnn_log_error(
@@ -187,7 +193,7 @@ enum xnn_status xnn_define_floor(
   }
 
   node->type = xnn_node_type_floor;
-  node->compute_type = xnn_compute_type_fp32;
+  node->compute_type = compute_type;
   node->num_inputs = 1;
   node->inputs[0] = input_id;
   node->num_outputs = 1;

--- a/src/subgraph/fully-connected-sparse.c
+++ b/src/subgraph/fully-connected-sparse.c
@@ -203,6 +203,11 @@ static inline enum xnn_compute_type validate_datatypes_with_bias(
           output_datatype == xnn_datatype_fp32)
       {
         return xnn_compute_type_fp32;
+      } else if (input_datatype == xnn_datatype_fp16 &&
+          bias_datatype == xnn_datatype_fp32 &&
+          output_datatype == xnn_datatype_fp16) {
+        // Flag: XNN_FLAG_FP32_STATIC_WEIGHTS
+        return xnn_compute_type_fp16;
       }
       break;
     default:
@@ -220,6 +225,9 @@ static inline enum xnn_compute_type validate_datatypes_without_bias(
     case xnn_datatype_fp32:
       if (input_datatype == xnn_datatype_fp32 && output_datatype == xnn_datatype_fp32) {
         return xnn_compute_type_fp32;
+      } else if (input_datatype == xnn_datatype_fp16 && output_datatype == xnn_datatype_fp16) {
+        // Flag: XNN_FLAG_FP32_STATIC_WEIGHTS
+        return xnn_compute_type_fp16;
       }
       break;
     default:
@@ -260,6 +268,7 @@ enum xnn_status xnn_define_fully_connected_sparse(
   }
 
   switch (input_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
       break;
     default:
@@ -293,6 +302,7 @@ enum xnn_status xnn_define_fully_connected_sparse(
   }
 
   switch (kernel_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
       break;
     default:
@@ -328,6 +338,7 @@ enum xnn_status xnn_define_fully_connected_sparse(
     }
 
     switch (bias_value->datatype) {
+      case xnn_datatype_fp16:
       case xnn_datatype_fp32:
         break;
       default:
@@ -351,6 +362,7 @@ enum xnn_status xnn_define_fully_connected_sparse(
   }
 
   switch (output_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
       break;
     default:

--- a/src/subgraph/fully-connected.c
+++ b/src/subgraph/fully-connected.c
@@ -709,6 +709,11 @@ static inline enum xnn_compute_type validate_datatypes_with_bias(
           output_datatype == xnn_datatype_fp32)
       {
         return xnn_compute_type_fp32;
+      } else if (input_datatype == xnn_datatype_fp16 &&
+          bias_datatype == xnn_datatype_fp32 &&
+          output_datatype == xnn_datatype_fp16) {
+        // Flag: XNN_FLAG_FP32_STATIC_WEIGHTS
+        return xnn_compute_type_fp16;
       }
       break;
     case xnn_datatype_qcint4:
@@ -776,6 +781,9 @@ static inline enum xnn_compute_type validate_datatypes_without_bias(
     case xnn_datatype_fp32:
       if (input_datatype == xnn_datatype_fp32 && output_datatype == xnn_datatype_fp32) {
         return xnn_compute_type_fp32;
+      } else if (input_datatype == xnn_datatype_fp16 && output_datatype == xnn_datatype_fp16) {
+        // Flag: XNN_FLAG_FP32_STATIC_WEIGHTS
+        return xnn_compute_type_fp16;
       }
       break;
     case xnn_datatype_qcint4:
@@ -842,6 +850,7 @@ enum xnn_status xnn_define_fully_connected(
   }
 
   switch (input_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
     case xnn_datatype_qint8:
     case xnn_datatype_quint8:
@@ -994,6 +1003,7 @@ enum xnn_status xnn_define_fully_connected(
     }
 
     switch (bias_value->datatype) {
+      case xnn_datatype_fp16:
       case xnn_datatype_fp32:
       case xnn_datatype_qint32:
         break;
@@ -1018,8 +1028,8 @@ enum xnn_status xnn_define_fully_connected(
   }
 
   switch (output_value->datatype) {
-    case xnn_datatype_fp32:
     case xnn_datatype_fp16:
+    case xnn_datatype_fp32:
     case xnn_datatype_qint8:
     case xnn_datatype_quint8:
       break;

--- a/src/subgraph/global-average-pooling.c
+++ b/src/subgraph/global-average-pooling.c
@@ -338,6 +338,7 @@ static enum xnn_status define_global_average_pooling_nd(
   }
 
   switch (input_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
     case xnn_datatype_qint8:
     case xnn_datatype_quint8:
@@ -363,6 +364,9 @@ static enum xnn_status define_global_average_pooling_nd(
 
   enum xnn_compute_type compute_type = xnn_compute_type_invalid;
   switch (output_value->datatype) {
+    case xnn_datatype_fp16:
+      compute_type = xnn_compute_type_fp16;
+      break;
     case xnn_datatype_fp32:
       compute_type = xnn_compute_type_fp32;
       break;

--- a/src/subgraph/global-sum-pooling.c
+++ b/src/subgraph/global-sum-pooling.c
@@ -214,6 +214,8 @@ static enum xnn_status define_global_sum_pooling_nd(
   }
 
   switch (input_value->datatype) {
+    case xnn_datatype_fp16:
+      break;
     case xnn_datatype_fp32:
       break;
     default:
@@ -237,6 +239,9 @@ static enum xnn_status define_global_sum_pooling_nd(
 
   enum xnn_compute_type compute_type = xnn_compute_type_invalid;
   switch (output_value->datatype) {
+    case xnn_datatype_fp16:
+      compute_type = xnn_compute_type_fp16;
+      break;
     case xnn_datatype_fp32:
       compute_type = xnn_compute_type_fp32;
       break;

--- a/src/subgraph/hardswish.c
+++ b/src/subgraph/hardswish.c
@@ -145,6 +145,8 @@ enum xnn_status xnn_define_hardswish(
   }
 
   switch (input_value->datatype) {
+    case xnn_datatype_fp16:
+      break;
     case xnn_datatype_fp32:
       break;
     default:
@@ -171,8 +173,13 @@ enum xnn_status xnn_define_hardswish(
     return status;
   }
 
+  enum xnn_compute_type compute_type = xnn_compute_type_invalid;
   switch (output_value->datatype) {
+    case xnn_datatype_fp16:
+      compute_type = xnn_compute_type_fp16;
+      break;
     case xnn_datatype_fp32:
+      compute_type = xnn_compute_type_fp32;
       break;
     default:
       xnn_log_error(
@@ -188,7 +195,7 @@ enum xnn_status xnn_define_hardswish(
   }
 
   node->type = xnn_node_type_hardswish;
-  node->compute_type = xnn_compute_type_fp32;
+  node->compute_type = compute_type;
   node->num_inputs = 1;
   node->inputs[0] = input_id;
   node->num_outputs = 1;

--- a/src/subgraph/leaky-relu.c
+++ b/src/subgraph/leaky-relu.c
@@ -202,6 +202,7 @@ enum xnn_status xnn_define_leaky_relu(
   }
 
   switch (input_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
     case xnn_datatype_qint8:
     case xnn_datatype_quint8:
@@ -232,6 +233,9 @@ enum xnn_status xnn_define_leaky_relu(
 
   enum xnn_compute_type compute_type = xnn_compute_type_invalid;
   switch (output_value->datatype) {
+    case xnn_datatype_fp16:
+      compute_type = xnn_compute_type_fp16;
+      break;
     case xnn_datatype_fp32:
       compute_type = xnn_compute_type_fp32;
       break;

--- a/src/subgraph/max-pooling-2d.c
+++ b/src/subgraph/max-pooling-2d.c
@@ -360,6 +360,7 @@ enum xnn_status xnn_define_max_pooling_2d(
   }
 
   switch (input_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
     case xnn_datatype_qint8:
     case xnn_datatype_quint8:
@@ -385,6 +386,9 @@ enum xnn_status xnn_define_max_pooling_2d(
 
   enum xnn_compute_type compute_type = xnn_compute_type_invalid;
   switch (output_value->datatype) {
+    case xnn_datatype_fp16:
+      compute_type = xnn_compute_type_fp16;
+      break;
     case xnn_datatype_fp32:
       compute_type = xnn_compute_type_fp32;
       break;

--- a/src/subgraph/maximum2.c
+++ b/src/subgraph/maximum2.c
@@ -181,6 +181,8 @@ enum xnn_status xnn_define_maximum2(
   }
 
   switch (input1_value->datatype) {
+    case xnn_datatype_fp16:
+      break;
     case xnn_datatype_fp32:
       break;
     default:
@@ -203,6 +205,8 @@ enum xnn_status xnn_define_maximum2(
   }
 
   switch (input2_value->datatype) {
+    case xnn_datatype_fp16:
+      break;
     case xnn_datatype_fp32:
       break;
     default:
@@ -224,8 +228,13 @@ enum xnn_status xnn_define_maximum2(
     return status;
   }
 
+  enum xnn_compute_type compute_type = xnn_compute_type_invalid;
   switch (output_value->datatype) {
+    case xnn_datatype_fp16:
+      compute_type = xnn_compute_type_fp16;
+      break;
     case xnn_datatype_fp32:
+      compute_type = xnn_compute_type_fp32;
       break;
     default:
       xnn_log_error(
@@ -241,7 +250,7 @@ enum xnn_status xnn_define_maximum2(
   }
 
   node->type = xnn_node_type_maximum2;
-  node->compute_type = xnn_compute_type_fp32;
+  node->compute_type = compute_type;
   node->num_inputs = 2;
   node->inputs[0] = input1_id;
   node->inputs[1] = input2_id;

--- a/src/subgraph/minimum2.c
+++ b/src/subgraph/minimum2.c
@@ -181,6 +181,8 @@ enum xnn_status xnn_define_minimum2(
   }
 
   switch (input1_value->datatype) {
+    case xnn_datatype_fp16:
+      break;
     case xnn_datatype_fp32:
       break;
     default:
@@ -203,6 +205,8 @@ enum xnn_status xnn_define_minimum2(
   }
 
   switch (input2_value->datatype) {
+    case xnn_datatype_fp16:
+      break;
     case xnn_datatype_fp32:
       break;
     default:
@@ -224,8 +228,13 @@ enum xnn_status xnn_define_minimum2(
     return status;
   }
 
+  enum xnn_compute_type compute_type = xnn_compute_type_invalid;
   switch (output_value->datatype) {
+    case xnn_datatype_fp16:
+      compute_type = xnn_compute_type_fp16;
+      break;
     case xnn_datatype_fp32:
+      compute_type = xnn_compute_type_fp32;
       break;
     default:
       xnn_log_error(
@@ -241,7 +250,7 @@ enum xnn_status xnn_define_minimum2(
   }
 
   node->type = xnn_node_type_minimum2;
-  node->compute_type = xnn_compute_type_fp32;
+  node->compute_type = compute_type;
   node->num_inputs = 2;
   node->inputs[0] = input1_id;
   node->inputs[1] = input2_id;

--- a/src/subgraph/multiply2.c
+++ b/src/subgraph/multiply2.c
@@ -265,6 +265,7 @@ enum xnn_status xnn_define_multiply2(
   }
 
   switch (input1_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
     case xnn_datatype_qint8:
     case xnn_datatype_quint8:
@@ -289,6 +290,7 @@ enum xnn_status xnn_define_multiply2(
   }
 
   switch (input2_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
     case xnn_datatype_qint8:
     case xnn_datatype_quint8:
@@ -314,6 +316,9 @@ enum xnn_status xnn_define_multiply2(
 
   enum xnn_compute_type compute_type = xnn_compute_type_invalid;
   switch (output_value->datatype) {
+    case xnn_datatype_fp16:
+      compute_type = xnn_compute_type_fp16;
+      break;
     case xnn_datatype_fp32:
       compute_type = xnn_compute_type_fp32;
       break;

--- a/src/subgraph/negate.c
+++ b/src/subgraph/negate.c
@@ -145,6 +145,7 @@ enum xnn_status xnn_define_negate(
   }
 
   switch (input_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
       break;
     default:
@@ -171,8 +172,13 @@ enum xnn_status xnn_define_negate(
     return status;
   }
 
+  enum xnn_compute_type compute_type = xnn_compute_type_invalid;
   switch (output_value->datatype) {
+    case xnn_datatype_fp16:
+      compute_type = xnn_compute_type_fp16;
+      break;
     case xnn_datatype_fp32:
+      compute_type = xnn_compute_type_fp32;
       break;
     default:
       xnn_log_error(
@@ -188,7 +194,7 @@ enum xnn_status xnn_define_negate(
   }
 
   node->type = xnn_node_type_negate;
-  node->compute_type = xnn_compute_type_fp32;
+  node->compute_type = compute_type;
   node->num_inputs = 1;
   node->inputs[0] = input_id;
   node->num_outputs = 1;

--- a/src/subgraph/prelu.c
+++ b/src/subgraph/prelu.c
@@ -176,6 +176,7 @@ enum xnn_status xnn_define_prelu(
   }
 
   switch (input_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
       break;
     default:
@@ -230,8 +231,13 @@ enum xnn_status xnn_define_prelu(
     return status;
   }
 
+  enum xnn_compute_type compute_type = xnn_compute_type_invalid;
   switch (output_value->datatype) {
+    case xnn_datatype_fp16:
+      compute_type = xnn_compute_type_fp16;
+      break;
     case xnn_datatype_fp32:
+      compute_type = xnn_compute_type_fp32;
       break;
     default:
       xnn_log_error(
@@ -247,7 +253,7 @@ enum xnn_status xnn_define_prelu(
   }
 
   node->type = xnn_node_type_prelu;
-  node->compute_type = xnn_compute_type_fp32;
+  node->compute_type = compute_type;
   node->num_inputs = 2;
   node->inputs[0] = input_id;
   node->inputs[1] = slope_id;

--- a/src/subgraph/rope.c
+++ b/src/subgraph/rope.c
@@ -188,12 +188,16 @@ enum xnn_status xnn_define_rope(
     return status;
   }
 
-  if (input_value->datatype != xnn_datatype_fp32) {
-    xnn_log_error(
-      "failed to define %s operator with input ID #%" PRIu32 ": unsupported Value datatype %s (%d)",
-      xnn_node_type_to_string(xnn_node_type_rope), input_id,
-      xnn_datatype_to_string(input_value->datatype), input_value->datatype);
-    return xnn_status_invalid_parameter;
+  switch (input_value->datatype) {
+    case xnn_datatype_fp16:
+    case xnn_datatype_fp32:
+      break;
+    default:
+      xnn_log_error(
+        "failed to define %s operator with input ID #%" PRIu32 ": unsupported Value datatype %s (%d)",
+        xnn_node_type_to_string(xnn_node_type_rope), input_id,
+        xnn_datatype_to_string(input_value->datatype), input_value->datatype);
+      return xnn_status_invalid_parameter;
   }
 
   const struct xnn_value* weights_value = &subgraph->values[weights_id];
@@ -202,12 +206,16 @@ enum xnn_status xnn_define_rope(
     return status;
   }
 
-  if (weights_value->datatype != xnn_datatype_fp32) {
-    xnn_log_error(
-      "failed to define %s operator with weights ID #%" PRIu32 ": unsupported Value datatype %s (%d)",
-      xnn_node_type_to_string(xnn_node_type_rope), weights_id,
-      xnn_datatype_to_string(weights_value->datatype), weights_value->datatype);
-    return xnn_status_invalid_parameter;
+  switch (weights_value->datatype) {
+    case xnn_datatype_fp16:
+    case xnn_datatype_fp32:
+      break;
+    default:
+      xnn_log_error(
+        "failed to define %s operator with weights ID #%" PRIu32 ": unsupported Value datatype %s (%d)",
+        xnn_node_type_to_string(xnn_node_type_rope), weights_id,
+        xnn_datatype_to_string(weights_value->datatype), weights_value->datatype);
+      return xnn_status_invalid_parameter;
   }
 
   status = xnn_subgraph_check_output_node_id(xnn_node_type_rope, output_id, subgraph->num_values);
@@ -226,12 +234,20 @@ enum xnn_status xnn_define_rope(
     return status;
   }
 
-  if (output_value->datatype != xnn_datatype_fp32) {
-    xnn_log_error(
-      "failed to define %s operator with output ID #%" PRIu32 ": unsupported Value datatype %s (%d)",
-      xnn_node_type_to_string(xnn_node_type_rope), output_id,
-      xnn_datatype_to_string(output_value->datatype), output_value->datatype);
-    return xnn_status_invalid_parameter;
+  enum xnn_compute_type compute_type = xnn_compute_type_invalid;
+  switch (output_value->datatype) {
+    case xnn_datatype_fp16:
+      compute_type = xnn_compute_type_fp16;
+      break;
+    case xnn_datatype_fp32:
+      compute_type = xnn_compute_type_fp32;
+      break;
+    default:
+      xnn_log_error(
+        "failed to define %s operator with output ID #%" PRIu32 ": unsupported Value datatype %s (%d)",
+        xnn_node_type_to_string(xnn_node_type_rope), output_id,
+        xnn_datatype_to_string(output_value->datatype), output_value->datatype);
+      return xnn_status_invalid_parameter;
   }
 
   status = xnn_subgraph_check_datatype_matches(xnn_node_type_subtract, input_id, input_value, output_id, output_value);
@@ -245,7 +261,7 @@ enum xnn_status xnn_define_rope(
   }
 
   node->type = xnn_node_type_rope;
-  node->compute_type = xnn_compute_type_fp32;
+  node->compute_type = compute_type;
   node->params.rope.max_tokens = max_tokens;
   node->num_inputs = 2;
   node->inputs[0] = input_id;

--- a/src/subgraph/scaled-dot-product-attention.c
+++ b/src/subgraph/scaled-dot-product-attention.c
@@ -445,6 +445,7 @@ static enum xnn_status check_inputs(
   }
 
   switch (input_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
       break;
     default:
@@ -727,6 +728,9 @@ enum xnn_status xnn_define_scaled_dot_product_attention(
 
   enum xnn_compute_type compute_type = xnn_compute_type_invalid;
   switch (output->datatype) {
+    case xnn_datatype_fp16:
+      compute_type = xnn_compute_type_fp16;
+      break;
     case xnn_datatype_fp32:
       compute_type = xnn_compute_type_fp32;
       break;

--- a/src/subgraph/sigmoid.c
+++ b/src/subgraph/sigmoid.c
@@ -201,6 +201,7 @@ enum xnn_status xnn_define_sigmoid(
   }
 
   switch (input_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
     case xnn_datatype_qint8:
     case xnn_datatype_quint8:
@@ -231,6 +232,9 @@ enum xnn_status xnn_define_sigmoid(
 
   enum xnn_compute_type compute_type = xnn_compute_type_invalid;
   switch (output_value->datatype) {
+    case xnn_datatype_fp16:
+      compute_type = xnn_compute_type_fp16;
+      break;
     case xnn_datatype_fp32:
       compute_type = xnn_compute_type_fp32;
       break;

--- a/src/subgraph/softmax.c
+++ b/src/subgraph/softmax.c
@@ -159,6 +159,7 @@ enum xnn_status xnn_define_softmax(
   }
 
   switch (input_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
       break;
     default:
@@ -185,8 +186,13 @@ enum xnn_status xnn_define_softmax(
     return status;
   }
 
+  enum xnn_compute_type compute_type = xnn_compute_type_invalid;
   switch (output_value->datatype) {
+    case xnn_datatype_fp16:
+      compute_type = xnn_compute_type_fp16;
+      break;
     case xnn_datatype_fp32:
+      compute_type = xnn_compute_type_fp32;
       break;
     default:
       xnn_log_error(
@@ -202,7 +208,7 @@ enum xnn_status xnn_define_softmax(
   }
 
   node->type = xnn_node_type_softmax;
-  node->compute_type = xnn_compute_type_fp32;
+  node->compute_type = compute_type;
   node->num_inputs = 1;
   node->inputs[0] = input_id;
   node->num_outputs = 1;

--- a/src/subgraph/space-to-depth-2d.c
+++ b/src/subgraph/space-to-depth-2d.c
@@ -199,6 +199,7 @@ enum xnn_status xnn_define_space_to_depth_2d(
   }
 
   switch (input_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
     case xnn_datatype_qint8:
     case xnn_datatype_quint8:
@@ -224,6 +225,9 @@ enum xnn_status xnn_define_space_to_depth_2d(
 
   enum xnn_compute_type compute_type = xnn_compute_type_invalid;
   switch (output_value->datatype) {
+    case xnn_datatype_fp16:
+      compute_type = xnn_compute_type_fp16;
+      break;
     case xnn_datatype_fp32:
       compute_type = xnn_compute_type_fp32;
       break;

--- a/src/subgraph/square-root.c
+++ b/src/subgraph/square-root.c
@@ -147,6 +147,7 @@ enum xnn_status xnn_define_square_root(
   }
 
   switch (input_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
       break;
     default:
@@ -173,8 +174,13 @@ enum xnn_status xnn_define_square_root(
     return status;
   }
 
+  enum xnn_compute_type compute_type = xnn_compute_type_invalid;
   switch (output_value->datatype) {
+    case xnn_datatype_fp16:
+      compute_type = xnn_compute_type_fp16;
+      break;
     case xnn_datatype_fp32:
+      compute_type = xnn_compute_type_fp32;
       break;
     default:
       xnn_log_error(
@@ -190,7 +196,7 @@ enum xnn_status xnn_define_square_root(
   }
 
   node->type = xnn_node_type_square_root;
-  node->compute_type = xnn_compute_type_fp32;
+  node->compute_type = compute_type;
   node->num_inputs = 1;
   node->inputs[0] = input_id;
   node->num_outputs = 1;

--- a/src/subgraph/square.c
+++ b/src/subgraph/square.c
@@ -145,6 +145,7 @@ enum xnn_status xnn_define_square(
   }
 
   switch (input_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
       break;
     default:
@@ -171,8 +172,13 @@ enum xnn_status xnn_define_square(
     return status;
   }
 
+  enum xnn_compute_type compute_type = xnn_compute_type_invalid;
   switch (output_value->datatype) {
+    case xnn_datatype_fp16:
+      compute_type = xnn_compute_type_fp16;
+      break;
     case xnn_datatype_fp32:
+      compute_type = xnn_compute_type_fp32;
       break;
     default:
       xnn_log_error(
@@ -188,7 +194,7 @@ enum xnn_status xnn_define_square(
   }
 
   node->type = xnn_node_type_square;
-  node->compute_type = xnn_compute_type_fp32;
+  node->compute_type = compute_type;
   node->num_inputs = 1;
   node->inputs[0] = input_id;
   node->num_outputs = 1;

--- a/src/subgraph/squared-difference.c
+++ b/src/subgraph/squared-difference.c
@@ -181,6 +181,7 @@ enum xnn_status xnn_define_squared_difference(
   }
 
   switch (input1_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
       break;
     default:
@@ -203,6 +204,7 @@ enum xnn_status xnn_define_squared_difference(
   }
 
   switch (input2_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
       break;
     default:
@@ -224,8 +226,13 @@ enum xnn_status xnn_define_squared_difference(
     return status;
   }
 
+  enum xnn_compute_type compute_type = xnn_compute_type_invalid;
   switch (output_value->datatype) {
+    case xnn_datatype_fp16:
+      compute_type = xnn_compute_type_fp16;
+      break;
     case xnn_datatype_fp32:
+      compute_type = xnn_compute_type_fp32;
       break;
     default:
       xnn_log_error(
@@ -241,7 +248,7 @@ enum xnn_status xnn_define_squared_difference(
   }
 
   node->type = xnn_node_type_squared_difference;
-  node->compute_type = xnn_compute_type_fp32;
+  node->compute_type = compute_type;
   node->num_inputs = 2;
   node->inputs[0] = input1_id;
   node->inputs[1] = input2_id;

--- a/src/subgraph/static-constant-pad.c
+++ b/src/subgraph/static-constant-pad.c
@@ -196,6 +196,7 @@ enum xnn_status xnn_define_static_constant_pad(
   }
 
   switch (input_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
     case xnn_datatype_qint8:
     case xnn_datatype_quint8:
@@ -221,6 +222,9 @@ enum xnn_status xnn_define_static_constant_pad(
 
   enum xnn_compute_type compute_type = xnn_compute_type_invalid;
   switch (output_value->datatype) {
+    case xnn_datatype_fp16:
+      compute_type = xnn_compute_type_fp16;
+      break;
     case xnn_datatype_fp32:
       compute_type = xnn_compute_type_fp32;
       break;
@@ -261,6 +265,9 @@ enum xnn_status xnn_define_static_constant_pad(
   switch (output_value->datatype) {
     case xnn_datatype_fp32:
       node->params.static_pad.padding_value = float_as_uint32(padding_value);
+      break;
+    case xnn_datatype_fp16:
+      node->params.static_pad.padding_value = fp16_ieee_from_fp32_value(padding_value);
       break;
     case xnn_datatype_qint8:
     {

--- a/src/subgraph/static-mean.c
+++ b/src/subgraph/static-mean.c
@@ -203,6 +203,7 @@ enum xnn_status xnn_define_static_mean(
   }
 
   switch (input_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
       break;
     default:
@@ -224,8 +225,13 @@ enum xnn_status xnn_define_static_mean(
     return status;
   }
 
+  enum xnn_compute_type compute_type = xnn_compute_type_invalid;
   switch (output_value->datatype) {
+    case xnn_datatype_fp16:
+      compute_type = xnn_compute_type_fp16;
+      break;
     case xnn_datatype_fp32:
+      compute_type = xnn_compute_type_fp32;
       break;
     default:
       xnn_log_error(
@@ -276,7 +282,7 @@ enum xnn_status xnn_define_static_mean(
   }
 
   node->type = xnn_node_type_static_mean;
-  node->compute_type = xnn_compute_type_fp32;
+  node->compute_type = compute_type;
   node->params.reduce.num_reduction_axes = num_reduction_axes;
   memcpy(node->params.reduce.reduction_axes, reduction_axes, num_reduction_axes * sizeof(size_t));
   node->num_inputs = 1;

--- a/src/subgraph/static-reshape.c
+++ b/src/subgraph/static-reshape.c
@@ -240,6 +240,7 @@ enum xnn_status xnn_define_static_reshape(
   }
 
   switch (input_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
     case xnn_datatype_qint8:
     case xnn_datatype_quint8:
@@ -265,6 +266,9 @@ enum xnn_status xnn_define_static_reshape(
 
   enum xnn_compute_type compute_type = xnn_compute_type_invalid;
   switch (output_value->datatype) {
+    case xnn_datatype_fp16:
+      compute_type = xnn_compute_type_fp16;
+      break;
     case xnn_datatype_fp32:
       compute_type = xnn_compute_type_fp32;
       break;

--- a/src/subgraph/static-resize-bilinear-2d.c
+++ b/src/subgraph/static-resize-bilinear-2d.c
@@ -332,6 +332,7 @@ enum xnn_status xnn_define_static_resize_bilinear_2d(
   }
 
   switch (input_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
     case xnn_datatype_qint8:
     case xnn_datatype_quint8:
@@ -357,6 +358,9 @@ enum xnn_status xnn_define_static_resize_bilinear_2d(
 
   enum xnn_compute_type compute_type = xnn_compute_type_invalid;
   switch (output_value->datatype) {
+    case xnn_datatype_fp16:
+      compute_type = xnn_compute_type_fp16;
+      break;
     case xnn_datatype_fp32:
       compute_type = xnn_compute_type_fp32;
       break;

--- a/src/subgraph/static-slice.c
+++ b/src/subgraph/static-slice.c
@@ -193,6 +193,7 @@ enum xnn_status xnn_define_static_slice(
   }
 
   switch (input_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
     case xnn_datatype_qint8:
     case xnn_datatype_quint8:
@@ -252,6 +253,9 @@ enum xnn_status xnn_define_static_slice(
 
   enum xnn_compute_type compute_type = xnn_compute_type_invalid;
   switch (output_value->datatype) {
+    case xnn_datatype_fp16:
+      compute_type = xnn_compute_type_fp16;
+      break;
     case xnn_datatype_fp32:
       compute_type = xnn_compute_type_fp32;
       break;

--- a/src/subgraph/static-transpose.c
+++ b/src/subgraph/static-transpose.c
@@ -244,6 +244,9 @@ enum xnn_status xnn_define_static_transpose(
 
   enum xnn_compute_type compute_type = xnn_compute_type_invalid;
   switch (output_value->datatype) {
+    case xnn_datatype_fp16:
+      compute_type = xnn_compute_type_fp16;
+      break;
     case xnn_datatype_fp32:
       compute_type = xnn_compute_type_fp32;
       break;
@@ -262,6 +265,7 @@ enum xnn_status xnn_define_static_transpose(
   }
 
   switch (input_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
     case xnn_datatype_qint8:
     case xnn_datatype_quint8:

--- a/src/subgraph/subtract.c
+++ b/src/subgraph/subtract.c
@@ -262,6 +262,7 @@ enum xnn_status xnn_define_subtract(
   }
 
   switch (input1_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
     case xnn_datatype_qint8:
     case xnn_datatype_quint8:
@@ -286,6 +287,7 @@ enum xnn_status xnn_define_subtract(
   }
 
   switch (input2_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
     case xnn_datatype_qint8:
     case xnn_datatype_quint8:
@@ -311,6 +313,9 @@ enum xnn_status xnn_define_subtract(
 
   enum xnn_compute_type compute_type = xnn_compute_type_invalid;
   switch (output_value->datatype) {
+    case xnn_datatype_fp16:
+      compute_type = xnn_compute_type_fp16;
+      break;
     case xnn_datatype_fp32:
       compute_type = xnn_compute_type_fp32;
       break;

--- a/src/subgraph/tanh.c
+++ b/src/subgraph/tanh.c
@@ -201,6 +201,7 @@ enum xnn_status xnn_define_tanh(
   }
 
   switch (input_value->datatype) {
+    case xnn_datatype_fp16:
     case xnn_datatype_fp32:
     case xnn_datatype_qint8:
     case xnn_datatype_quint8:
@@ -231,6 +232,9 @@ enum xnn_status xnn_define_tanh(
 
   enum xnn_compute_type compute_type = xnn_compute_type_invalid;
   switch (output_value->datatype) {
+    case xnn_datatype_fp16:
+      compute_type = xnn_compute_type_fp16;
+      break;
     case xnn_datatype_fp32:
       compute_type = xnn_compute_type_fp32;
       break;

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -3309,7 +3309,7 @@ xnnpack_unit_test(
         "abs.cc",
     ],
     deps = [
-        "@fp16",
+        "@FP16",
         ":subgraph_unary_tester",
         "//:XNNPACK_test_mode",
         "//:node_type",
@@ -3324,6 +3324,7 @@ xnnpack_unit_test(
         "add2.cc",
     ],
     deps = [
+        "@FP16",
         ":subgraph_binary_tester",
         "//:XNNPACK_test_mode",
         "//:node_type",
@@ -3352,6 +3353,7 @@ xnnpack_unit_test(
         "argmax-pooling-2d.cc",
     ],
     deps = [
+        "@FP16",
         "//:XNNPACK_test_mode",
         "//:aligned_allocator",
         "//:common",
@@ -3367,6 +3369,7 @@ xnnpack_unit_test(
         "average-pooling-2d.cc",
     ],
     deps = [
+        "@FP16",
         "//:XNNPACK_test_mode",
         "//:aligned_allocator",
         "//:common",
@@ -3399,6 +3402,7 @@ xnnpack_unit_test(
         "bankers-rounding.cc",
     ],
     deps = [
+        "@FP16",
         ":subgraph_unary_tester",
         "//:XNNPACK_test_mode",
         "//:node_type",
@@ -3413,6 +3417,7 @@ xnnpack_unit_test(
         "batch-matrix-multiply.cc",
     ],
     deps = [
+        "@FP16",
         "//:XNNPACK_test_mode",
         "//:aligned_allocator",
         "//:common",
@@ -3427,6 +3432,7 @@ xnnpack_unit_test(
         "ceiling.cc",
     ],
     deps = [
+        "@FP16",
         ":subgraph_unary_tester",
         "//:XNNPACK_test_mode",
         "//:node_type",
@@ -3441,6 +3447,7 @@ xnnpack_unit_test(
         "clamp.cc",
     ],
     deps = [
+        "@FP16",
         ":subgraph_unary_tester",
         "//:XNNPACK_test_mode",
         "//:node_type",
@@ -3455,6 +3462,7 @@ xnnpack_unit_test(
         "concatenate2.cc",
     ],
     deps = [
+        "@FP16",
         "//:XNNPACK_test_mode",
         "//:node_type",
         "//:operators_test_mode",
@@ -3468,6 +3476,7 @@ xnnpack_unit_test(
         "concatenate3.cc",
     ],
     deps = [
+        "@FP16",
         "//:XNNPACK_test_mode",
         "//:node_type",
         "//:operators_test_mode",
@@ -3481,6 +3490,7 @@ xnnpack_unit_test(
         "concatenate4.cc",
     ],
     deps = [
+        "@FP16",
         "//:XNNPACK_test_mode",
         "//:node_type",
         "//:operators_test_mode",
@@ -3494,6 +3504,7 @@ xnnpack_unit_test(
         "concatenate5.cc",
     ],
     deps = [
+        "@FP16",
         "//:XNNPACK_test_mode",
         "//:node_type",
         "//:operators_test_mode",
@@ -3507,6 +3518,7 @@ xnnpack_unit_test(
         "convert.cc",
     ],
     deps = [
+        "@FP16",
         ":subgraph_unary_tester",
         "//:XNNPACK_test_mode",
         "//:node_type",
@@ -3521,6 +3533,7 @@ xnnpack_unit_test(
         "convolution-2d.cc",
     ],
     deps = [
+        "@FP16",
         ":convolution_test_helpers",
         "//:XNNPACK_test_mode",
         "//:aligned_allocator",
@@ -3537,6 +3550,7 @@ xnnpack_unit_test(
         "copy.cc",
     ],
     deps = [
+        "@FP16",
         ":subgraph_unary_tester",
         "//:XNNPACK_test_mode",
         "//:node_type",
@@ -3553,6 +3567,7 @@ xnnpack_unit_test(
     ],
     shard_count = 5,
     deps = [
+        "@FP16",
         "//:XNNPACK_test_mode",
         "//:operator_utils",
         "//:operators_test_mode",
@@ -3567,6 +3582,7 @@ xnnpack_unit_test(
         "depth-to-space-2d.cc",
     ],
     deps = [
+        "@FP16",
         "//:XNNPACK_test_mode",
         "//:node_type",
         "//:operators_test_mode",
@@ -3580,6 +3596,7 @@ xnnpack_unit_test(
         "depthwise-convolution-2d.cc",
     ],
     deps = [
+        "@FP16",
         ":convolution_test_helpers",
         "//:XNNPACK_test_mode",
         "//:aligned_allocator",
@@ -3596,6 +3613,7 @@ xnnpack_unit_test(
         "divide2.cc",
     ],
     deps = [
+        "@FP16",
         ":subgraph_binary_tester",
         "//:XNNPACK_test_mode",
         "//:node_type",
@@ -3610,6 +3628,7 @@ xnnpack_unit_test(
         "elu.cc",
     ],
     deps = [
+        "@FP16",
         ":subgraph_unary_tester",
         "//:XNNPACK_test_mode",
         "//:node_type",
@@ -3624,6 +3643,7 @@ xnnpack_unit_test(
         "even-split2.cc",
     ],
     deps = [
+        "@FP16",
         "//:XNNPACK_test_mode",
         "//:node_type",
         "//:operators_test_mode",
@@ -3637,6 +3657,7 @@ xnnpack_unit_test(
         "even-split3.cc",
     ],
     deps = [
+        "@FP16",
         "//:XNNPACK_test_mode",
         "//:node_type",
         "//:operators_test_mode",
@@ -3650,6 +3671,7 @@ xnnpack_unit_test(
         "even-split4.cc",
     ],
     deps = [
+        "@FP16",
         "//:XNNPACK_test_mode",
         "//:node_type",
         "//:operators_test_mode",
@@ -3663,6 +3685,7 @@ xnnpack_unit_test(
         "floor.cc",
     ],
     deps = [
+        "@FP16",
         ":subgraph_unary_tester",
         "//:XNNPACK_test_mode",
         "//:node_type",
@@ -3694,6 +3717,7 @@ xnnpack_unit_test(
         "global-average-pooling-1d.cc",
     ],
     deps = [
+        "@FP16",
         "//:XNNPACK_test_mode",
         "//:aligned_allocator",
         "//:node_type",
@@ -3709,6 +3733,7 @@ xnnpack_unit_test(
         "global-average-pooling-2d.cc",
     ],
     deps = [
+        "@FP16",
         "//:XNNPACK_test_mode",
         "//:aligned_allocator",
         "//:node_type",
@@ -3724,6 +3749,7 @@ xnnpack_unit_test(
         "global-sum-pooling-1d.cc",
     ],
     deps = [
+        "@FP16",
         "//:XNNPACK_test_mode",
         "//:aligned_allocator",
         "//:node_type",
@@ -3738,6 +3764,7 @@ xnnpack_unit_test(
         "global-sum-pooling-2d.cc",
     ],
     deps = [
+        "@FP16",
         "//:XNNPACK_test_mode",
         "//:aligned_allocator",
         "//:node_type",
@@ -3752,6 +3779,7 @@ xnnpack_unit_test(
         "hardswish.cc",
     ],
     deps = [
+        "@FP16",
         ":subgraph_unary_tester",
         "//:XNNPACK_test_mode",
         "//:node_type",
@@ -3766,6 +3794,7 @@ xnnpack_unit_test(
         "leaky-relu.cc",
     ],
     deps = [
+        "@FP16",
         ":subgraph_unary_tester",
         "//:XNNPACK_test_mode",
         "//:node_type",
@@ -3780,6 +3809,7 @@ xnnpack_unit_test(
         "max-pooling-2d.cc",
     ],
     deps = [
+        "@FP16",
         "//:XNNPACK_test_mode",
         "//:node_type",
         "//:operator_utils",
@@ -3795,6 +3825,7 @@ xnnpack_unit_test(
         "maximum2.cc",
     ],
     deps = [
+        "@FP16",
         ":subgraph_binary_tester",
         "//:XNNPACK_test_mode",
         "//:node_type",
@@ -3809,6 +3840,7 @@ xnnpack_unit_test(
         "minimum2.cc",
     ],
     deps = [
+        "@FP16",
         ":subgraph_binary_tester",
         "//:XNNPACK_test_mode",
         "//:node_type",
@@ -3823,6 +3855,7 @@ xnnpack_unit_test(
         "multiply2.cc",
     ],
     deps = [
+        "@FP16",
         ":subgraph_binary_tester",
         "//:XNNPACK_test_mode",
         "//:node_type",
@@ -3837,6 +3870,7 @@ xnnpack_unit_test(
         "negate.cc",
     ],
     deps = [
+        "@FP16",
         ":subgraph_unary_tester",
         "//:XNNPACK_test_mode",
         "//:node_type",
@@ -3851,6 +3885,7 @@ xnnpack_unit_test(
         "prelu.cc",
     ],
     deps = [
+        "@FP16",
         "//:XNNPACK_test_mode",
         "//:node_type",
         "//:operators_test_mode",
@@ -3864,6 +3899,7 @@ xnnpack_unit_test(
         "rope.cc",
     ],
     deps = [
+        "@FP16",
         "//:XNNPACK_test_mode",
         "//:node_type",
         "//:operators_test_mode",
@@ -3878,6 +3914,7 @@ xnnpack_unit_test(
         "scaled-dot-product-attention.cc",
     ],
     deps = [
+        "@FP16",
         "//:XNNPACK_test_mode",
         "//:aligned_allocator",
         "//:common",
@@ -3893,6 +3930,7 @@ xnnpack_unit_test(
         "sigmoid.cc",
     ],
     deps = [
+        "@FP16",
         ":subgraph_unary_tester",
         "//:XNNPACK_test_mode",
         "//:node_type",
@@ -3907,6 +3945,7 @@ xnnpack_unit_test(
         "softmax.cc",
     ],
     deps = [
+        "@FP16",
         ":subgraph_unary_tester",
         "//:XNNPACK_test_mode",
         "//:node_type",
@@ -3921,6 +3960,7 @@ xnnpack_unit_test(
         "space-to-depth-2d.cc",
     ],
     deps = [
+        "@FP16",
         ":subgraph_unary_tester",
         "//:XNNPACK_test_mode",
         "//:node_type",
@@ -3935,6 +3975,7 @@ xnnpack_unit_test(
         "square.cc",
     ],
     deps = [
+        "@FP16",
         ":subgraph_unary_tester",
         "//:XNNPACK_test_mode",
         "//:node_type",
@@ -3949,6 +3990,7 @@ xnnpack_unit_test(
         "square-root.cc",
     ],
     deps = [
+        "@FP16",
         ":subgraph_unary_tester",
         "//:XNNPACK_test_mode",
         "//:node_type",
@@ -3963,6 +4005,7 @@ xnnpack_unit_test(
         "squared-difference.cc",
     ],
     deps = [
+        "@FP16",
         ":subgraph_binary_tester",
         "//:XNNPACK_test_mode",
         "//:node_type",
@@ -3977,8 +4020,8 @@ xnnpack_unit_test(
         "static-constant-pad.cc",
     ],
     deps = [
-        ":subgraph_unary_tester",
         "@FP16",
+        ":subgraph_unary_tester",
         "//:XNNPACK_test_mode",
         "//:node_type",
         "//:operators_test_mode",
@@ -3992,6 +4035,7 @@ xnnpack_unit_test(
         "static-mean.cc",
     ],
     deps = [
+        "@FP16",
         "//:XNNPACK_test_mode",
         "//:aligned_allocator",
         "//:common",
@@ -4007,6 +4051,7 @@ xnnpack_unit_test(
         "static-reshape.cc",
     ],
     deps = [
+        "@FP16",
         ":subgraph_unary_tester",
         "//:XNNPACK_test_mode",
         "//:node_type",
@@ -4021,6 +4066,7 @@ xnnpack_unit_test(
         "reshape-2d.cc",
     ],
     deps = [
+        "@FP16",
         ":subgraph_unary_tester",
         "//:XNNPACK_test_mode",
         "//:node_type",
@@ -4035,6 +4081,7 @@ xnnpack_unit_test(
         "static-resize-bilinear-2d.cc",
     ],
     deps = [
+        "@FP16",
         ":subgraph_unary_tester",
         "//:XNNPACK_test_mode",
         "//:node_type",
@@ -4049,6 +4096,7 @@ xnnpack_unit_test(
         "static-slice.cc",
     ],
     deps = [
+        "@FP16",
         ":subgraph_unary_tester",
         "//:XNNPACK_test_mode",
         "//:node_type",
@@ -4063,6 +4111,7 @@ xnnpack_unit_test(
         "static-transpose.cc",
     ],
     deps = [
+        "@FP16",
         ":subgraph_unary_tester",
         "//:XNNPACK_test_mode",
         "//:node_type",
@@ -4077,6 +4126,7 @@ xnnpack_unit_test(
         "subtract2.cc",
     ],
     deps = [
+        "@FP16",
         ":subgraph_binary_tester",
         "//:XNNPACK_test_mode",
         "//:node_type",
@@ -4091,6 +4141,7 @@ xnnpack_unit_test(
         "tanh.cc",
     ],
     deps = [
+        "@FP16",
         ":subgraph_unary_tester",
         "//:XNNPACK_test_mode",
         "//:node_type",
@@ -4105,6 +4156,7 @@ xnnpack_unit_test(
         "transpose-reshape.cc",
     ],
     deps = [
+        "@FP16",
         ":subgraph_unary_tester",
         "//:XNNPACK_test_mode",
         "//:node_type",

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -3309,6 +3309,7 @@ xnnpack_unit_test(
         "abs.cc",
     ],
     deps = [
+        "@fp16",
         ":subgraph_unary_tester",
         "//:XNNPACK_test_mode",
         "//:node_type",

--- a/test/abs.cc
+++ b/test/abs.cc
@@ -11,15 +11,53 @@
 #include <memory>
 #include <random>
 
+#include <fp16/fp16.h>
+#include <gtest/gtest.h>
+
 #include <xnnpack.h>
 #include <xnnpack/node-type.h>
 #include <xnnpack/operator.h>
 #include <xnnpack/subgraph.h>
 
 #include "subgraph-unary-tester.h"
-#include <gtest/gtest.h>
 
+using AbsTestF16 = UnaryTest<uint16_t>;
 using AbsTestF32 = UnaryTest<float>;
+
+TEST_F(AbsTestF16, define)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, 0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, 1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(xnn_status_success, xnn_define_abs(subgraph, input_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_abs);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
+  ASSERT_EQ(node->num_inputs, 1);
+  ASSERT_EQ(node->inputs[0], input_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
 
 TEST_F(AbsTestF32, define)
 {
@@ -54,6 +92,62 @@ TEST_F(AbsTestF32, define)
   ASSERT_EQ(node->num_outputs, 1);
   ASSERT_EQ(node->outputs[0], output_id);
   ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(AbsTestF16, matches_operator_api)
+{
+  std::uniform_real_distribution<float> f32dist(-255.0f, 255.0f);
+  std::generate(input.begin(), input.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  // Call operator API.
+  xnn_operator_t op = nullptr;
+  const xnn_status status = xnn_create_abs_nc_f16(/*flags=*/0, &op);
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  ASSERT_EQ(xnn_status_success, xnn_reshape_abs_nc_f16(op, batch_size, channels, channels, channels, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_setup_abs_nc_f16(op, input.data(), operator_output.data()));
+
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, /*external_id=*/0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, /*external_id=*/1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_define_abs(subgraph, input_id, output_id, /*flags=*/0));
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 2> external = {
+    xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  ASSERT_EQ(subgraph_output, operator_output);
 }
 
 TEST_F(AbsTestF32, matches_operator_api)

--- a/test/add2.cc
+++ b/test/add2.cc
@@ -15,16 +15,19 @@
 #include <random>
 #include <vector>
 
+#include <fp16/fp16.h>
+#include <gtest/gtest.h>
+
 #include <xnnpack.h>
 #include <xnnpack/node-type.h>
 #include <xnnpack/operator.h>
 #include <xnnpack/subgraph.h>
 
 #include "subgraph-binary-tester.h"
-#include <gtest/gtest.h>
 
 using Add2TestQS8 = BinaryTest<int8_t>;
 using Add2TestQU8 = BinaryTest<uint8_t>;
+using Add2TestF16 = BinaryTest<uint16_t>;
 using Add2TestF32 = BinaryTest<float>;
 
 TEST_F(Add2TestQS8, define)
@@ -117,6 +120,53 @@ TEST_F(Add2TestQU8, define)
   const struct xnn_node* node = &subgraph->nodes[0];
   ASSERT_EQ(node->type, xnn_node_type_add2);
   ASSERT_EQ(node->compute_type, xnn_compute_type_qu8);
+  ASSERT_EQ(node->activation.output_min, output_min);
+  ASSERT_EQ(node->activation.output_max, output_max);
+  ASSERT_EQ(node->num_inputs, 2);
+  ASSERT_EQ(node->inputs[0], input1_id);
+  ASSERT_EQ(node->inputs[1], input2_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(Add2TestF16, define)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(3, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  uint32_t input1_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input1_dims.size(), input1_dims.data(), nullptr,
+                          /*external_id=*/0, /*flags=*/0, &input1_id));
+  ASSERT_NE(input1_id, XNN_INVALID_NODE_ID);
+
+  uint32_t input2_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input2_dims.size(), input2_dims.data(), nullptr,
+                          /*external_id=*/0, /*flags=*/0, &input2_id));
+  ASSERT_NE(input2_id, XNN_INVALID_NODE_ID);
+
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_tensor_value(
+      subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr, XNN_INVALID_VALUE_ID, /*flags=*/0, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_add2(subgraph, output_min, output_max, input1_id, input2_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_add2);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
   ASSERT_EQ(node->activation.output_min, output_min);
   ASSERT_EQ(node->activation.output_max, output_max);
   ASSERT_EQ(node->num_inputs, 2);
@@ -359,6 +409,76 @@ TEST_F(Add2TestQU8, matches_operator_api)
   for (size_t i = 0; i < observed_output_num_dims; i++) {
     ASSERT_EQ(output_dims[i], observed_output_dims[i]);
   }
+
+  // Check outputs match.
+  ASSERT_EQ(subgraph_output, operator_output);
+}
+
+TEST_F(Add2TestF16, matches_operator_api)
+{
+  std::generate(input1.begin(), input1.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::generate(input2.begin(), input2.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_operator_t op = nullptr;
+
+  // Call operator API.
+  ASSERT_EQ(xnn_status_success, xnn_create_add_nd_f16(output_min, output_max, 0, &op));
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  ASSERT_EQ(
+    xnn_status_success, xnn_reshape_add_nd_f16(
+                          op, input1_dims.size(), input1_dims.data(), input2_dims.size(), input2_dims.data(),
+                          /*threadpool=*/nullptr));
+
+  ASSERT_EQ(
+    xnn_status_success, xnn_setup_add_nd_f16(op, input1.data(), input2.data(), operator_output.data()));
+
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(3, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  uint32_t input1_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input1_dims.size(), input1_dims.data(), nullptr,
+                          /*external_id=*/0, /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input1_id));
+  ASSERT_NE(input1_id, XNN_INVALID_NODE_ID);
+
+  uint32_t input2_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input2_dims.size(), input2_dims.data(), nullptr,
+                          /*external_id=*/1, /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input2_id));
+  ASSERT_NE(input2_id, XNN_INVALID_NODE_ID);
+
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_tensor_value(
+      subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr, /*external_id=*/2,
+      /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_add2(subgraph, output_min, output_max, input1_id, input2_id, output_id, /*flags=*/0));
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 3> external = {
+    xnn_external_value{input1_id, input1.data()}, xnn_external_value{input2_id, input2.data()},
+    xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
 
   // Check outputs match.
   ASSERT_EQ(subgraph_output, operator_output);

--- a/test/average-pooling-2d.cc
+++ b/test/average-pooling-2d.cc
@@ -12,6 +12,7 @@
 #include <random>
 #include <vector>
 
+#include <fp16/fp16.h>
 #include <gtest/gtest.h>
 
 #include <xnnpack.h>
@@ -22,9 +23,12 @@
 #include <xnnpack/operator.h>
 #include <xnnpack/subgraph.h>
 
-class AveragePoolingTestF32 : public ::testing::Test {
+template <
+  typename InputType,
+  typename OutputType = InputType>
+class AveragePoolingTest : public ::testing::Test {
 protected:
-  AveragePoolingTestF32()
+  AveragePoolingTest()
   {
     random_device = std::make_unique<std::random_device>();
     rng = std::mt19937((*random_device)());
@@ -52,9 +56,9 @@ protected:
     output_max = std::uniform_real_distribution<float>(0.1f, 255.0f)(rng);
     input_dims = {batch_size, input_height, input_width, channels};
     output_dims = {batch_size, output_height, output_width, channels};
-    input = std::vector<float>(XNN_EXTRA_BYTES / sizeof(float) + batch_size * input_height * input_width * channels);
-    operator_output = std::vector<float>(batch_size * output_height * output_width * channels);
-    subgraph_output = std::vector<float>(batch_size * output_height * output_width * channels);
+    input = std::vector<InputType>(XNN_EXTRA_BYTES / sizeof(InputType) + batch_size * input_height * input_width * channels);
+    operator_output = std::vector<OutputType>(batch_size * output_height * output_width * channels);
+    subgraph_output = std::vector<OutputType>(batch_size * output_height * output_width * channels);
   }
 
   std::unique_ptr<std::random_device> random_device;
@@ -84,10 +88,64 @@ protected:
   uint32_t input_id;
   uint32_t output_id;
 
-  std::vector<float> input;
-  std::vector<float> operator_output;
-  std::vector<float> subgraph_output;
+  std::vector<InputType> input;
+  std::vector<OutputType> operator_output;
+  std::vector<OutputType> subgraph_output;
 };
+
+using AveragePoolingTestF16 = AveragePoolingTest<uint16_t>;
+using AveragePoolingTestF32 = AveragePoolingTest<float>;
+
+TEST_F(AveragePoolingTestF16, define)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input_dims.size(), input_dims.data(), nullptr, 0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr, 1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_average_pooling_2d(
+      subgraph, input_padding_top, input_padding_right, input_padding_bottom, input_padding_left, pooling_height,
+      pooling_width, stride_height, stride_width, output_min, output_max, input_id, output_id,
+      /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_average_pooling_2d);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
+
+  ASSERT_EQ(node->params.pooling_2d.padding_top, input_padding_top);
+  ASSERT_EQ(node->params.pooling_2d.padding_right, input_padding_right);
+  ASSERT_EQ(node->params.pooling_2d.padding_bottom, input_padding_bottom);
+  ASSERT_EQ(node->params.pooling_2d.padding_left, input_padding_left);
+  ASSERT_EQ(node->params.pooling_2d.pooling_height, pooling_height);
+  ASSERT_EQ(node->params.pooling_2d.pooling_width, pooling_width);
+  ASSERT_EQ(node->params.pooling_2d.stride_height, stride_height);
+  ASSERT_EQ(node->params.pooling_2d.stride_width, stride_width);
+  ASSERT_EQ(node->activation.output_min, output_min);
+  ASSERT_EQ(node->activation.output_max, output_max);
+  ASSERT_EQ(node->num_inputs, 1);
+  ASSERT_EQ(node->inputs[0], input_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
 
 TEST_F(AveragePoolingTestF32, define)
 {
@@ -138,6 +196,82 @@ TEST_F(AveragePoolingTestF32, define)
   ASSERT_EQ(node->num_outputs, 1);
   ASSERT_EQ(node->outputs[0], output_id);
   ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(AveragePoolingTestF16, matches_operator_api)
+{
+  std::uniform_real_distribution<float> f32dist;
+  std::generate(input.begin(), input.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  // Call operator API.
+  xnn_operator_t op = nullptr;
+  const xnn_status status = xnn_create_average_pooling2d_nhwc_f16(
+    input_padding_top, input_padding_right, input_padding_bottom, input_padding_left, pooling_height, pooling_width,
+    stride_height, stride_width, output_min, output_max, /*flags=*/0, &op);
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  size_t workspace_size = 0;
+  size_t workspace_alignment = 0;
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_reshape_average_pooling2d_nhwc_f16(
+      op, batch_size, input_height, input_width,
+      channels, /*input_pixel_stride=*/channels, /*output_pixel_stride=*/channels,
+      &workspace_size, &workspace_alignment,
+      /*output_height_out=*/nullptr, /*output_width_out=*/nullptr,
+      /*threadpool=*/nullptr));
+  ASSERT_LE(workspace_alignment, XNN_ALLOCATION_ALIGNMENT);
+
+  std::vector<char, AlignedAllocator<char, XNN_ALLOCATION_ALIGNMENT>> workspace(workspace_size);
+  ASSERT_EQ(xnn_status_success, xnn_setup_average_pooling2d_nhwc_f16(op, workspace.data(), input.data(), operator_output.data()));
+
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input_dims.size(), input_dims.data(), nullptr, /*external_id=*/0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_tensor_value(
+      subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr, /*external_id=*/1,
+      /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_average_pooling_2d(
+      subgraph, input_padding_top, input_padding_right, input_padding_bottom, input_padding_left, pooling_height,
+      pooling_width, stride_height, stride_width, output_min, output_max, input_id, output_id,
+      /*flags=*/0));
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 2> external = {
+    xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  ASSERT_EQ(subgraph_output, operator_output);
 }
 
 TEST_F(AveragePoolingTestF32, matches_operator_api)

--- a/test/bankers-rounding.cc
+++ b/test/bankers-rounding.cc
@@ -11,15 +11,53 @@
 #include <memory>
 #include <random>
 
+#include <fp16/fp16.h>
+#include <gtest/gtest.h>
+
 #include <xnnpack.h>
 #include <xnnpack/node-type.h>
 #include <xnnpack/operator.h>
 #include <xnnpack/subgraph.h>
 
 #include "subgraph-unary-tester.h"
-#include <gtest/gtest.h>
 
+using BankersRoundingTestF16 = UnaryTest<uint16_t>;
 using BankersRoundingTestF32 = UnaryTest<float>;
+
+TEST_F(BankersRoundingTestF16, define)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, 0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, 1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(xnn_status_success, xnn_define_bankers_rounding(subgraph, input_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_bankers_rounding);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
+  ASSERT_EQ(node->num_inputs, 1);
+  ASSERT_EQ(node->inputs[0], input_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
 
 TEST_F(BankersRoundingTestF32, define)
 {
@@ -54,6 +92,63 @@ TEST_F(BankersRoundingTestF32, define)
   ASSERT_EQ(node->num_outputs, 1);
   ASSERT_EQ(node->outputs[0], output_id);
   ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(BankersRoundingTestF16, matches_operator_api)
+{
+  std::uniform_real_distribution<float> f32dist(-5.0f, 5.0f);
+  std::generate(input.begin(), input.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  // Call operator API.
+  xnn_operator_t op = nullptr;
+  const xnn_status status = xnn_create_bankers_rounding_nc_f16(/*flags=*/0, &op);
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  ASSERT_EQ(xnn_status_success, xnn_reshape_bankers_rounding_nc_f16(op, batch_size, channels, channels, channels, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_setup_bankers_rounding_nc_f16(op, input.data(), operator_output.data()));
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, /*external_id=*/0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, /*external_id=*/1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_define_bankers_rounding(subgraph, input_id, output_id, /*flags=*/0));
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 2> external = {
+    xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+
+
+  ASSERT_EQ(subgraph_output, operator_output);
 }
 
 TEST_F(BankersRoundingTestF32, matches_operator_api)

--- a/test/batch-matrix-multiply.cc
+++ b/test/batch-matrix-multiply.cc
@@ -12,13 +12,14 @@
 #include <random>     // For std::random_device, std::mt19937, std::uniform_real_distribution.
 #include <vector>     // For std::vector.
 
+#include <fp16/fp16.h>
+#include <gtest/gtest.h>
+
 #include <xnnpack.h>
 #include <xnnpack/aligned-allocator.h>
 #include <xnnpack/common.h>
 #include <xnnpack/operator.h>
 #include <xnnpack/subgraph.h>
-
-#include <gtest/gtest.h>
 
 template <class T, class BiasType = T> class BatchMatrixMultiplyTestBase : public ::testing::Test {
 protected:
@@ -92,7 +93,54 @@ protected:
   std::vector<T> subgraph_output;
 };
 
+using BatchMatrixMultiplyTestF16 = BatchMatrixMultiplyTestBase<uint16_t>;
 using BatchMatrixMultiplyTestF32 = BatchMatrixMultiplyTestBase<float>;
+
+TEST_F(BatchMatrixMultiplyTestF16, define)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(3, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  uint32_t input1_id = XNN_INVALID_VALUE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input1_dims.size(), input1_dims.data(), nullptr,
+                          /*external_id=*/0, /*flags=*/0, &input1_id));
+  ASSERT_NE(input1_id, XNN_INVALID_VALUE_ID);
+
+  uint32_t input2_id = XNN_INVALID_VALUE_ID;
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_tensor_value(
+      subgraph, xnn_datatype_fp16, input2_dims.size(), input2_dims.data(), input2.data(), /*external_id=*/1,
+      /*flags=*/0, &input2_id));
+  ASSERT_NE(input2_id, XNN_INVALID_VALUE_ID);
+
+  uint32_t output_id = XNN_INVALID_VALUE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr,
+                          /*external_id=*/2, /*flags=*/0, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_VALUE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_batch_matrix_multiply(subgraph, input1_id, input2_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_batch_matrix_multiply);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
+  ASSERT_EQ(node->num_inputs, 2);
+  ASSERT_EQ(node->inputs[0], input1_id);
+  ASSERT_EQ(node->inputs[1], input2_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
 
 TEST_F(BatchMatrixMultiplyTestF32, define)
 {
@@ -184,6 +232,90 @@ TEST_F(BatchMatrixMultiplyTestF32, define_transposed)
   ASSERT_EQ(node->num_outputs, 1);
   ASSERT_EQ(node->outputs[0], output_id);
   ASSERT_EQ(node->flags, XNN_FLAG_TRANSPOSE_B);
+}
+
+TEST_F(BatchMatrixMultiplyTestF16, matches_operator_api)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_operator_t op = nullptr;
+
+  std::generate(input1.begin(), input1.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::generate(input2.begin(), input2.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+
+  // Call operator API.
+  const xnn_status status = xnn_create_batch_matrix_multiply_nc_f16(/*flags=*/0, &op);
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+
+  size_t workspace_size = 0;
+  size_t workspace_alignment = 0;
+  ASSERT_EQ(
+    xnn_status_success, xnn_reshape_batch_matrix_multiply_nc_f16(
+                          op, batch_size, m, k, n,
+                          &workspace_size, &workspace_alignment, /*threadpool=*/nullptr));
+  ASSERT_NE(workspace_size, 0);
+  ASSERT_LE(workspace_alignment, XNN_ALLOCATION_ALIGNMENT);
+
+  std::vector<char, AlignedAllocator<char, XNN_ALLOCATION_ALIGNMENT>> workspace(workspace_size);
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_setup_batch_matrix_multiply_nc_f16(op, workspace.data(), input1.data(), input2.data(), operator_output.data()));
+
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(3, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  uint32_t input1_id = XNN_INVALID_VALUE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input1_dims.size(), input1_dims.data(), nullptr,
+                          /*external_id=*/0, XNN_VALUE_FLAG_EXTERNAL_INPUT, &input1_id));
+  ASSERT_NE(input1_id, XNN_INVALID_VALUE_ID);
+
+  uint32_t input2_id = XNN_INVALID_VALUE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input2_dims.size(), input2_dims.data(), nullptr,
+                          /*external_id=*/1, XNN_VALUE_FLAG_EXTERNAL_INPUT, &input2_id));
+  ASSERT_NE(input2_id, XNN_INVALID_VALUE_ID);
+
+  uint32_t output_id = XNN_INVALID_VALUE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr,
+                          /*external_id=*/2, XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_VALUE_ID);
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_batch_matrix_multiply(subgraph, input1_id, input2_id, output_id, /*flags=*/0));
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 3> external = {
+    xnn_external_value{input1_id, input1.data()},
+    xnn_external_value{input2_id, input2.data()},
+    xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  // Check outputs match.
+  for (size_t i = 0; i < operator_output.size(); i++) {
+    ASSERT_EQ(subgraph_output[i], operator_output[i]);
+  }
 }
 
 TEST_F(BatchMatrixMultiplyTestF32, matches_operator_api)

--- a/test/ceiling.cc
+++ b/test/ceiling.cc
@@ -11,15 +11,53 @@
 #include <memory>
 #include <random>
 
+#include <fp16/fp16.h>
+#include <gtest/gtest.h>
+
 #include <xnnpack.h>
 #include <xnnpack/node-type.h>
 #include <xnnpack/operator.h>
 #include <xnnpack/subgraph.h>
 
 #include "subgraph-unary-tester.h"
-#include <gtest/gtest.h>
 
+using CeilingTestF16 = UnaryTest<uint16_t>;
 using CeilingTestF32 = UnaryTest<float>;
+
+TEST_F(CeilingTestF16, define)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, 0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, 1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(xnn_status_success, xnn_define_ceiling(subgraph, input_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_ceiling);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
+  ASSERT_EQ(node->num_inputs, 1);
+  ASSERT_EQ(node->inputs[0], input_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
 
 TEST_F(CeilingTestF32, define)
 {
@@ -54,6 +92,61 @@ TEST_F(CeilingTestF32, define)
   ASSERT_EQ(node->num_outputs, 1);
   ASSERT_EQ(node->outputs[0], output_id);
   ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(CeilingTestF16, matches_operator_api)
+{
+  std::uniform_real_distribution<float> f32dist(-5.0f, -0.0f);
+  std::generate(input.begin(), input.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  // Call operator API.
+  xnn_operator_t op = nullptr;
+  const xnn_status status = xnn_create_ceiling_nc_f16(/*flags=*/0, &op);
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  ASSERT_EQ(xnn_status_success, xnn_reshape_ceiling_nc_f16(op, batch_size, channels, channels, channels, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_setup_ceiling_nc_f16(op, input.data(), operator_output.data()));
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, /*external_id=*/0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, /*external_id=*/1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_define_ceiling(subgraph, input_id, output_id, /*flags=*/0));
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 2> external = {
+    xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  ASSERT_EQ(subgraph_output, operator_output);
 }
 
 TEST_F(CeilingTestF32, matches_operator_api)

--- a/test/clamp.cc
+++ b/test/clamp.cc
@@ -11,16 +11,19 @@
 #include <memory>
 #include <random>
 
+#include <fp16/fp16.h>
+#include <gtest/gtest.h>
+
 #include <xnnpack.h>
 #include <xnnpack/node-type.h>
 #include <xnnpack/operator.h>
 #include <xnnpack/subgraph.h>
 
 #include "subgraph-unary-tester.h"
-#include <gtest/gtest.h>
 
 using ClampTestQS8 = UnaryTest<int8_t>;
 using ClampTestQU8 = UnaryTest<uint8_t>;
+using ClampTestF16 = UnaryTest<uint16_t>;
 using ClampTestF32 = UnaryTest<float>;
 
 TEST_F(ClampTestQS8, define)
@@ -104,6 +107,44 @@ TEST_F(ClampTestQU8, define)
   const struct xnn_node* node = &subgraph->nodes[0];
   ASSERT_EQ(node->type, xnn_node_type_clamp);
   ASSERT_EQ(node->compute_type, xnn_compute_type_qu8);
+  ASSERT_EQ(node->num_inputs, 1);
+  ASSERT_EQ(node->inputs[0], input_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(ClampTestF16, define)
+{
+  const float output_min = std::uniform_real_distribution<float>(-128.0f, 0.0f)(rng);
+  const float output_max = std::uniform_real_distribution<float>(1.0f, 127.0f)(rng);
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, 0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, 1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(xnn_status_success, xnn_define_clamp(subgraph, output_min, output_max, input_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_clamp);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
   ASSERT_EQ(node->num_inputs, 1);
   ASSERT_EQ(node->inputs[0], input_id);
   ASSERT_EQ(node->num_outputs, 1);
@@ -269,6 +310,64 @@ TEST_F(ClampTestQU8, matches_operator_api)
   ASSERT_NE(nullptr, runtime);
   std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
 
+  std::array<xnn_external_value, 2> external = {
+    xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  ASSERT_EQ(subgraph_output, operator_output);
+}
+
+TEST_F(ClampTestF16, matches_operator_api)
+{
+  const float output_min = std::uniform_real_distribution<float>(-128.0f, 0.0f)(rng);
+  const float output_max = std::uniform_real_distribution<float>(1.0f, 127.0f)(rng);
+  std::uniform_real_distribution<float> f32dist(-255.0f, 255.0f);
+  std::generate(input.begin(), input.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  // Call operator API.
+  xnn_operator_t op = nullptr;
+  const xnn_status status =
+    xnn_create_clamp_nc_f16(output_min, output_max, /*flags=*/0, &op);
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  ASSERT_EQ(xnn_status_success, xnn_reshape_clamp_nc_f16(op, batch_size, channels, channels, channels, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_setup_clamp_nc_f16(op, input.data(), operator_output.data()));
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, /*external_id=*/0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, /*external_id=*/1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_define_clamp(subgraph, output_min, output_max, input_id, output_id, /*flags=*/0));
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
   std::array<xnn_external_value, 2> external = {
     xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
   ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));

--- a/test/concatenate2.cc
+++ b/test/concatenate2.cc
@@ -12,6 +12,8 @@
 #include <numeric>
 #include <random>
 
+#include <fp16/fp16.h>
+
 #include <xnnpack.h>
 #include <xnnpack/node-type.h>
 #include <xnnpack/operator.h>
@@ -122,6 +124,7 @@ protected:
 
 using Concatenate2TestQS8 = Concatenate2Test<int8_t>;
 using Concatenate2TestQU8 = Concatenate2Test<uint8_t>;
+using Concatenate2TestF16 = Concatenate2Test<uint16_t>;
 using Concatenate2TestF32 = Concatenate2Test<float>;
 
 TEST_F(Concatenate2TestQS8, define)
@@ -209,6 +212,50 @@ TEST_F(Concatenate2TestQU8, define)
   const struct xnn_node* node = &subgraph->nodes[0];
   ASSERT_EQ(node->type, xnn_node_type_concatenate2);
   ASSERT_EQ(node->compute_type, xnn_compute_type_qu8);
+  ASSERT_EQ(node->params.concatenate.axis, axis);
+  ASSERT_EQ(node->num_inputs, 2);
+  ASSERT_EQ(node->inputs[0], input1_id);
+  ASSERT_EQ(node->inputs[1], input2_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(Concatenate2TestF16, define)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/3, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  input1_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input1_dims.size(), input1_dims.data(), nullptr, 0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input1_id));
+  ASSERT_NE(input1_id, XNN_INVALID_NODE_ID);
+
+  input2_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input2_dims.size(), input2_dims.data(), nullptr, 1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input2_id));
+  ASSERT_NE(input2_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr, 2,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(xnn_status_success, xnn_define_concatenate2(subgraph, axis, input1_id, input2_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_concatenate2);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
   ASSERT_EQ(node->params.concatenate.axis, axis);
   ASSERT_EQ(node->num_inputs, 2);
   ASSERT_EQ(node->inputs[0], input1_id);
@@ -392,6 +439,77 @@ TEST_F(Concatenate2TestQU8, matches_operator_api)
     xnn_define_quantized_tensor_value(
       subgraph, xnn_datatype_quint8, unsigned_zero_point, scale, output_dims.size(), output_dims.data(), nullptr, 2,
       /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(xnn_status_success, xnn_define_concatenate2(subgraph, axis, input1_id, input2_id, output_id, /*flags=*/0));
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 3> external = {
+    xnn_external_value{input1_id, input1.data()}, xnn_external_value{input2_id, input2.data()},
+    xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  // Check outputs match.
+  ASSERT_EQ(subgraph_output, operator_output);
+}
+
+TEST_F(Concatenate2TestF16, matches_operator_api)
+{
+  std::generate(input1.begin(), input1.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::generate(input2.begin(), input2.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(std::nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(std::nanf("")));
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_operator_t op1 = nullptr;
+  xnn_operator_t op2 = nullptr;
+
+  // Call operator API.
+  ASSERT_EQ(xnn_status_success, xnn_create_copy_nc_x16(/*flags=*/0, &op1));
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op1(op1, xnn_delete_operator);
+  ASSERT_EQ(xnn_status_success, xnn_create_copy_nc_x16(/*flags=*/0, &op2));
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op2(op2, xnn_delete_operator);
+
+  ASSERT_EQ(xnn_status_success, xnn_reshape_copy_nc_x16(op1, batch_size, channels_1, channels_1, output_stride, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_reshape_copy_nc_x16(op2, batch_size, channels_2, channels_2, output_stride, /*threadpool=*/nullptr));
+
+  ASSERT_EQ(xnn_status_success, xnn_setup_copy_nc_x16(op1, input1.data(), operator_output.data()));
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_setup_copy_nc_x16( op2, input2.data(), (uint16_t*) operator_output.data() + op1->channels));
+
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op1, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op2, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/3, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  input1_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input1_dims.size(), input1_dims.data(), nullptr, 0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input1_id));
+  ASSERT_NE(input1_id, XNN_INVALID_NODE_ID);
+
+  input2_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input2_dims.size(), input2_dims.data(), nullptr, 1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input2_id));
+  ASSERT_NE(input2_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr, 2,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
   ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
 
   ASSERT_EQ(xnn_status_success, xnn_define_concatenate2(subgraph, axis, input1_id, input2_id, output_id, /*flags=*/0));

--- a/test/concatenate3.cc
+++ b/test/concatenate3.cc
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include <gtest/gtest.h>
+#include <fp16/fp16.h>
 
 #include <xnnpack.h>
 #include <xnnpack/node-type.h>
@@ -132,6 +133,7 @@ protected:
 
 using Concatenate3TestQS8 = Concatenate3Test<int8_t>;
 using Concatenate3TestQU8 = Concatenate3Test<uint8_t>;
+using Concatenate3TestF16 = Concatenate3Test<uint16_t>;
 using Concatenate3TestF32 = Concatenate3Test<float>;
 
 TEST_F(Concatenate3TestQS8, define)
@@ -240,6 +242,60 @@ TEST_F(Concatenate3TestQU8, define)
   const struct xnn_node* node = &subgraph->nodes[0];
   ASSERT_EQ(node->type, xnn_node_type_concatenate3);
   ASSERT_EQ(node->compute_type, xnn_compute_type_qu8);
+  ASSERT_EQ(node->params.concatenate.axis, axis);
+  ASSERT_EQ(node->num_inputs, 3);
+  ASSERT_EQ(node->inputs[0], input1_id);
+  ASSERT_EQ(node->inputs[1], input2_id);
+  ASSERT_EQ(node->inputs[2], input3_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(Concatenate3TestF16, define)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/4, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  input1_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input1_dims.size(), input1_dims.data(), nullptr, 0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input1_id));
+  ASSERT_NE(input1_id, XNN_INVALID_NODE_ID);
+
+  input2_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input2_dims.size(), input2_dims.data(), nullptr, 1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input2_id));
+  ASSERT_NE(input2_id, XNN_INVALID_NODE_ID);
+
+  input3_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input3_dims.size(), input3_dims.data(), nullptr, 2,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input3_id));
+  ASSERT_NE(input3_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr, 3,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_concatenate3(subgraph, axis, input1_id, input2_id, input3_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_concatenate3);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
   ASSERT_EQ(node->params.concatenate.axis, axis);
   ASSERT_EQ(node->num_inputs, 3);
   ASSERT_EQ(node->inputs[0], input1_id);
@@ -474,6 +530,97 @@ TEST_F(Concatenate3TestQU8, matches_operator_api)
     xnn_define_quantized_tensor_value(
       subgraph, xnn_datatype_quint8, unsigned_zero_point, scale, output_dims.size(), output_dims.data(), nullptr, 3,
       /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_concatenate3(subgraph, axis, input1_id, input2_id, input3_id, output_id, /*flags=*/0));
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 4> external = {
+    xnn_external_value{input1_id, input1.data()}, xnn_external_value{input2_id, input2.data()},
+    xnn_external_value{input3_id, input3.data()}, xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  // Check outputs match.
+  ASSERT_EQ(subgraph_output, operator_output);
+}
+
+TEST_F(Concatenate3TestF16, matches_operator_api)
+{
+  std::generate(input1.begin(), input1.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::generate(input2.begin(), input2.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::generate(input3.begin(), input3.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(std::nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(std::nanf("")));
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_operator_t op1 = nullptr;
+  xnn_operator_t op2 = nullptr;
+  xnn_operator_t op3 = nullptr;
+
+  // Call operator API.
+  ASSERT_EQ(xnn_status_success, xnn_create_copy_nc_x16(/*flags=*/0, &op1));
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op1(op1, xnn_delete_operator);
+  ASSERT_EQ(xnn_status_success, xnn_create_copy_nc_x16(/*flags=*/0, &op2));
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op2(op2, xnn_delete_operator);
+  ASSERT_EQ(xnn_status_success, xnn_create_copy_nc_x16(/*flags=*/0, &op3));
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op3(op3, xnn_delete_operator);
+
+  ASSERT_EQ(xnn_status_success, xnn_reshape_copy_nc_x16(op1, batch_size, channels_1, channels_1, output_stride, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_reshape_copy_nc_x16(op2, batch_size, channels_2, channels_2, output_stride, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_reshape_copy_nc_x16(op3, batch_size, channels_3, channels_3, output_stride, /*threadpool=*/nullptr));
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_setup_copy_nc_x16(op1, input1.data(), operator_output.data()));
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_setup_copy_nc_x16(op2, input2.data(), (uint16_t*) operator_output.data() + op1->channels));
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_setup_copy_nc_x16(op3, input3.data(), (uint16_t*) operator_output.data() + op1->channels + op2->channels));
+
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op1, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op2, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op3, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/4, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  input1_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input1_dims.size(), input1_dims.data(), nullptr, 0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input1_id));
+  ASSERT_NE(input1_id, XNN_INVALID_NODE_ID);
+
+  input2_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input2_dims.size(), input2_dims.data(), nullptr, 1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input2_id));
+  ASSERT_NE(input2_id, XNN_INVALID_NODE_ID);
+
+  input3_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input3_dims.size(), input3_dims.data(), nullptr, 2,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input3_id));
+  ASSERT_NE(input3_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr, 3,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
   ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
 
   ASSERT_EQ(

--- a/test/concatenate4.cc
+++ b/test/concatenate4.cc
@@ -14,6 +14,7 @@
 #include <random>
 #include <vector>
 
+#include <fp16/fp16.h>
 #include <gtest/gtest.h>
 
 #include <xnnpack.h>
@@ -140,6 +141,7 @@ protected:
 
 using Concatenate4TestQS8 = Concatenate4Test<int8_t>;
 using Concatenate4TestQU8 = Concatenate4Test<uint8_t>;
+using Concatenate4TestF16 = Concatenate4Test<uint16_t>;
 using Concatenate4TestF32 = Concatenate4Test<float>;
 
 TEST_F(Concatenate4TestQS8, define)
@@ -265,6 +267,68 @@ TEST_F(Concatenate4TestQU8, define)
   const struct xnn_node* node = &subgraph->nodes[0];
   ASSERT_EQ(node->type, xnn_node_type_concatenate4);
   ASSERT_EQ(node->compute_type, xnn_compute_type_qu8);
+  ASSERT_EQ(node->params.concatenate.axis, axis);
+  ASSERT_EQ(node->num_inputs, 4);
+  ASSERT_EQ(node->inputs[0], input1_id);
+  ASSERT_EQ(node->inputs[1], input2_id);
+  ASSERT_EQ(node->inputs[2], input3_id);
+  ASSERT_EQ(node->inputs[3], input4_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(Concatenate4TestF16, define)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/5, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  input1_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input1_dims.size(), input1_dims.data(), nullptr, 0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input1_id));
+  ASSERT_NE(input1_id, XNN_INVALID_NODE_ID);
+
+  input2_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input2_dims.size(), input2_dims.data(), nullptr, 1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input2_id));
+  ASSERT_NE(input2_id, XNN_INVALID_NODE_ID);
+
+  input3_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input3_dims.size(), input3_dims.data(), nullptr, 2,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input3_id));
+  ASSERT_NE(input3_id, XNN_INVALID_NODE_ID);
+
+  input4_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input4_dims.size(), input4_dims.data(), nullptr, 3,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input4_id));
+  ASSERT_NE(input4_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr, 4,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_concatenate4(subgraph, axis, input1_id, input2_id, input3_id, input4_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_concatenate4);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
   ASSERT_EQ(node->params.concatenate.axis, axis);
   ASSERT_EQ(node->num_inputs, 4);
   ASSERT_EQ(node->inputs[0], input1_id);
@@ -545,6 +609,115 @@ TEST_F(Concatenate4TestQU8, matches_operator_api)
     xnn_define_quantized_tensor_value(
       subgraph, xnn_datatype_quint8, unsigned_zero_point, scale, output_dims.size(), output_dims.data(), nullptr, 4,
       /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_concatenate4(subgraph, axis, input1_id, input2_id, input3_id, input4_id, output_id, /*flags=*/0));
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 5> external = {
+    xnn_external_value{input1_id, input1.data()}, xnn_external_value{input2_id, input2.data()},
+    xnn_external_value{input3_id, input3.data()}, xnn_external_value{input4_id, input4.data()},
+    xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  // Check outputs match.
+  ASSERT_EQ(subgraph_output, operator_output);
+}
+
+TEST_F(Concatenate4TestF16, matches_operator_api)
+{
+  std::generate(input1.begin(), input1.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::generate(input2.begin(), input2.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::generate(input3.begin(), input3.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::generate(input4.begin(), input4.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(std::nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(std::nanf("")));
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_operator_t op1 = nullptr;
+  xnn_operator_t op2 = nullptr;
+  xnn_operator_t op3 = nullptr;
+  xnn_operator_t op4 = nullptr;
+
+  // Call operator API.
+  ASSERT_EQ(xnn_status_success, xnn_create_copy_nc_x16(/*flags=*/0, &op1));
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op1(op1, xnn_delete_operator);
+  ASSERT_EQ(xnn_status_success, xnn_create_copy_nc_x16(/*flags=*/0, &op2));
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op2(op2, xnn_delete_operator);
+  ASSERT_EQ(xnn_status_success, xnn_create_copy_nc_x16(/*flags=*/0, &op3));
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op3(op3, xnn_delete_operator);
+  ASSERT_EQ(xnn_status_success, xnn_create_copy_nc_x16(/*flags=*/0, &op4));
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op4(op4, xnn_delete_operator);
+
+  ASSERT_EQ(xnn_status_success, xnn_reshape_copy_nc_x16(op1, batch_size, channels_1, channels_1, output_stride, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_reshape_copy_nc_x16(op2, batch_size, channels_2, channels_2, output_stride, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_reshape_copy_nc_x16(op3, batch_size, channels_3, channels_3, output_stride, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_reshape_copy_nc_x16(op4, batch_size, channels_4, channels_4, output_stride, /*threadpool=*/nullptr));
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_setup_copy_nc_x16(op1, input1.data(), operator_output.data()));
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_setup_copy_nc_x16(op2, input2.data(), (uint16_t*) operator_output.data() + op1->channels));
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_setup_copy_nc_x16(op3, input3.data(), (uint16_t*) operator_output.data() + op1->channels + op2->channels));
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_setup_copy_nc_x16(
+      op4, input4.data(), (uint16_t*) operator_output.data() + op1->channels + op2->channels + op3->channels));
+
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op1, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op2, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op3, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op4, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/5, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  input1_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input1_dims.size(), input1_dims.data(), nullptr, 0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input1_id));
+  ASSERT_NE(input1_id, XNN_INVALID_NODE_ID);
+
+  input2_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input2_dims.size(), input2_dims.data(), nullptr, 1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input2_id));
+  ASSERT_NE(input2_id, XNN_INVALID_NODE_ID);
+
+  input3_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input3_dims.size(), input3_dims.data(), nullptr, 2,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input3_id));
+  ASSERT_NE(input3_id, XNN_INVALID_NODE_ID);
+
+  input4_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input4_dims.size(), input4_dims.data(), nullptr, 3,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input4_id));
+  ASSERT_NE(input4_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr, 4,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
   ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
 
   ASSERT_EQ(

--- a/test/concatenate5.cc
+++ b/test/concatenate5.cc
@@ -14,6 +14,7 @@
 #include <random>
 #include <vector>
 
+#include <fp16.h>
 #include <gtest/gtest.h>
 
 #include <xnnpack.h>
@@ -148,6 +149,7 @@ protected:
 
 using Concatenate5TestQS8 = Concatenate5Test<int8_t>;
 using Concatenate5TestQU8 = Concatenate5Test<uint8_t>;
+using Concatenate5TestF16 = Concatenate5Test<uint16_t>;
 using Concatenate5TestF32 = Concatenate5Test<float>;
 
 TEST_F(Concatenate5TestQS8, define)
@@ -290,6 +292,76 @@ TEST_F(Concatenate5TestQU8, define)
   const struct xnn_node* node = &subgraph->nodes[0];
   ASSERT_EQ(node->type, xnn_node_type_concatenate5);
   ASSERT_EQ(node->compute_type, xnn_compute_type_qu8);
+  ASSERT_EQ(node->params.concatenate.axis, axis);
+  ASSERT_EQ(node->num_inputs, 5);
+  ASSERT_EQ(node->inputs[0], input1_id);
+  ASSERT_EQ(node->inputs[1], input2_id);
+  ASSERT_EQ(node->inputs[2], input3_id);
+  ASSERT_EQ(node->inputs[3], input4_id);
+  ASSERT_EQ(node->inputs[4], input5_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(Concatenate5TestF16, define)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/6, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  input1_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input1_dims.size(), input1_dims.data(), nullptr, 0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input1_id));
+  ASSERT_NE(input1_id, XNN_INVALID_NODE_ID);
+
+  input2_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input2_dims.size(), input2_dims.data(), nullptr, 1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input2_id));
+  ASSERT_NE(input2_id, XNN_INVALID_NODE_ID);
+
+  input3_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input3_dims.size(), input3_dims.data(), nullptr, 2,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input3_id));
+  ASSERT_NE(input3_id, XNN_INVALID_NODE_ID);
+
+  input4_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input4_dims.size(), input4_dims.data(), nullptr, 3,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input4_id));
+  ASSERT_NE(input4_id, XNN_INVALID_NODE_ID);
+
+  input5_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input5_dims.size(), input5_dims.data(), nullptr, 4,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input5_id));
+  ASSERT_NE(input5_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr, 5,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_concatenate5(subgraph, axis, input1_id, input2_id, input3_id, input4_id, input5_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_concatenate5);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
   ASSERT_EQ(node->params.concatenate.axis, axis);
   ASSERT_EQ(node->num_inputs, 5);
   ASSERT_EQ(node->inputs[0], input1_id);
@@ -615,6 +687,132 @@ TEST_F(Concatenate5TestQU8, matches_operator_api)
     xnn_define_quantized_tensor_value(
       subgraph, xnn_datatype_quint8, unsigned_zero_point, scale, output_dims.size(), output_dims.data(), nullptr, 5,
       /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_concatenate5(subgraph, axis, input1_id, input2_id, input3_id, input4_id, input5_id, output_id, /*flags=*/0));
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 6> external = {
+    xnn_external_value{input1_id, input1.data()}, xnn_external_value{input2_id, input2.data()},
+    xnn_external_value{input3_id, input3.data()}, xnn_external_value{input4_id, input4.data()},
+    xnn_external_value{input5_id, input5.data()}, xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  // Check outputs match.
+  ASSERT_EQ(subgraph_output, operator_output);
+}
+
+TEST_F(Concatenate5TestF16, matches_operator_api)
+{
+  std::generate(input1.begin(), input1.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::generate(input2.begin(), input2.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::generate(input3.begin(), input3.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::generate(input4.begin(), input4.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::generate(input5.begin(), input5.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(std::nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(std::nanf("")));
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_operator_t op1 = nullptr;
+  xnn_operator_t op2 = nullptr;
+  xnn_operator_t op3 = nullptr;
+  xnn_operator_t op4 = nullptr;
+  xnn_operator_t op5 = nullptr;
+
+  // Call operator API.
+  ASSERT_EQ(xnn_status_success, xnn_create_copy_nc_x16(/*flags=*/0, &op1));
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op1(op1, xnn_delete_operator);
+  ASSERT_EQ(xnn_status_success, xnn_create_copy_nc_x16(/*flags=*/0, &op2));
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op2(op2, xnn_delete_operator);
+  ASSERT_EQ(xnn_status_success, xnn_create_copy_nc_x16(/*flags=*/0, &op3));
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op3(op3, xnn_delete_operator);
+  ASSERT_EQ(xnn_status_success, xnn_create_copy_nc_x16(/*flags=*/0, &op4));
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op4(op4, xnn_delete_operator);
+  ASSERT_EQ(xnn_status_success, xnn_create_copy_nc_x16(/*flags=*/0, &op5));
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op5(op5, xnn_delete_operator);
+
+  ASSERT_EQ(xnn_status_success, xnn_reshape_copy_nc_x16(op1, batch_size, channels_1, channels_1, output_stride, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_reshape_copy_nc_x16(op2, batch_size, channels_2, channels_2, output_stride, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_reshape_copy_nc_x16(op3, batch_size, channels_3, channels_3, output_stride, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_reshape_copy_nc_x16(op4, batch_size, channels_4, channels_4, output_stride, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_reshape_copy_nc_x16(op5, batch_size, channels_5, channels_5, output_stride, /*threadpool=*/nullptr));
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_setup_copy_nc_x16(op1, input1.data(), operator_output.data()));
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_setup_copy_nc_x16(op2, input2.data(), (uint16_t*) operator_output.data() + op1->channels));
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_setup_copy_nc_x16(op3, input3.data(), (uint16_t*) operator_output.data() + op1->channels + op2->channels));
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_setup_copy_nc_x16(
+      op4, input4.data(), (uint16_t*) operator_output.data() + op1->channels + op2->channels + op3->channels));
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_setup_copy_nc_x16(
+      op5, input5.data(), (uint16_t*) operator_output.data() + op1->channels + op2->channels + op3->channels + op4->channels));
+
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op1, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op2, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op3, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op4, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op5, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/6, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  input1_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input1_dims.size(), input1_dims.data(), nullptr, 0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input1_id));
+  ASSERT_NE(input1_id, XNN_INVALID_NODE_ID);
+
+  input2_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input2_dims.size(), input2_dims.data(), nullptr, 1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input2_id));
+  ASSERT_NE(input2_id, XNN_INVALID_NODE_ID);
+
+  input3_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input3_dims.size(), input3_dims.data(), nullptr, 2,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input3_id));
+  ASSERT_NE(input3_id, XNN_INVALID_NODE_ID);
+
+  input4_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input4_dims.size(), input4_dims.data(), nullptr, 3,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input4_id));
+  ASSERT_NE(input4_id, XNN_INVALID_NODE_ID);
+
+  input5_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input5_dims.size(), input5_dims.data(), nullptr, 4,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input5_id));
+  ASSERT_NE(input5_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr, 5,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
   ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
 
   ASSERT_EQ(

--- a/test/concatenate5.cc
+++ b/test/concatenate5.cc
@@ -14,7 +14,7 @@
 #include <random>
 #include <vector>
 
-#include <fp16.h>
+#include <fp16/fp16.h>
 #include <gtest/gtest.h>
 
 #include <xnnpack.h>

--- a/test/convert.cc
+++ b/test/convert.cc
@@ -12,21 +12,100 @@
 #include <random>
 #include <vector>
 
+#include <fp16/fp16.h>
+#include <gtest/gtest.h>
+
 #include <xnnpack.h>
 #include <xnnpack/node-type.h>
 #include <xnnpack/operator.h>
 #include <xnnpack/subgraph.h>
 
 #include "subgraph-unary-tester.h"
-#include <gtest/gtest.h>
 
+using ConvertTestF32ToF16 = UnaryTest<float, uint16_t>;
 using ConvertTestF32ToQD8 = UnaryTest<float, int8_t, /*min_dim=*/1>;
 using ConvertTestF32ToQS8 = UnaryTest<float, int8_t>;
 using ConvertTestF32ToQU8 = UnaryTest<float, uint8_t>;
+
 using ConvertTestQS8ToQS8 = UnaryTest<int8_t, int8_t>;
+using ConvertTestQS8ToF16 = UnaryTest<int8_t, uint16_t>;
 using ConvertTestQS8ToF32 = UnaryTest<int8_t, float>;
+
 using ConvertTestQU8ToQU8 = UnaryTest<uint8_t, uint8_t>;
 using ConvertTestQU8ToF32 = UnaryTest<uint8_t, float>;
+
+using ConvertTestF16ToF32 = UnaryTest<uint16_t, float>;
+using ConvertTestF16ToQD8 = UnaryTest<uint16_t, int8_t, /*min_dim=*/1>;
+
+TEST_F(ConvertTestF16ToF32, define)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, 0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp32, dims.size(), dims.data(), nullptr, 1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(xnn_status_success, xnn_define_convert(subgraph, input_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_convert);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16_to_fp32);
+  ASSERT_EQ(node->num_inputs, 1);
+  ASSERT_EQ(node->inputs[0], input_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(ConvertTestF32ToF16, define)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp32, dims.size(), dims.data(), nullptr, 0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, 1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(xnn_status_success, xnn_define_convert(subgraph, input_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_convert);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp32_to_fp16);
+  ASSERT_EQ(node->num_inputs, 1);
+  ASSERT_EQ(node->inputs[0], input_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
 
 TEST_F(ConvertTestF32ToQS8, define)
 {
@@ -92,6 +171,41 @@ TEST_F(ConvertTestF32ToQU8, define)
   const struct xnn_node* node = &subgraph->nodes[0];
   ASSERT_EQ(node->type, xnn_node_type_convert);
   ASSERT_EQ(node->compute_type, xnn_compute_type_fp32_to_qu8);
+  ASSERT_EQ(node->num_inputs, 1);
+  ASSERT_EQ(node->inputs[0], input_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(ConvertTestQS8ToF16, define)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_quantized_tensor_value(
+                          subgraph, xnn_datatype_qint8, signed_zero_point, scale, dims.size(), dims.data(), nullptr, 0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, 1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(xnn_status_success, xnn_define_convert(subgraph, input_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_convert);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_qs8_to_fp16);
   ASSERT_EQ(node->num_inputs, 1);
   ASSERT_EQ(node->inputs[0], input_id);
   ASSERT_EQ(node->num_outputs, 1);
@@ -256,6 +370,118 @@ TEST_F(ConvertTestQU8ToQU8, define)
   ASSERT_EQ(node->flags, 0);
 }
 
+TEST_F(ConvertTestF16ToF32, matches_operator_api)
+{
+  std::uniform_real_distribution<float> f32dist(-1.0f, 1.0f);
+  std::generate(input.begin(), input.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::fill(operator_output.begin(), operator_output.end(), nanf(""));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), nanf(""));
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  // Call operator API.
+  xnn_operator_t op = nullptr;
+  const xnn_status status = xnn_create_convert_nc_f16_f32(/*flags=*/0, &op);
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  ASSERT_EQ(xnn_status_success, xnn_reshape_convert_nc_f16_f32(op, batch_size, channels, channels, channels, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_setup_convert_nc_f16_f32(op, input.data(), operator_output.data()));
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, /*external_id=*/0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_tensor_value(
+      subgraph, xnn_datatype_fp32, dims.size(), dims.data(), nullptr, /*external_id=*/1,
+      /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_define_convert(subgraph, input_id, output_id, /*flags=*/0));
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 2> external = {
+    xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  ASSERT_EQ(subgraph_output, operator_output);
+}
+
+TEST_F(ConvertTestF32ToF16, matches_operator_api)
+{
+  std::uniform_real_distribution<float> f32dist(-1.0f, 1.0f);
+  std::generate(input.begin(), input.end(), [&]() { return f32dist(rng); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  // Call operator API.
+  xnn_operator_t op = nullptr;
+  const xnn_status status = xnn_create_convert_nc_f32_f16(/*flags=*/0, &op);
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  ASSERT_EQ(xnn_status_success, xnn_reshape_convert_nc_f32_f16(op, batch_size, channels, channels, channels, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_setup_convert_nc_f32_f16(op, input.data(), operator_output.data()));
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp32, dims.size(), dims.data(), nullptr, /*external_id=*/0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_tensor_value(
+      subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, /*external_id=*/1,
+      /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_define_convert(subgraph, input_id, output_id, /*flags=*/0));
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 2> external = {
+    xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  ASSERT_EQ(subgraph_output, operator_output);
+}
+
 TEST_F(ConvertTestF32ToQS8, matches_operator_api)
 {
   std::uniform_real_distribution<float> f32dist(-1.0f, 1.0f);
@@ -298,6 +524,62 @@ TEST_F(ConvertTestF32ToQS8, matches_operator_api)
     xnn_define_quantized_tensor_value(
       subgraph, xnn_datatype_qint8, signed_zero_point, scale, dims.size(), dims.data(), nullptr, /*external_id=*/1,
       /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_define_convert(subgraph, input_id, output_id, /*flags=*/0));
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 2> external = {
+    xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  ASSERT_EQ(subgraph_output, operator_output);
+}
+
+TEST_F(ConvertTestQS8ToF16, matches_operator_api)
+{
+  std::generate(input.begin(), input.end(), [&]() { return i8dist(rng); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(std::nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(std::nanf("")));
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  // Call operator API.
+  xnn_operator_t op = nullptr;
+  const xnn_status status =
+    xnn_create_convert_nc_qs8_f16(scale, signed_zero_point, /*flags=*/0, &op);
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  ASSERT_EQ(xnn_status_success, xnn_reshape_convert_nc_qs8_f16(op, batch_size, channels, channels, channels, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_setup_convert_nc_qs8_f16(op, input.data(), operator_output.data()));
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_quantized_tensor_value(
+                          subgraph, xnn_datatype_qint8, signed_zero_point, scale, dims.size(), dims.data(), nullptr, 0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, 1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
   ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
 
   xnn_runtime_t runtime = nullptr;
@@ -611,6 +893,41 @@ TEST_F(ConvertTestQU8ToQU8, matches_operator_api)
   ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
 
   ASSERT_EQ(subgraph_output, operator_output);
+}
+
+TEST_F(ConvertTestF16ToQD8, define)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, 0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_dynamically_quantized_tensor_value(
+                          subgraph, xnn_datatype_qdint8, dims.size(), /*num_nonbatch_dims=*/1,  dims.data(),
+                          /*external_id=*/1, /*flags=*/0, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(xnn_status_success, xnn_define_convert(subgraph, input_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_convert);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16_to_qd8);
+  ASSERT_EQ(node->num_inputs, 1);
+  ASSERT_EQ(node->inputs[0], input_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
 }
 
 TEST_F(ConvertTestF32ToQD8, define)

--- a/test/convolution-2d.cc
+++ b/test/convolution-2d.cc
@@ -136,6 +136,7 @@ using ConvolutionTestQD8F16QC8W = QuantizedConvolutionTestBase<float, int8_t, fl
 using ConvolutionTestQD8F32QC8W = QuantizedConvolutionTestBase<float, int8_t, float, float>;
 using ConvolutionTestQS8 = QuantizedConvolutionTestBase<int8_t, int8_t, int32_t,int8_t>;
 using ConvolutionTestQU8 = QuantizedConvolutionTestBase<uint8_t, uint8_t, int32_t,uint8_t>;
+using ConvolutionTestF16 = ConvolutionTestBase<uint16_t, float, float>;
 using ConvolutionTestF32 = ConvolutionTestBase<float>;
 
 TEST_F(ConvolutionTestQC8, define)
@@ -698,6 +699,77 @@ TEST_F(ConvolutionTestQU8, define)
   ASSERT_EQ(node->flags, 0);
 }
 
+TEST_F(ConvolutionTestF16, define)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(4, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  uint32_t input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input_dims.size(), input_dims.data(), nullptr,
+                          /*external_id=*/0, /*flags=*/0, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  uint32_t filter_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_tensor_value(
+      subgraph, xnn_datatype_fp32, filter_dims.size(), filter_dims.data(), filter.data(), /*external_id=*/1,
+      /*flags=*/0, &filter_id));
+
+  uint32_t bias_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp32, bias_dims.size(), bias_dims.data(), bias.data(),
+                          /*external_id=*/2, /*flags=*/0, &bias_id));
+
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr,
+                          /*external_id=*/3, /*flags=*/0, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_convolution_2d(
+      subgraph, input_padding_top, input_padding_right, input_padding_bottom, input_padding_left, kernel_height,
+      kernel_width, subsampling_height, subsampling_width, dilation_height, dilation_width, groups,
+      group_input_channels, group_output_channels, output_min, output_max, input_id, filter_id, bias_id, output_id,
+      /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_convolution_2d);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
+  ASSERT_EQ(node->params.convolution_2d.input_padding_top, input_padding_top);
+  ASSERT_EQ(node->params.convolution_2d.input_padding_right, input_padding_right);
+  ASSERT_EQ(node->params.convolution_2d.input_padding_bottom, input_padding_bottom);
+  ASSERT_EQ(node->params.convolution_2d.input_padding_left, input_padding_left);
+  ASSERT_EQ(node->params.convolution_2d.kernel_height, kernel_height);
+  ASSERT_EQ(node->params.convolution_2d.kernel_width, kernel_width);
+  ASSERT_EQ(node->params.convolution_2d.subsampling_height, subsampling_height);
+  ASSERT_EQ(node->params.convolution_2d.subsampling_width, subsampling_width);
+  ASSERT_EQ(node->params.convolution_2d.dilation_height, dilation_height);
+  ASSERT_EQ(node->params.convolution_2d.dilation_width, dilation_width);
+  ASSERT_EQ(node->params.convolution_2d.groups, groups);
+  ASSERT_EQ(node->params.convolution_2d.group_input_channels, group_input_channels);
+  ASSERT_EQ(node->params.convolution_2d.group_output_channels, group_output_channels);
+  ASSERT_EQ(node->activation.output_min, output_min);
+  ASSERT_EQ(node->activation.output_max, output_max);
+  ASSERT_EQ(node->num_inputs, 3);
+  ASSERT_EQ(node->inputs[0], input_id);
+  ASSERT_EQ(node->inputs[1], filter_id);
+  ASSERT_EQ(node->inputs[2], bias_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
+
 TEST_F(ConvolutionTestF32, define)
 {
   ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
@@ -1172,6 +1244,100 @@ TEST_F(ConvolutionTestQU8, matches_operator_api)
     xnn_status_success, xnn_define_quantized_tensor_value(
                           subgraph, xnn_datatype_quint8, output_zero_point, output_scale, output_dims.size(),
                           output_dims.data(), nullptr, /*external_id=*/3, XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_convolution_2d(
+      subgraph, input_padding_top, input_padding_right, input_padding_bottom, input_padding_left, kernel_height,
+      kernel_width, subsampling_height, subsampling_width, dilation_height, dilation_width, groups,
+      group_input_channels, group_output_channels, output_min, output_max, input_id, filter_id, bias_id, output_id,
+      /*flags=*/0));
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 2> external = {
+    xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  // Check outputs match.
+  for (size_t i = 0; i < operator_output.size(); i++) {
+    ASSERT_EQ(subgraph_output[i], operator_output[i]);
+  }
+}
+
+TEST_F(ConvolutionTestF16, matches_operator_api)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_operator_t op = nullptr;
+
+  std::generate(input.begin(), input.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::generate(filter.begin(), filter.end(), [&]() { return f32dist(rng); });
+  std::generate(bias.begin(), bias.end(), [&]() { return f32dist(rng); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+
+  // Call operator API.
+  const xnn_status status = xnn_create_convolution2d_nhwc_f16(
+    input_padding_top, input_padding_right, input_padding_bottom, input_padding_left, kernel_height, kernel_width,
+    subsampling_height, subsampling_width, dilation_height, dilation_width, groups, group_input_channels,
+    group_output_channels, groups * group_input_channels, groups * group_output_channels, filter.data(), bias.data(),
+    output_min, output_max,
+    XNN_FLAG_FP32_STATIC_WEIGHTS, nullptr, nullptr, &op);
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+  size_t workspace_size = SIZE_MAX;
+  size_t workspace_alignment = SIZE_MAX;
+  ASSERT_EQ(
+    xnn_status_success, xnn_reshape_convolution2d_nhwc_f16(
+                          op, batch_size, input_height, input_width,
+                          &workspace_size, &workspace_alignment,
+                          /*output_height_out=*/nullptr, /*output_width_out=*/nullptr,
+                          /*threadpool=*/nullptr));
+  ASSERT_EQ(workspace_size, 0);
+  ASSERT_EQ(workspace_alignment, 1);
+  ASSERT_EQ(xnn_status_success, xnn_setup_convolution2d_nhwc_f16(op, /*workspace=*/nullptr, input.data(), operator_output.data()));
+
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(4, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  uint32_t input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input_dims.size(), input_dims.data(), nullptr,
+                          /*external_id=*/0, XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  uint32_t filter_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp32, filter_dims.size(), filter_dims.data(), filter.data(),
+                          /*external_id=*/1, /*flags=*/0, &filter_id));
+
+  uint32_t bias_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp32, bias_dims.size(), bias_dims.data(), bias.data(),
+                          /*external_id=*/2, /*flags=*/0, &bias_id));
+
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr,
+                          /*external_id=*/3, XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
   ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
   ASSERT_EQ(
     xnn_status_success,

--- a/test/copy.cc
+++ b/test/copy.cc
@@ -8,16 +8,19 @@
 #include <cstddef>     // For size_t.
 #include <memory>      // For std::unique_ptr.
 
+#include <fp16/fp16.h>
+#include <gtest/gtest.h>
+
 #include <xnnpack.h>
 #include <xnnpack/node-type.h>
 #include <xnnpack/operator.h>
 #include <xnnpack/subgraph.h>
 
 #include "subgraph-unary-tester.h"
-#include <gtest/gtest.h>
 
 using CopyTestQS8 = UnaryTest<int8_t>;
 using CopyTestQU8 = UnaryTest<uint8_t>;
+using CopyTestF16 = UnaryTest<uint16_t>;
 using CopyTestF32 = UnaryTest<float>;
 
 TEST_F(CopyTestQS8, define)
@@ -89,6 +92,40 @@ TEST_F(CopyTestQU8, define)
   const struct xnn_node* node = &subgraph->nodes[0];
   ASSERT_EQ(node->type, xnn_node_type_copy);
   ASSERT_EQ(node->compute_type, xnn_compute_type_qu8);
+  ASSERT_EQ(node->num_inputs, 1);
+  ASSERT_EQ(node->inputs[0], input_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(CopyTestF16, define)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(0, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+  uint32_t input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_tensor_value(
+      subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, XNN_INVALID_VALUE_ID, /*flags=*/0, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_tensor_value(
+      subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, XNN_INVALID_VALUE_ID, /*flags=*/0, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(xnn_status_success, xnn_define_copy(subgraph, input_id, output_id, 0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_copy);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
   ASSERT_EQ(node->num_inputs, 1);
   ASSERT_EQ(node->inputs[0], input_id);
   ASSERT_EQ(node->num_outputs, 1);
@@ -240,6 +277,61 @@ TEST_F(CopyTestQU8, matches_operator_api)
   ASSERT_NE(nullptr, runtime);
   std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
 
+  std::array<xnn_external_value, 2> external = {
+    xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  ASSERT_EQ(subgraph_output, operator_output);
+}
+
+TEST_F(CopyTestF16, matches_operator_api)
+{
+  std::generate(input.begin(), input.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  // Call operator API.
+  xnn_operator_t op = nullptr;
+  xnn_status status = xnn_create_copy_nc_x16(/*flags=*/0, &op);
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+  size_t batch_size = NumElements(dims);
+  ASSERT_EQ(xnn_status_success, xnn_reshape_copy_nc_x16(op, batch_size, 1, 1, 1, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_setup_copy_nc_x16(op, input.data(), operator_output.data()));
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  ASSERT_NE(nullptr, subgraph);
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+  uint32_t input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, /*external_id=*/0,
+                          XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr,
+                          /*external_id=*/1, XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_copy(subgraph, input_id, output_id, /*flags=*/0));
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
   std::array<xnn_external_value, 2> external = {
     xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
   ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));

--- a/test/depth-to-space-2d.cc
+++ b/test/depth-to-space-2d.cc
@@ -13,12 +13,13 @@
 #include <numeric>
 #include <random>
 
+#include <fp16/fp16.h>
+#include <gtest/gtest.h>
+
 #include <xnnpack.h>
 #include <xnnpack/node-type.h>
 #include <xnnpack/operator.h>
 #include <xnnpack/subgraph.h>
-
-#include <gtest/gtest.h>
 
 template <typename T> class DepthToSpaceTest : public ::testing::Test {
 protected:
@@ -92,6 +93,7 @@ protected:
 
 using DepthToSpaceTestQS8 = DepthToSpaceTest<int8_t>;
 using DepthToSpaceTestQU8 = DepthToSpaceTest<uint8_t>;
+using DepthToSpaceTestF16 = DepthToSpaceTest<uint16_t>;
 using DepthToSpaceTestF32 = DepthToSpaceTest<float>;
 
 TEST_F(DepthToSpaceTestQS8, define)
@@ -168,6 +170,43 @@ TEST_F(DepthToSpaceTestQU8, define)
   const struct xnn_node* node = &subgraph->nodes[0];
   ASSERT_EQ(node->type, xnn_node_type_depth_to_space_2d);
   ASSERT_EQ(node->compute_type, xnn_compute_type_qu8);
+  ASSERT_EQ(node->num_inputs, 1);
+  ASSERT_EQ(node->inputs[0], input_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(DepthToSpaceTestF16, define)
+{
+  uint32_t block_size = std::uniform_int_distribution<uint32_t>(2, 10)(rng);
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input_dims.size(), input_dims.data(), nullptr, 0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr, 1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(xnn_status_success, xnn_define_depth_to_space_2d(subgraph, block_size, input_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_depth_to_space_2d);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
   ASSERT_EQ(node->num_inputs, 1);
   ASSERT_EQ(node->inputs[0], input_id);
   ASSERT_EQ(node->num_outputs, 1);
@@ -336,6 +375,68 @@ TEST_F(DepthToSpaceTestQU8, matches_operator_api)
   ASSERT_NE(nullptr, runtime);
   std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
 
+  std::array<xnn_external_value, 2> external = {
+    xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  ASSERT_EQ(subgraph_output, operator_output);
+}
+
+TEST_F(DepthToSpaceTestF16, matches_operator_api)
+{
+  std::uniform_real_distribution<float> f32dist(-255.0f, 255.0f);
+  std::generate(input.begin(), input.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  // Call operator API.
+  xnn_operator_t op = nullptr;
+  const xnn_status status = xnn_create_depth_to_space_nhwc_x16(
+    block_size, /*flags=*/0, &op);
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  ASSERT_EQ(
+    xnn_status_success, xnn_reshape_depth_to_space_nhwc_x16(
+                          op, batch_size(), input_height(), input_width(), input_channel(),
+                          /*output_height_out=*/nullptr, /*output_width_out=*/nullptr, /*output_channels_out=*/nullptr,
+                          /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_setup_depth_to_space_nhwc_x16(op, input.data(), operator_output.data()));
+
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input_dims.size(), input_dims.data(), nullptr, /*external_id=*/0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_tensor_value(
+      subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr, /*external_id=*/1,
+      /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_define_depth_to_space_2d(subgraph, block_size, input_id, output_id, /*flags=*/0));
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
   std::array<xnn_external_value, 2> external = {
     xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
   ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));

--- a/test/divide2.cc
+++ b/test/divide2.cc
@@ -11,15 +11,66 @@
 #include <memory>
 #include <vector>
 
+#include <fp16/fp16.h>
+#include <gtest/gtest.h>
+
 #include <xnnpack.h>
 #include <xnnpack/node-type.h>
 #include <xnnpack/operator.h>
 #include <xnnpack/subgraph.h>
 
 #include "subgraph-binary-tester.h"
-#include <gtest/gtest.h>
 
+using Divide2TestF16 = BinaryTest<uint16_t>;
 using Divide2TestF32 = BinaryTest<float>;
+
+TEST_F(Divide2TestF16, define) {
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(3, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  std::vector<size_t> dims = RandomShape();
+
+  uint32_t input1_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr,
+                          /*external_id=*/0, /*flags=*/0, &input1_id));
+  ASSERT_NE(input1_id, XNN_INVALID_NODE_ID);
+
+  uint32_t input2_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr,
+                          /*external_id=*/0, /*flags=*/0, &input2_id));
+  ASSERT_NE(input2_id, XNN_INVALID_NODE_ID);
+
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_tensor_value(
+      subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, XNN_INVALID_VALUE_ID, /*flags=*/0, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_divide(subgraph, output_min, output_max, input1_id, input2_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_divide);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
+  ASSERT_EQ(node->activation.output_min, output_min);
+  ASSERT_EQ(node->activation.output_max, output_max);
+  ASSERT_EQ(node->num_inputs, 2);
+  ASSERT_EQ(node->inputs[0], input1_id);
+  ASSERT_EQ(node->inputs[1], input2_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
 
 TEST_F(Divide2TestF32, define) {
   ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
@@ -67,6 +118,75 @@ TEST_F(Divide2TestF32, define) {
   ASSERT_EQ(node->num_outputs, 1);
   ASSERT_EQ(node->outputs[0], output_id);
   ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(Divide2TestF16, matches_operator_api)
+{
+  std::generate(input1.begin(), input1.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::generate(input2.begin(), input2.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_operator_t op = nullptr;
+
+  // Call operator API.
+  ASSERT_EQ(xnn_status_success, xnn_create_divide_nd_f16(output_min, output_max, 0, &op));
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  ASSERT_EQ(
+    xnn_status_success, xnn_reshape_divide_nd_f16(
+                          op, input1_dims.size(), input1_dims.data(), input2_dims.size(), input2_dims.data(),
+                          /*threadpool=*/nullptr));
+
+  ASSERT_EQ(
+    xnn_status_success, xnn_setup_divide_nd_f16(op, input1.data(), input2.data(), operator_output.data()));
+
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(3, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  uint32_t input1_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input1_dims.size(), input1_dims.data(), nullptr,
+                          /*external_id=*/0, /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input1_id));
+  ASSERT_NE(input1_id, XNN_INVALID_NODE_ID);
+
+  uint32_t input2_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input2_dims.size(), input2_dims.data(), nullptr,
+                          /*external_id=*/1, /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input2_id));
+  ASSERT_NE(input2_id, XNN_INVALID_NODE_ID);
+
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_tensor_value(
+      subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr, /*external_id=*/2,
+      /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_divide(subgraph, output_min, output_max, input1_id, input2_id, output_id, /*flags=*/0));
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 3> external = {
+    xnn_external_value{input1_id, input1.data()}, xnn_external_value{input2_id, input2.data()},
+    xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  ASSERT_EQ(subgraph_output, operator_output);
 }
 
 TEST_F(Divide2TestF32, matches_operator_api)

--- a/test/elu.cc
+++ b/test/elu.cc
@@ -11,15 +11,18 @@
 #include <memory>
 #include <random>
 
+#include <fp16/fp16.h>
+#include <gtest/gtest.h>
+
 #include <xnnpack.h>
 #include <xnnpack/node-type.h>
 #include <xnnpack/operator.h>
 #include <xnnpack/subgraph.h>
 
 #include "subgraph-unary-tester.h"
-#include <gtest/gtest.h>
 
 using EluTestQS8 = UnaryTest<int8_t>;
+using EluTestF16 = UnaryTest<uint16_t>;
 using EluTestF32 = UnaryTest<float>;
 
 TEST_F(EluTestQS8, define)
@@ -56,6 +59,44 @@ TEST_F(EluTestQS8, define)
   const struct xnn_node* node = &subgraph->nodes[0];
   ASSERT_EQ(node->type, xnn_node_type_elu);
   ASSERT_EQ(node->compute_type, xnn_compute_type_qs8);
+  ASSERT_EQ(node->params.elu.alpha, alpha);
+  ASSERT_EQ(node->num_inputs, 1);
+  ASSERT_EQ(node->inputs[0], input_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(EluTestF16, define)
+{
+  const float alpha = std::uniform_real_distribution<float>(1.0e-4f, 1.0f)(rng);
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, 0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, 1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(xnn_status_success, xnn_define_elu(subgraph, alpha, input_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_elu);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
   ASSERT_EQ(node->params.elu.alpha, alpha);
   ASSERT_EQ(node->num_inputs, 1);
   ASSERT_EQ(node->inputs[0], input_id);
@@ -156,6 +197,62 @@ TEST_F(EluTestQS8, matches_operator_api)
   ASSERT_NE(nullptr, runtime);
   std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
 
+  std::array<xnn_external_value, 2> external = {
+    xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  ASSERT_EQ(subgraph_output, operator_output);
+}
+
+TEST_F(EluTestF16, matches_operator_api)
+{
+  const float alpha = std::uniform_real_distribution<float>(1.0e-4f, 1.0f)(rng);
+  std::uniform_real_distribution<float> f32dist(-255.0f, 255.0f);
+  std::generate(input.begin(), input.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  // Call operator API.
+  xnn_operator_t op = nullptr;
+  const xnn_status status = xnn_create_elu_nc_f16(alpha, /*flags=*/0, &op);
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  ASSERT_EQ(xnn_status_success, xnn_reshape_elu_nc_f16(op, batch_size, channels, channels, channels, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_setup_elu_nc_f16(op, input.data(), operator_output.data()));
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, /*external_id=*/0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, /*external_id=*/1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_define_elu(subgraph, alpha, input_id, output_id, /*flags=*/0));
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
   std::array<xnn_external_value, 2> external = {
     xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
   ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));

--- a/test/even-split2.cc
+++ b/test/even-split2.cc
@@ -14,12 +14,13 @@
 #include <random>
 #include <vector>
 
+#include <fp16/fp16.h>
+#include <gtest/gtest.h>
+
 #include <xnnpack.h>
 #include <xnnpack/node-type.h>
 #include <xnnpack/operator.h>
 #include <xnnpack/subgraph.h>
-
-#include <gtest/gtest.h>
 
 template <typename T> class EvenSplit2Test : public ::testing::Test {
 protected:
@@ -116,6 +117,7 @@ protected:
 
 using EvenSplit2TestQS8 = EvenSplit2Test<int8_t>;
 using EvenSplit2TestQU8 = EvenSplit2Test<uint8_t>;
+using EvenSplit2TestF16 = EvenSplit2Test<uint16_t>;
 using EvenSplit2TestF32 = EvenSplit2Test<float>;
 
 TEST_F(EvenSplit2TestQS8, define)
@@ -203,6 +205,49 @@ TEST_F(EvenSplit2TestQU8, define)
   const struct xnn_node* node = &subgraph->nodes[0];
   ASSERT_EQ(node->type, xnn_node_type_even_split2);
   ASSERT_EQ(node->compute_type, xnn_compute_type_qu8);
+  ASSERT_EQ(node->params.even_split.axis, axis);
+  ASSERT_EQ(node->num_inputs, 1);
+  ASSERT_EQ(node->inputs[0], input_id);
+  ASSERT_EQ(node->num_outputs, 2);
+  ASSERT_EQ(node->outputs[0], output1_id);
+  ASSERT_EQ(node->outputs[1], output2_id);
+  ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(EvenSplit2TestF16, define)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/3, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input_dims.size(), input_dims.data(), nullptr, 0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output1_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output1_dims.size(), output1_dims.data(), nullptr, 1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output1_id));
+  ASSERT_NE(output1_id, XNN_INVALID_NODE_ID);
+
+  output2_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output2_dims.size(), output2_dims.data(), nullptr, 2,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output2_id));
+  ASSERT_NE(output2_id, XNN_INVALID_NODE_ID);
+  ASSERT_EQ(xnn_status_success, xnn_define_even_split2(subgraph, axis, input_id, output1_id, output2_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_even_split2);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
   ASSERT_EQ(node->params.even_split.axis, axis);
   ASSERT_EQ(node->num_inputs, 1);
   ASSERT_EQ(node->inputs[0], input_id);
@@ -393,6 +438,82 @@ TEST_F(EvenSplit2TestQU8, matches_operator_api)
     xnn_define_quantized_tensor_value(
       subgraph, xnn_datatype_quint8, unsigned_zero_point, scale, output2_dims.size(), output2_dims.data(), nullptr, 2,
       /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output2_id));
+  ASSERT_NE(output2_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(xnn_status_success, xnn_define_even_split2(subgraph, axis, input_id, output1_id, output2_id, /*flags=*/0));
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 3> external = {
+    xnn_external_value{input_id, input.data()},
+    xnn_external_value{output1_id, subgraph_output1.data()},
+    xnn_external_value{output2_id, subgraph_output2.data()},
+  };
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  ASSERT_EQ(subgraph_output1, operator_output1);
+  ASSERT_EQ(subgraph_output2, operator_output2);
+}
+
+TEST_F(EvenSplit2TestF16, matches_operator_api)
+{
+  std::generate(input.begin(), input.end(), [&]() { return f32dist(rng); });
+  std::fill(operator_output1.begin(), operator_output1.end(), fp16_ieee_from_fp32_value(std::nanf("")));
+  std::fill(operator_output2.begin(), operator_output2.end(), fp16_ieee_from_fp32_value(std::nanf("")));
+  std::fill(subgraph_output1.begin(), subgraph_output1.end(), fp16_ieee_from_fp32_value(std::nanf("")));
+  std::fill(subgraph_output2.begin(), subgraph_output2.end(), fp16_ieee_from_fp32_value(std::nanf("")));
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_operator_t op1 = nullptr;
+  xnn_operator_t op2 = nullptr;
+
+  // Call operator API.
+  ASSERT_EQ(xnn_status_success, xnn_create_copy_nc_x16(/*flags=*/0, &op1));
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op1(op1, xnn_delete_operator);
+  ASSERT_EQ(xnn_status_success, xnn_create_copy_nc_x16(/*flags=*/0, &op2));
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op2(op2, xnn_delete_operator);
+
+  ASSERT_EQ(xnn_status_success, xnn_reshape_copy_nc_x16(op1, batch_size, channels, input_stride, channels, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_reshape_copy_nc_x16(op2, batch_size, channels, input_stride, channels, /*threadpool=*/nullptr));
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_setup_copy_nc_x16(op1, input.data(), operator_output1.data()));
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_setup_copy_nc_x16(op2, (uint16_t*) input.data() + op1->channels, operator_output2.data()));
+
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op1, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op2, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/3, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input_dims.size(), input_dims.data(), nullptr, 0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output1_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output1_dims.size(), output1_dims.data(), nullptr, 1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output1_id));
+  ASSERT_NE(output1_id, XNN_INVALID_NODE_ID);
+
+  output2_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output2_dims.size(), output2_dims.data(), nullptr, 2,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output2_id));
   ASSERT_NE(output2_id, XNN_INVALID_NODE_ID);
 
   ASSERT_EQ(xnn_status_success, xnn_define_even_split2(subgraph, axis, input_id, output1_id, output2_id, /*flags=*/0));

--- a/test/even-split4.cc
+++ b/test/even-split4.cc
@@ -14,12 +14,13 @@
 #include <random>
 #include <vector>
 
+#include <fp16/fp16.h>
+#include <gtest/gtest.h>
+
 #include <xnnpack.h>
 #include <xnnpack/node-type.h>
 #include <xnnpack/operator.h>
 #include <xnnpack/subgraph.h>
-
-#include <gtest/gtest.h>
 
 template <typename T> class EvenSplit4Test : public ::testing::Test {
 protected:
@@ -130,6 +131,7 @@ protected:
 
 using EvenSplit4TestQS8 = EvenSplit4Test<int8_t>;
 using EvenSplit4TestQU8 = EvenSplit4Test<uint8_t>;
+using EvenSplit4TestF16 = EvenSplit4Test<uint16_t>;
 using EvenSplit4TestF32 = EvenSplit4Test<float>;
 
 TEST_F(EvenSplit4TestQS8, define)
@@ -255,6 +257,68 @@ TEST_F(EvenSplit4TestQU8, define)
   const struct xnn_node* node = &subgraph->nodes[0];
   ASSERT_EQ(node->type, xnn_node_type_even_split4);
   ASSERT_EQ(node->compute_type, xnn_compute_type_qu8);
+  ASSERT_EQ(node->params.even_split.axis, axis);
+  ASSERT_EQ(node->num_inputs, 1);
+  ASSERT_EQ(node->inputs[0], input_id);
+  ASSERT_EQ(node->num_outputs, 4);
+  ASSERT_EQ(node->outputs[0], output1_id);
+  ASSERT_EQ(node->outputs[1], output2_id);
+  ASSERT_EQ(node->outputs[2], output3_id);
+  ASSERT_EQ(node->outputs[3], output4_id);
+  ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(EvenSplit4TestF16, define)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/5, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input_dims.size(), input_dims.data(), nullptr, 0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output1_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output1_dims.size(), output1_dims.data(), nullptr, 1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output1_id));
+  ASSERT_NE(output1_id, XNN_INVALID_NODE_ID);
+
+  output2_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output2_dims.size(), output2_dims.data(), nullptr, 2,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output2_id));
+  ASSERT_NE(output2_id, XNN_INVALID_NODE_ID);
+
+  output3_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output3_dims.size(), output3_dims.data(), nullptr, 3,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output3_id));
+  ASSERT_NE(output3_id, XNN_INVALID_NODE_ID);
+
+  output4_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output4_dims.size(), output4_dims.data(), nullptr, 4,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output4_id));
+  ASSERT_NE(output4_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_even_split4(subgraph, axis, input_id, output1_id, output2_id, output3_id, output4_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_even_split4);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
   ASSERT_EQ(node->params.even_split.axis, axis);
   ASSERT_EQ(node->num_inputs, 1);
   ASSERT_EQ(node->inputs[0], input_id);
@@ -544,6 +608,122 @@ TEST_F(EvenSplit4TestQU8, matches_operator_api)
     xnn_define_quantized_tensor_value(
       subgraph, xnn_datatype_quint8, unsigned_zero_point, scale, output4_dims.size(), output4_dims.data(), nullptr, 4,
       /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output4_id));
+  ASSERT_NE(output4_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_even_split4(subgraph, axis, input_id, output1_id, output2_id, output3_id, output4_id, /*flags=*/0));
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 5> external = {
+    xnn_external_value{input_id, input.data()},
+    xnn_external_value{output1_id, subgraph_output1.data()},
+    xnn_external_value{output2_id, subgraph_output2.data()},
+    xnn_external_value{output3_id, subgraph_output3.data()},
+    xnn_external_value{output4_id, subgraph_output4.data()},
+  };
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  ASSERT_EQ(subgraph_output1, operator_output1);
+  ASSERT_EQ(subgraph_output2, operator_output2);
+  ASSERT_EQ(subgraph_output3, operator_output3);
+  ASSERT_EQ(subgraph_output4, operator_output4);
+}
+
+TEST_F(EvenSplit4TestF16, matches_operator_api)
+{
+  std::generate(input.begin(), input.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::fill(operator_output1.begin(), operator_output1.end(), fp16_ieee_from_fp32_value(std::nanf("")));
+  std::fill(operator_output2.begin(), operator_output2.end(), fp16_ieee_from_fp32_value(std::nanf("")));
+  std::fill(operator_output3.begin(), operator_output3.end(), fp16_ieee_from_fp32_value(std::nanf("")));
+  std::fill(operator_output4.begin(), operator_output4.end(), fp16_ieee_from_fp32_value(std::nanf("")));
+  std::fill(subgraph_output1.begin(), subgraph_output1.end(), fp16_ieee_from_fp32_value(std::nanf("")));
+  std::fill(subgraph_output2.begin(), subgraph_output2.end(), fp16_ieee_from_fp32_value(std::nanf("")));
+  std::fill(subgraph_output3.begin(), subgraph_output3.end(), fp16_ieee_from_fp32_value(std::nanf("")));
+  std::fill(subgraph_output4.begin(), subgraph_output4.end(), fp16_ieee_from_fp32_value(std::nanf("")));
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_operator_t op1 = nullptr;
+  xnn_operator_t op2 = nullptr;
+  xnn_operator_t op3 = nullptr;
+  xnn_operator_t op4 = nullptr;
+
+  // Call operator API.
+  ASSERT_EQ(xnn_status_success, xnn_create_copy_nc_x16(/*flags=*/0, &op1));
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op1(op1, xnn_delete_operator);
+  ASSERT_EQ(xnn_status_success, xnn_create_copy_nc_x16(/*flags=*/0, &op2));
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op2(op2, xnn_delete_operator);
+  ASSERT_EQ(xnn_status_success, xnn_create_copy_nc_x16(/*flags=*/0, &op3));
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op3(op3, xnn_delete_operator);
+  ASSERT_EQ(xnn_status_success, xnn_create_copy_nc_x16(/*flags=*/0, &op4));
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op4(op4, xnn_delete_operator);
+
+  ASSERT_EQ(xnn_status_success, xnn_reshape_copy_nc_x16(op1, batch_size, channels, input_stride, channels, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_reshape_copy_nc_x16(op2, batch_size, channels, input_stride, channels, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_reshape_copy_nc_x16(op3, batch_size, channels, input_stride, channels, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_reshape_copy_nc_x16(op4, batch_size, channels, input_stride, channels, /*threadpool=*/nullptr));
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_setup_copy_nc_x16(op1, input.data(), operator_output1.data()));
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_setup_copy_nc_x16(op2, (uint16_t*) input.data() + op1->channels, operator_output2.data()));
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_setup_copy_nc_x16(op3, (uint16_t*) input.data() + op1->channels * 2, operator_output3.data()));
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_setup_copy_nc_x16(op4, (uint16_t*) input.data() + op1->channels * 3, operator_output4.data()));
+
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op1, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op2, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op3, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op4, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/5, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input_dims.size(), input_dims.data(), nullptr, 0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output1_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output1_dims.size(), output1_dims.data(), nullptr, 1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output1_id));
+  ASSERT_NE(output1_id, XNN_INVALID_NODE_ID);
+
+  output2_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output2_dims.size(), output2_dims.data(), nullptr, 2,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output2_id));
+  ASSERT_NE(output2_id, XNN_INVALID_NODE_ID);
+
+  output3_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output3_dims.size(), output3_dims.data(), nullptr, 3,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output3_id));
+  ASSERT_NE(output3_id, XNN_INVALID_NODE_ID);
+
+  output4_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output4_dims.size(), output4_dims.data(), nullptr, 4,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output4_id));
   ASSERT_NE(output4_id, XNN_INVALID_NODE_ID);
 
   ASSERT_EQ(

--- a/test/floor.cc
+++ b/test/floor.cc
@@ -11,15 +11,53 @@
 #include <memory>
 #include <random>
 
+#include <fp16/fp16.h>
+#include <gtest/gtest.h>
+
 #include <xnnpack.h>
 #include <xnnpack/node-type.h>
 #include <xnnpack/operator.h>
 #include <xnnpack/subgraph.h>
 
 #include "subgraph-unary-tester.h"
-#include <gtest/gtest.h>
 
+using FloorTestF16 = UnaryTest<uint16_t>;
 using FloorTestF32 = UnaryTest<float>;
+
+TEST_F(FloorTestF16, define)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, 0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, 1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(xnn_status_success, xnn_define_floor(subgraph, input_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_floor);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
+  ASSERT_EQ(node->num_inputs, 1);
+  ASSERT_EQ(node->inputs[0], input_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
 
 TEST_F(FloorTestF32, define)
 {
@@ -54,6 +92,61 @@ TEST_F(FloorTestF32, define)
   ASSERT_EQ(node->num_outputs, 1);
   ASSERT_EQ(node->outputs[0], output_id);
   ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(FloorTestF16, matches_operator_api)
+{
+  std::uniform_real_distribution<float> f32dist(0.0f, 5.00f);
+  std::generate(input.begin(), input.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  // Call operator API.
+  xnn_operator_t op = nullptr;
+  const xnn_status status = xnn_create_floor_nc_f16(/*flags=*/0, &op);
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  ASSERT_EQ(xnn_status_success, xnn_reshape_floor_nc_f16(op, batch_size, channels, channels, channels, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_setup_floor_nc_f16(op, input.data(), operator_output.data()));
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, /*external_id=*/0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, /*external_id=*/1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_define_floor(subgraph, input_id, output_id, /*flags=*/0));
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 2> external = {
+    xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  ASSERT_EQ(subgraph_output, operator_output);
 }
 
 TEST_F(FloorTestF32, matches_operator_api)

--- a/test/fully-connected.cc
+++ b/test/fully-connected.cc
@@ -134,6 +134,7 @@ class FullyConnectedTestF32QC8W : public FullyConnectedTestBase<float, int8_t, f
 using FullyConnectedTestQC8 = QuantizedFullyConnectedTestBase<int8_t>;
 using FullyConnectedTestQS8 = QuantizedFullyConnectedTestBase<int8_t>;
 using FullyConnectedTestQU8 = QuantizedFullyConnectedTestBase<uint8_t>;
+using FullyConnectedTestF16 = FullyConnectedTestBase<uint16_t, float, float>;
 using FullyConnectedTestF32 = FullyConnectedTestBase<float>;
 using DynamicFullyConnectedTestF32 = FullyConnectedTestBase<float>;
 
@@ -288,6 +289,60 @@ TEST_F(FullyConnectedTestQU8, define)
   const struct xnn_node* node = &subgraph->nodes[0];
   ASSERT_EQ(node->type, xnn_node_type_fully_connected);
   ASSERT_EQ(node->compute_type, xnn_compute_type_qu8);
+  ASSERT_EQ(node->activation.output_min, output_min);
+  ASSERT_EQ(node->activation.output_max, output_max);
+  ASSERT_EQ(node->num_inputs, 3);
+  ASSERT_EQ(node->inputs[0], input_id);
+  ASSERT_EQ(node->inputs[1], kernel_id);
+  ASSERT_EQ(node->inputs[2], bias_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(FullyConnectedTestF16, define)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(4, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  uint32_t input_id = XNN_INVALID_VALUE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input_dims.size(), input_dims.data(), nullptr,
+                          /*external_id=*/0, /*flags=*/0, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_VALUE_ID);
+
+  uint32_t kernel_id = XNN_INVALID_VALUE_ID;
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_tensor_value(
+      subgraph, xnn_datatype_fp32, kernel_dims.size(), kernel_dims.data(), kernel.data(), /*external_id=*/1,
+      /*flags=*/0, &kernel_id));
+
+  uint32_t bias_id = XNN_INVALID_VALUE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp32, bias_dims.size(), bias_dims.data(), bias.data(),
+                          /*external_id=*/2, /*flags=*/0, &bias_id));
+
+  uint32_t output_id = XNN_INVALID_VALUE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr,
+                          /*external_id=*/3, /*flags=*/0, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_VALUE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_fully_connected(subgraph, output_min, output_max, input_id, kernel_id, bias_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_fully_connected);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
   ASSERT_EQ(node->activation.output_min, output_min);
   ASSERT_EQ(node->activation.output_max, output_max);
   ASSERT_EQ(node->num_inputs, 3);
@@ -916,6 +971,82 @@ TEST_F(FullyConnectedTestQU8, matches_operator_api)
     xnn_status_success, xnn_define_quantized_tensor_value(
                           subgraph, xnn_datatype_quint8, output_zero_point, output_scale, output_dims.size(),
                           output_dims.data(), nullptr, /*external_id=*/3, XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_VALUE_ID);
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_fully_connected(subgraph, output_min, output_max, input_id, kernel_id, bias_id, output_id, /*flags=*/0));
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 2> external = {
+    xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  // Check outputs match.
+  EXPECT_THAT(subgraph_output, ElementsAreArray(operator_output));
+}
+
+TEST_F(FullyConnectedTestF16, matches_operator_api)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_operator_t op = nullptr;
+
+  std::generate(input.begin(), input.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::generate(kernel.begin(), kernel.end(), [&]() { return f32dist(rng); });
+  std::generate(bias.begin(), bias.end(), [&]() { return f32dist(rng); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+
+  // Call operator API.
+  const xnn_status status = xnn_create_fully_connected_nc_f16(
+    input_channels, output_channels, input_channels, output_channels, kernel.data(), bias.data(), output_min,
+    output_max, XNN_FLAG_FP32_STATIC_WEIGHTS, nullptr, nullptr, &op);
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+  ASSERT_EQ(xnn_status_success, xnn_reshape_fully_connected_nc_f16(op, batch_size, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_setup_fully_connected_nc_f16(op, input.data(), operator_output.data()));
+
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(4, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  uint32_t input_id = XNN_INVALID_VALUE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input_dims.size(), input_dims.data(), nullptr,
+                          /*external_id=*/0, XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_VALUE_ID);
+
+  uint32_t kernel_id = XNN_INVALID_VALUE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp32, kernel_dims.size(), kernel_dims.data(), kernel.data(),
+                          /*external_id=*/1, /*flags=*/0, &kernel_id));
+
+  uint32_t bias_id = XNN_INVALID_VALUE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp32, bias_dims.size(), bias_dims.data(), bias.data(),
+                          /*external_id=*/2, /*flags=*/0, &bias_id));
+
+  uint32_t output_id = XNN_INVALID_VALUE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr,
+                          /*external_id=*/3, XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
   ASSERT_NE(output_id, XNN_INVALID_VALUE_ID);
   ASSERT_EQ(
     xnn_status_success,

--- a/test/global-average-pooling-1d.cc
+++ b/test/global-average-pooling-1d.cc
@@ -414,8 +414,7 @@ TEST_F(GlobalAveragePooling1DTestF16, matches_operator_api)
 
   // Call operator API.
   const xnn_status status = xnn_create_global_average_pooling_nwc_f16(
-    channels, channels, channels, output_min, output_max,
-    /*flags=*/0, &op);
+    output_min, output_max, /*flags=*/0, &op);
   std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
 
   if (status == xnn_status_unsupported_hardware) {
@@ -428,7 +427,10 @@ TEST_F(GlobalAveragePooling1DTestF16, matches_operator_api)
   size_t workspace_alignment = 0;
   ASSERT_EQ(
     xnn_status_success, xnn_reshape_global_average_pooling_nwc_f16(
-                          op, batch_size, input_width, &workspace_size, &workspace_alignment, /*threadpool=*/nullptr));
+                          op, batch_size, input_width, channels,
+                          /*input_stride=*/channels,
+                          /*output_stride=*/channels,
+                          &workspace_size, &workspace_alignment, /*threadpool=*/nullptr));
   ASSERT_LE(workspace_alignment, XNN_ALLOCATION_ALIGNMENT);
 
   std::vector<char, AlignedAllocator<char, XNN_ALLOCATION_ALIGNMENT>> workspace(workspace_size);

--- a/test/global-average-pooling-1d.cc
+++ b/test/global-average-pooling-1d.cc
@@ -12,14 +12,15 @@
 #include <random>
 #include <vector>
 
+#include <fp16/fp16.h>
+#include <gtest/gtest.h>
+
 #include <xnnpack.h>
 #include <xnnpack/aligned-allocator.h>
 #include <xnnpack/node-type.h>
 #include <xnnpack/operator.h>
 #include <xnnpack/requantization.h>
 #include <xnnpack/subgraph.h>
-
-#include <gtest/gtest.h>
 
 template <typename T> class GlobalAveragePooling1DTest : public ::testing::Test {
 protected:
@@ -90,6 +91,7 @@ protected:
 
 using GlobalAveragePooling1DTestQS8 = GlobalAveragePooling1DTest<int8_t>;
 using GlobalAveragePooling1DTestQU8 = GlobalAveragePooling1DTest<uint8_t>;
+using GlobalAveragePooling1DTestF16 = GlobalAveragePooling1DTest<uint16_t>;
 using GlobalAveragePooling1DTestF32 = GlobalAveragePooling1DTest<float>;
 
 TEST_F(GlobalAveragePooling1DTestQS8, define)
@@ -161,6 +163,45 @@ TEST_F(GlobalAveragePooling1DTestQU8, define)
   const struct xnn_node* node = &subgraph->nodes[0];
   ASSERT_EQ(node->type, xnn_node_type_global_average_pooling_1d);
   ASSERT_EQ(node->compute_type, xnn_compute_type_qu8);
+  ASSERT_EQ(node->activation.output_min, output_min);
+  ASSERT_EQ(node->activation.output_max, output_max);
+  ASSERT_EQ(node->num_inputs, 1);
+  ASSERT_EQ(node->inputs[0], input_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(GlobalAveragePooling1DTestF16, define)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  uint32_t input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input_dims.size(), input_dims.data(), nullptr,
+                          /*external_id=*/0, /*flags=*/0, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr,
+                          /*external_id=*/1, /*flags=*/0, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_global_average_pooling_1d(subgraph, output_min, output_max, input_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_global_average_pooling_1d);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
   ASSERT_EQ(node->activation.output_min, output_min);
   ASSERT_EQ(node->activation.output_max, output_max);
   ASSERT_EQ(node->num_inputs, 1);
@@ -345,6 +386,76 @@ TEST_F(GlobalAveragePooling1DTestQU8, matches_operator_api)
       /*external_id=*/1, XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
   ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
 
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_global_average_pooling_1d(subgraph, output_min, output_max, input_id, output_id, /*flags=*/0));
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 2> external = {
+    xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  ASSERT_EQ(subgraph_output, operator_output);
+}
+
+TEST_F(GlobalAveragePooling1DTestF16, matches_operator_api)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_operator_t op = nullptr;
+
+  std::generate(input.begin(), input.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+
+  // Call operator API.
+  const xnn_status status = xnn_create_global_average_pooling_nwc_f16(
+    channels, channels, channels, output_min, output_max,
+    /*flags=*/0, &op);
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+  size_t workspace_size = 0;
+  size_t workspace_alignment = 0;
+  ASSERT_EQ(
+    xnn_status_success, xnn_reshape_global_average_pooling_nwc_f16(
+                          op, batch_size, input_width, &workspace_size, &workspace_alignment, /*threadpool=*/nullptr));
+  ASSERT_LE(workspace_alignment, XNN_ALLOCATION_ALIGNMENT);
+
+  std::vector<char, AlignedAllocator<char, XNN_ALLOCATION_ALIGNMENT>> workspace(workspace_size);
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_setup_global_average_pooling_nwc_f16(op, workspace.data(), input.data(), operator_output.data()));
+
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  uint32_t input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input_dims.size(), input_dims.data(), nullptr,
+                          /*external_id=*/0, XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr,
+                          /*external_id=*/1, XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
   ASSERT_EQ(
     xnn_status_success,
     xnn_define_global_average_pooling_1d(subgraph, output_min, output_max, input_id, output_id, /*flags=*/0));

--- a/test/global-average-pooling-2d.cc
+++ b/test/global-average-pooling-2d.cc
@@ -412,8 +412,7 @@ TEST_F(GlobalAveragePooling2DTestF16, matches_operator_api)
 
   // Call operator API.
   const xnn_status status = xnn_create_global_average_pooling_nwc_f16(
-    channels, channels, channels, output_min, output_max,
-    /*flags=*/0, &op);
+    output_min, output_max, /*flags=*/0, &op);
   std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
 
   if (status == xnn_status_unsupported_hardware) {
@@ -426,7 +425,10 @@ TEST_F(GlobalAveragePooling2DTestF16, matches_operator_api)
   size_t workspace_alignment = 0;
   ASSERT_EQ(
     xnn_status_success, xnn_reshape_global_average_pooling_nwc_f16(
-                          op, batch_size, input_width, &workspace_size, &workspace_alignment, /*threadpool=*/nullptr));
+                          op, batch_size, input_width, channels,
+                          /*input_stride=*/channels,
+                          /*output_stride=*/channels,
+                          &workspace_size, &workspace_alignment, /*threadpool=*/nullptr));
   ASSERT_LE(workspace_alignment, XNN_ALLOCATION_ALIGNMENT);
 
   std::vector<char, AlignedAllocator<char, XNN_ALLOCATION_ALIGNMENT>> workspace(workspace_size);

--- a/test/global-average-pooling-2d.cc
+++ b/test/global-average-pooling-2d.cc
@@ -12,14 +12,15 @@
 #include <random>
 #include <vector>
 
+#include <fp16/fp16.h>
+#include <gtest/gtest.h>
+
 #include <xnnpack.h>
 #include <xnnpack/aligned-allocator.h>
 #include <xnnpack/node-type.h>
 #include <xnnpack/operator.h>
 #include <xnnpack/requantization.h>
 #include <xnnpack/subgraph.h>
-
-#include <gtest/gtest.h>
 
 template <typename T> class GlobalAveragePooling2DTest : public ::testing::Test {
 protected:
@@ -88,6 +89,7 @@ protected:
 
 using GlobalAveragePooling2DTestQS8 = GlobalAveragePooling2DTest<int8_t>;
 using GlobalAveragePooling2DTestQU8 = GlobalAveragePooling2DTest<uint8_t>;
+using GlobalAveragePooling2DTestF16 = GlobalAveragePooling2DTest<uint16_t>;
 using GlobalAveragePooling2DTestF32 = GlobalAveragePooling2DTest<float>;
 
 TEST_F(GlobalAveragePooling2DTestQS8, define)
@@ -159,6 +161,45 @@ TEST_F(GlobalAveragePooling2DTestQU8, define)
   const struct xnn_node* node = &subgraph->nodes[0];
   ASSERT_EQ(node->type, xnn_node_type_global_average_pooling_2d);
   ASSERT_EQ(node->compute_type, xnn_compute_type_qu8);
+  ASSERT_EQ(node->activation.output_min, output_min);
+  ASSERT_EQ(node->activation.output_max, output_max);
+  ASSERT_EQ(node->num_inputs, 1);
+  ASSERT_EQ(node->inputs[0], input_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(GlobalAveragePooling2DTestF16, define)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  uint32_t input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input_dims.size(), input_dims.data(), nullptr,
+                          /*external_id=*/0, /*flags=*/0, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr,
+                          /*external_id=*/1, /*flags=*/0, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_global_average_pooling_2d(subgraph, output_min, output_max, input_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_global_average_pooling_2d);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
   ASSERT_EQ(node->activation.output_min, output_min);
   ASSERT_EQ(node->activation.output_max, output_max);
   ASSERT_EQ(node->num_inputs, 1);
@@ -343,6 +384,76 @@ TEST_F(GlobalAveragePooling2DTestQU8, matches_operator_api)
       /*external_id=*/1, XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
   ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
 
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_global_average_pooling_2d(subgraph, output_min, output_max, input_id, output_id, /*flags=*/0));
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 2> external = {
+    xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  ASSERT_EQ(subgraph_output, operator_output);
+}
+
+TEST_F(GlobalAveragePooling2DTestF16, matches_operator_api)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_operator_t op = nullptr;
+
+  std::generate(input.begin(), input.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+
+  // Call operator API.
+  const xnn_status status = xnn_create_global_average_pooling_nwc_f16(
+    channels, channels, channels, output_min, output_max,
+    /*flags=*/0, &op);
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+  size_t workspace_size = 0;
+  size_t workspace_alignment = 0;
+  ASSERT_EQ(
+    xnn_status_success, xnn_reshape_global_average_pooling_nwc_f16(
+                          op, batch_size, input_width, &workspace_size, &workspace_alignment, /*threadpool=*/nullptr));
+  ASSERT_LE(workspace_alignment, XNN_ALLOCATION_ALIGNMENT);
+
+  std::vector<char, AlignedAllocator<char, XNN_ALLOCATION_ALIGNMENT>> workspace(workspace_size);
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_setup_global_average_pooling_nwc_f16(op, workspace.data(), input.data(), operator_output.data()));
+
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  uint32_t input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input_dims.size(), input_dims.data(), nullptr,
+                          /*external_id=*/0, XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr,
+                          /*external_id=*/1, XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
   ASSERT_EQ(
     xnn_status_success,
     xnn_define_global_average_pooling_2d(subgraph, output_min, output_max, input_id, output_id, /*flags=*/0));

--- a/test/global-sum-pooling-1d.cc
+++ b/test/global-sum-pooling-1d.cc
@@ -173,8 +173,7 @@ TEST_F(GlobalSumPooling1DTestF16, matches_operator_api)
 
   // Call operator API.
   const xnn_status status = xnn_create_global_sum_pooling_nwc_f16(
-    channels, channels, channels, output_min, output_max,
-    /*flags=*/0, &op);
+    output_min, output_max, /*flags=*/0, &op);
   std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
 
   if (status == xnn_status_unsupported_hardware) {
@@ -187,7 +186,8 @@ TEST_F(GlobalSumPooling1DTestF16, matches_operator_api)
   size_t workspace_alignment = 0;
   ASSERT_EQ(
     xnn_status_success, xnn_reshape_global_sum_pooling_nwc_f16(
-                          op, batch_size, input_width, &workspace_size, &workspace_alignment, /*threadpool=*/nullptr));
+                          op, batch_size, input_width, channels, channels, channels,
+                          &workspace_size, &workspace_alignment, /*threadpool=*/nullptr));
   ASSERT_LE(workspace_alignment, XNN_ALLOCATION_ALIGNMENT);
 
   std::vector<char, AlignedAllocator<char, XNN_ALLOCATION_ALIGNMENT>> workspace(workspace_size);

--- a/test/global-sum-pooling-1d.cc
+++ b/test/global-sum-pooling-1d.cc
@@ -12,13 +12,14 @@
 #include <random>
 #include <vector>
 
+#include <fp16/fp16.h>
+#include <gtest/gtest.h>
+
 #include <xnnpack.h>
 #include <xnnpack/aligned-allocator.h>
 #include <xnnpack/node-type.h>
 #include <xnnpack/operator.h>
 #include <xnnpack/subgraph.h>
-
-#include <gtest/gtest.h>
 
 template <typename T> class GlobalSumPooling1DTest : public ::testing::Test {
 protected:
@@ -79,7 +80,47 @@ protected:
   std::vector<T> subgraph_output;
 };
 
+using GlobalSumPooling1DTestF16 = GlobalSumPooling1DTest<uint16_t>;
 using GlobalSumPooling1DTestF32 = GlobalSumPooling1DTest<float>;
+
+TEST_F(GlobalSumPooling1DTestF16, define)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  uint32_t input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input_dims.size(), input_dims.data(), nullptr,
+                          /*external_id=*/0, /*flags=*/0, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr,
+                          /*external_id=*/1, /*flags=*/0, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_global_sum_pooling_1d(subgraph, output_min, output_max, input_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_global_sum_pooling_1d);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
+  ASSERT_EQ(node->activation.output_min, output_min);
+  ASSERT_EQ(node->activation.output_max, output_max);
+  ASSERT_EQ(node->num_inputs, 1);
+  ASSERT_EQ(node->inputs[0], input_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
 
 TEST_F(GlobalSumPooling1DTestF32, define)
 {
@@ -118,6 +159,76 @@ TEST_F(GlobalSumPooling1DTestF32, define)
   ASSERT_EQ(node->num_outputs, 1);
   ASSERT_EQ(node->outputs[0], output_id);
   ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(GlobalSumPooling1DTestF16, matches_operator_api)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_operator_t op = nullptr;
+
+  std::generate(input.begin(), input.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+
+  // Call operator API.
+  const xnn_status status = xnn_create_global_sum_pooling_nwc_f16(
+    channels, channels, channels, output_min, output_max,
+    /*flags=*/0, &op);
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+  size_t workspace_size = 0;
+  size_t workspace_alignment = 0;
+  ASSERT_EQ(
+    xnn_status_success, xnn_reshape_global_sum_pooling_nwc_f16(
+                          op, batch_size, input_width, &workspace_size, &workspace_alignment, /*threadpool=*/nullptr));
+  ASSERT_LE(workspace_alignment, XNN_ALLOCATION_ALIGNMENT);
+
+  std::vector<char, AlignedAllocator<char, XNN_ALLOCATION_ALIGNMENT>> workspace(workspace_size);
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_setup_global_sum_pooling_nwc_f16(op, workspace.data(), input.data(), operator_output.data()));
+
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  uint32_t input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input_dims.size(), input_dims.data(), nullptr,
+                          /*external_id=*/0, XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr,
+                          /*external_id=*/1, XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_global_sum_pooling_1d(subgraph, output_min, output_max, input_id, output_id, /*flags=*/0));
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 2> external = {
+    xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  ASSERT_EQ(subgraph_output, operator_output);
 }
 
 TEST_F(GlobalSumPooling1DTestF32, matches_operator_api)

--- a/test/global-sum-pooling-2d.cc
+++ b/test/global-sum-pooling-2d.cc
@@ -170,8 +170,7 @@ TEST_F(GlobalSumPooling2DTestF16, matches_operator_api)
 
   // Call operator API.
   const xnn_status status = xnn_create_global_sum_pooling_nwc_f16(
-    channels, channels, channels, output_min, output_max,
-    /*flags=*/0, &op);
+    output_min, output_max, /*flags=*/0, &op);
   std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
 
   if (status == xnn_status_unsupported_hardware) {
@@ -184,7 +183,9 @@ TEST_F(GlobalSumPooling2DTestF16, matches_operator_api)
   size_t workspace_alignment = 0;
   ASSERT_EQ(
     xnn_status_success, xnn_reshape_global_sum_pooling_nwc_f16(
-                          op, batch_size, input_width, &workspace_size, &workspace_alignment, /*threadpool=*/nullptr));
+                          op, batch_size, input_width, channels,
+                          /*input_stride=*/channels, /*output_stride=*/ channels,
+                          &workspace_size, &workspace_alignment, /*threadpool=*/nullptr));
   ASSERT_LE(workspace_alignment, XNN_ALLOCATION_ALIGNMENT);
 
   std::vector<char, AlignedAllocator<char, XNN_ALLOCATION_ALIGNMENT>> workspace(workspace_size);

--- a/test/global-sum-pooling-2d.cc
+++ b/test/global-sum-pooling-2d.cc
@@ -12,13 +12,14 @@
 #include <random>
 #include <vector>
 
+#include <fp16/fp16.h>
+#include <gtest/gtest.h>
+
 #include <xnnpack.h>
 #include <xnnpack/aligned-allocator.h>
 #include <xnnpack/node-type.h>
 #include <xnnpack/operator.h>
 #include <xnnpack/subgraph.h>
-
-#include <gtest/gtest.h>
 
 template <typename T> class GlobalSumPooling2DTest : public ::testing::Test {
 protected:
@@ -76,7 +77,47 @@ protected:
   std::vector<T> subgraph_output;
 };
 
+using GlobalSumPooling2DTestF16 = GlobalSumPooling2DTest<uint16_t>;
 using GlobalSumPooling2DTestF32 = GlobalSumPooling2DTest<float>;
+
+TEST_F(GlobalSumPooling2DTestF16, define)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  uint32_t input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input_dims.size(), input_dims.data(), nullptr,
+                          /*external_id=*/0, /*flags=*/0, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr,
+                          /*external_id=*/1, /*flags=*/0, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_global_sum_pooling_2d(subgraph, output_min, output_max, input_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_global_sum_pooling_2d);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
+  ASSERT_EQ(node->activation.output_min, output_min);
+  ASSERT_EQ(node->activation.output_max, output_max);
+  ASSERT_EQ(node->num_inputs, 1);
+  ASSERT_EQ(node->inputs[0], input_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
 
 TEST_F(GlobalSumPooling2DTestF32, define)
 {
@@ -115,6 +156,76 @@ TEST_F(GlobalSumPooling2DTestF32, define)
   ASSERT_EQ(node->num_outputs, 1);
   ASSERT_EQ(node->outputs[0], output_id);
   ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(GlobalSumPooling2DTestF16, matches_operator_api)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_operator_t op = nullptr;
+
+  std::generate(input.begin(), input.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+
+  // Call operator API.
+  const xnn_status status = xnn_create_global_sum_pooling_nwc_f16(
+    channels, channels, channels, output_min, output_max,
+    /*flags=*/0, &op);
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+  size_t workspace_size = 0;
+  size_t workspace_alignment = 0;
+  ASSERT_EQ(
+    xnn_status_success, xnn_reshape_global_sum_pooling_nwc_f16(
+                          op, batch_size, input_width, &workspace_size, &workspace_alignment, /*threadpool=*/nullptr));
+  ASSERT_LE(workspace_alignment, XNN_ALLOCATION_ALIGNMENT);
+
+  std::vector<char, AlignedAllocator<char, XNN_ALLOCATION_ALIGNMENT>> workspace(workspace_size);
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_setup_global_sum_pooling_nwc_f16(op, workspace.data(), input.data(), operator_output.data()));
+
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  uint32_t input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input_dims.size(), input_dims.data(), nullptr,
+                          /*external_id=*/0, XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr,
+                          /*external_id=*/1, XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_global_sum_pooling_2d(subgraph, output_min, output_max, input_id, output_id, /*flags=*/0));
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 2> external = {
+    xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  ASSERT_EQ(subgraph_output, operator_output);
 }
 
 TEST_F(GlobalSumPooling2DTestF32, matches_operator_api)

--- a/test/hardswish.cc
+++ b/test/hardswish.cc
@@ -12,6 +12,7 @@
 #include <random>      // For std::random_device, std::mt19937, std::uniform_real_distribution.
 #include <vector>      // For std::vector.
 
+#include <fp16/fp16.h>
 #include <gtest/gtest.h>
 
 #include <xnnpack.h>
@@ -21,7 +22,43 @@
 
 #include "subgraph-unary-tester.h"
 
+using HardSwishTestF16 = UnaryTest<uint16_t>;
 using HardSwishTestF32 = UnaryTest<float>;
+
+TEST_F(HardSwishTestF16, define)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(0, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+  const std::array<size_t, 3> dims = {{1, 3, 5}};
+  uint32_t input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_tensor_value(
+      subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, XNN_INVALID_VALUE_ID, /*flags=*/0, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_tensor_value(
+      subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, XNN_INVALID_VALUE_ID, /*flags=*/0, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(xnn_status_success, xnn_define_hardswish(subgraph, input_id, output_id, 0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_hardswish);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
+  ASSERT_EQ(node->num_inputs, 1);
+  ASSERT_EQ(node->inputs[0], input_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
 
 TEST_F(HardSwishTestF32, define)
 {
@@ -56,6 +93,64 @@ TEST_F(HardSwishTestF32, define)
   ASSERT_EQ(node->num_outputs, 1);
   ASSERT_EQ(node->outputs[0], output_id);
   ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(HardSwishTestF16, matches_operator_api)
+{
+  std::vector<uint16_t> input(num_output_elements + XNN_EXTRA_BYTES / sizeof(uint16_t), std::nanf(""));
+  std::uniform_real_distribution<float> f32dist(-4.0f, 4.0f);
+  std::generate(input.begin(), input.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::vector<uint16_t> subgraph_output(num_output_elements, fp16_ieee_from_fp32_value(std::nanf("")));
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  // Call operator API.
+  xnn_operator_t op = nullptr;
+  xnn_status status = xnn_create_hardswish_nc_f16(/*flags=*/0, &op);
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+  std::vector<uint16_t> operator_output(num_output_elements, std::nanf(""));
+  ASSERT_EQ(xnn_status_success, xnn_reshape_hardswish_nc_f16(op, batch_size, channels, channels, channels, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_setup_hardswish_nc_f16(op, input.data(), operator_output.data()));
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  ASSERT_NE(nullptr, subgraph);
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+  uint32_t input_id =  XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, /*external_id=*/0,
+                          XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, /*external_id=*/1,
+                          XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+  ASSERT_EQ(xnn_status_success, xnn_define_hardswish(subgraph, input_id, output_id, /*flags=*/0));
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 2> external = {
+    xnn_external_value{input_id, input.data()},
+    xnn_external_value{output_id, subgraph_output.data()}
+  };
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  // Check outputs match.
+  for (size_t i = 0; i < num_output_elements; i++) {
+    ASSERT_EQ(subgraph_output[i], operator_output[i]);
+  }
 }
 
 TEST_F(HardSwishTestF32, matches_operator_api)

--- a/test/leaky-relu.cc
+++ b/test/leaky-relu.cc
@@ -11,17 +11,58 @@
 #include <memory>
 #include <random>
 
+#include <fp16/fp16.h>
+#include <gtest/gtest.h>
+
 #include <xnnpack.h>
 #include <xnnpack/node-type.h>
 #include <xnnpack/operator.h>
 #include <xnnpack/subgraph.h>
 
 #include "subgraph-unary-tester.h"
-#include <gtest/gtest.h>
 
+using LeakyReLUTestF16 = UnaryTest<uint16_t>;
 using LeakyReLUTestF32 = UnaryTest<float>;
 using LeakyReLUTestQS8 = UnaryTest<int8_t>;
 using LeakyReLUTestQU8 = UnaryTest<uint8_t>;
+
+TEST_F(LeakyReLUTestF16, define)
+{
+  const float negative_slope = std::uniform_real_distribution<float>(0.5f, 1.2f)(rng);
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, 0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, 1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(xnn_status_success, xnn_define_leaky_relu(subgraph, negative_slope, input_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_leaky_relu);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
+  ASSERT_EQ(node->params.leaky_relu.negative_slope, negative_slope);
+  ASSERT_EQ(node->num_inputs, 1);
+  ASSERT_EQ(node->inputs[0], input_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
 
 TEST_F(LeakyReLUTestF32, define)
 {
@@ -144,6 +185,62 @@ TEST_F(LeakyReLUTestQU8, define)
   ASSERT_EQ(node->num_outputs, 1);
   ASSERT_EQ(node->outputs[0], output_id);
   ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(LeakyReLUTestF16, matches_operator_api)
+{
+  const float negative_slope = std::uniform_real_distribution<float>(0.1f, 10.0f)(rng);
+  std::uniform_real_distribution<float> f32dist(-255.0f, 255.0f);
+  std::generate(input.begin(), input.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  // Call operator API.
+  xnn_operator_t op = nullptr;
+  const xnn_status status = xnn_create_leaky_relu_nc_f16(negative_slope, /*flags=*/0, &op);
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  ASSERT_EQ(xnn_status_success, xnn_reshape_leaky_relu_nc_f16(op, batch_size, channels, channels, channels, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_setup_leaky_relu_nc_f16(op, input.data(), operator_output.data()));
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, /*external_id=*/0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, /*external_id=*/1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_define_leaky_relu(subgraph, negative_slope, input_id, output_id, /*flags=*/0));
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 2> external = {
+    xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  ASSERT_EQ(subgraph_output, operator_output);
 }
 
 TEST_F(LeakyReLUTestF32, matches_operator_api)

--- a/test/max-pooling-2d.cc
+++ b/test/max-pooling-2d.cc
@@ -13,13 +13,14 @@
 #include <random>     // For std::random_device, std::mt19937, std::uniform_real_distribution.
 #include <vector>     // For std::vector.
 
+#include <fp16/fp16.h>
+#include <gtest/gtest.h>
+
 #include <xnnpack.h>
 #include <xnnpack/operator.h>
 #include <xnnpack/operator-utils.h>
 #include <xnnpack/requantization.h>
 #include <xnnpack/subgraph.h>
-
-#include <gtest/gtest.h>
 
 template <class T> class MaxPooling2DTestBase : public ::testing::Test {
 protected:
@@ -110,6 +111,7 @@ protected:
 
 using MaxPooling2DTestQS8 = MaxPooling2DTestBase<int8_t>;
 using MaxPooling2DTestQU8 = MaxPooling2DTestBase<uint8_t>;
+using MaxPooling2DTestF16 = MaxPooling2DTestBase<uint16_t>;
 using MaxPooling2DTestF32 = MaxPooling2DTestBase<float>;
 
 TEST_F(MaxPooling2DTestQS8, define)
@@ -196,6 +198,57 @@ TEST_F(MaxPooling2DTestQU8, define)
   const struct xnn_node* node = &subgraph->nodes[0];
   ASSERT_EQ(node->type, xnn_node_type_max_pooling_2d);
   ASSERT_EQ(node->compute_type, xnn_compute_type_qu8);
+  ASSERT_EQ(node->params.pooling_2d.padding_top, padding_top);
+  ASSERT_EQ(node->params.pooling_2d.padding_right, padding_right);
+  ASSERT_EQ(node->params.pooling_2d.padding_bottom, padding_bottom);
+  ASSERT_EQ(node->params.pooling_2d.padding_left, padding_left);
+  ASSERT_EQ(node->params.pooling_2d.pooling_height, pooling_height);
+  ASSERT_EQ(node->params.pooling_2d.pooling_width, pooling_width);
+  ASSERT_EQ(node->params.pooling_2d.stride_height, stride_height);
+  ASSERT_EQ(node->params.pooling_2d.stride_width, stride_width);
+  ASSERT_EQ(node->params.pooling_2d.dilation_height, dilation_height);
+  ASSERT_EQ(node->params.pooling_2d.dilation_width, dilation_width);
+  ASSERT_EQ(node->activation.output_min, output_min);
+  ASSERT_EQ(node->activation.output_max, output_max);
+  ASSERT_EQ(node->num_inputs, 1);
+  ASSERT_EQ(node->inputs[0], input_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(MaxPooling2DTestF16, define)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  uint32_t input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input_dims.size(), input_dims.data(), nullptr,
+                          /*external_id=*/0, /*flags=*/0, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr,
+                          /*external_id=*/1, /*flags=*/0, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_max_pooling_2d(
+      subgraph, padding_top, padding_right, padding_bottom, padding_left, pooling_height, pooling_width, stride_height,
+      stride_width, dilation_height, dilation_width, output_min, output_max, input_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_max_pooling_2d);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
   ASSERT_EQ(node->params.pooling_2d.padding_top, padding_top);
   ASSERT_EQ(node->params.pooling_2d.padding_right, padding_right);
   ASSERT_EQ(node->params.pooling_2d.padding_bottom, padding_bottom);
@@ -391,6 +444,74 @@ TEST_F(MaxPooling2DTestQU8, matches_operator_api)
     xnn_status_success, xnn_define_quantized_tensor_value(
                           subgraph, xnn_datatype_quint8, output_zero_point, output_scale, output_dims.size(),
                           output_dims.data(), nullptr, /*external_id=*/1, XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_max_pooling_2d(
+      subgraph, padding_top, padding_right, padding_bottom, padding_left, pooling_height, pooling_width, stride_height,
+      stride_width, dilation_height, dilation_width, output_min, output_max, input_id, output_id, /*flags=*/0));
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 2> external = {
+    xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  for (size_t i = 0; i < batch_size * output_height * output_width * channels; i++) {
+    ASSERT_EQ(subgraph_output[i], operator_output[i]);
+  }
+}
+
+TEST_F(MaxPooling2DTestF16, matches_operator_api)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+  std::generate(input.begin(), input.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+
+  // Call operator API.
+  xnn_operator_t op = nullptr;
+  const xnn_status status = xnn_create_max_pooling2d_nhwc_f16(
+    padding_top, padding_right, padding_bottom, padding_left, pooling_height, pooling_width, stride_height,
+    stride_width, dilation_height, dilation_width, channels, channels, channels, output_min, output_max, /*flags=*/0,
+    &op);
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+  ASSERT_EQ(
+    xnn_status_success, xnn_reshape_max_pooling2d_nhwc_f16(
+                          op, batch_size, input_height, input_width,
+                          /*output_height_out=*/nullptr, /*output_width_out=*/nullptr,
+                          /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_setup_max_pooling2d_nhwc_f16(op, input.data(), operator_output.data()));
+
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  uint32_t input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input_dims.size(), input_dims.data(), nullptr,
+                          /*external_id=*/0, XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr,
+                          /*external_id=*/1, XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
   ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
   ASSERT_EQ(
     xnn_status_success,

--- a/test/maximum2.cc
+++ b/test/maximum2.cc
@@ -10,15 +10,62 @@
 #include <memory>
 #include <vector>
 
+#include <fp16/fp16.h>
+#include <gtest/gtest.h>
+
 #include <xnnpack.h>
 #include <xnnpack/node-type.h>
 #include <xnnpack/operator.h>
 #include <xnnpack/subgraph.h>
 
 #include "subgraph-binary-tester.h"
-#include <gtest/gtest.h>
 
+using Maximum2TestF16 = BinaryTest<uint16_t>;
 using Maximum2TestF32 = BinaryTest<float>;
+
+TEST_F(Maximum2TestF16, define) {
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(3, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  uint32_t input1_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input1_dims.size(), input1_dims.data(), nullptr,
+                          /*external_id=*/0, /*flags=*/0, &input1_id));
+  ASSERT_NE(input1_id, XNN_INVALID_NODE_ID);
+
+  uint32_t input2_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input2_dims.size(), input2_dims.data(), nullptr,
+                          /*external_id=*/0, /*flags=*/0, &input2_id));
+  ASSERT_NE(input2_id, XNN_INVALID_NODE_ID);
+
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_tensor_value(
+      subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr, XNN_INVALID_VALUE_ID, /*flags=*/0, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_maximum2(subgraph, input1_id, input2_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_maximum2);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
+  ASSERT_EQ(node->num_inputs, 2);
+  ASSERT_EQ(node->inputs[0], input1_id);
+  ASSERT_EQ(node->inputs[1], input2_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
 
 TEST_F(Maximum2TestF32, define) {
   ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
@@ -62,6 +109,71 @@ TEST_F(Maximum2TestF32, define) {
   ASSERT_EQ(node->num_outputs, 1);
   ASSERT_EQ(node->outputs[0], output_id);
   ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(Maximum2TestF16, matches_operator_api)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_operator_t op = nullptr;
+
+  // Call operator API.
+  ASSERT_EQ(xnn_status_success, xnn_create_maximum_nd_f16(0, &op));
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  ASSERT_EQ(
+    xnn_status_success, xnn_reshape_maximum_nd_f16(
+                          op, input1_dims.size(), input1_dims.data(), input2_dims.size(), input2_dims.data(),
+                          /*threadpool=*/nullptr));
+
+  ASSERT_EQ(
+    xnn_status_success, xnn_setup_maximum_nd_f16(
+                          op, input1.data(), input2.data(), operator_output.data()));
+
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(3, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  uint32_t input1_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input1_dims.size(), input1_dims.data(), nullptr,
+                          /*external_id=*/0, /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input1_id));
+  ASSERT_NE(input1_id, XNN_INVALID_NODE_ID);
+
+  uint32_t input2_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input2_dims.size(), input2_dims.data(), nullptr,
+                          /*external_id=*/1, /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input2_id));
+  ASSERT_NE(input2_id, XNN_INVALID_NODE_ID);
+
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_tensor_value(
+      subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr, /*external_id=*/2,
+      /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_maximum2(subgraph, input1_id, input2_id, output_id, /*flags=*/0));
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 3> external = {
+    xnn_external_value{input1_id, input1.data()}, xnn_external_value{input2_id, input2.data()},
+    xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  ASSERT_EQ(subgraph_output, operator_output);
 }
 
 TEST_F(Maximum2TestF32, matches_operator_api)

--- a/test/minimum2.cc
+++ b/test/minimum2.cc
@@ -10,15 +10,62 @@
 #include <memory>
 #include <vector>
 
+#include <fp16/fp16.h>
+#include <gtest/gtest.h>
+
 #include <xnnpack.h>
 #include <xnnpack/node-type.h>
 #include <xnnpack/operator.h>
 #include <xnnpack/subgraph.h>
 
 #include "subgraph-binary-tester.h"
-#include <gtest/gtest.h>
 
+using Minimum2TestF16 = BinaryTest<uint16_t>;
 using Minimum2TestF32 = BinaryTest<float>;
+
+TEST_F(Minimum2TestF16, define) {
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(3, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  uint32_t input1_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input1_dims.size(), input1_dims.data(), nullptr,
+                          /*external_id=*/0, /*flags=*/0, &input1_id));
+  ASSERT_NE(input1_id, XNN_INVALID_NODE_ID);
+
+  uint32_t input2_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input2_dims.size(), input2_dims.data(), nullptr,
+                          /*external_id=*/0, /*flags=*/0, &input2_id));
+  ASSERT_NE(input2_id, XNN_INVALID_NODE_ID);
+
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_tensor_value(
+      subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr, XNN_INVALID_VALUE_ID, /*flags=*/0, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_minimum2(subgraph, input1_id, input2_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_minimum2);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
+  ASSERT_EQ(node->num_inputs, 2);
+  ASSERT_EQ(node->inputs[0], input1_id);
+  ASSERT_EQ(node->inputs[1], input2_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
 
 TEST_F(Minimum2TestF32, define) {
   ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
@@ -62,6 +109,70 @@ TEST_F(Minimum2TestF32, define) {
   ASSERT_EQ(node->num_outputs, 1);
   ASSERT_EQ(node->outputs[0], output_id);
   ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(Minimum2TestF16, matches_operator_api)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_operator_t op = nullptr;
+
+  // Call operator API.
+  ASSERT_EQ(xnn_status_success, xnn_create_minimum_nd_f16(0, &op));
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  ASSERT_EQ(
+    xnn_status_success, xnn_reshape_minimum_nd_f16(
+                          op, input1_dims.size(), input1_dims.data(), input2_dims.size(), input2_dims.data(),
+                          /*threadpool=*/nullptr));
+
+  ASSERT_EQ(
+    xnn_status_success, xnn_setup_minimum_nd_f16(op, input1.data(), input2.data(), operator_output.data()));
+
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(3, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  uint32_t input1_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input1_dims.size(), input1_dims.data(), nullptr,
+                          /*external_id=*/0, /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input1_id));
+  ASSERT_NE(input1_id, XNN_INVALID_NODE_ID);
+
+  uint32_t input2_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input2_dims.size(), input2_dims.data(), nullptr,
+                          /*external_id=*/1, /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input2_id));
+  ASSERT_NE(input2_id, XNN_INVALID_NODE_ID);
+
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_tensor_value(
+      subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr, /*external_id=*/2,
+      /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_minimum2(subgraph, input1_id, input2_id, output_id, /*flags=*/0));
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 3> external = {
+    xnn_external_value{input1_id, input1.data()}, xnn_external_value{input2_id, input2.data()},
+    xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  ASSERT_EQ(subgraph_output, operator_output);
 }
 
 TEST_F(Minimum2TestF32, matches_operator_api)

--- a/test/multiply2.cc
+++ b/test/multiply2.cc
@@ -10,16 +10,19 @@
 #include <memory>
 #include <vector>
 
+#include <fp16/fp16.h>
+#include <gtest/gtest.h>
+
 #include <xnnpack.h>
 #include <xnnpack/node-type.h>
 #include <xnnpack/operator.h>
 #include <xnnpack/subgraph.h>
 
 #include "subgraph-binary-tester.h"
-#include <gtest/gtest.h>
 
 using Multiply2TestQS8 = BinaryTest<int8_t>;
 using Multiply2TestQU8 = BinaryTest<uint8_t>;
+using Multiply2TestF16 = BinaryTest<uint16_t>;
 using Multiply2TestF32 = BinaryTest<float>;
 
 TEST_F(Multiply2TestQS8, define)
@@ -120,6 +123,53 @@ TEST_F(Multiply2TestQU8, define)
   const struct xnn_node* node = &subgraph->nodes[0];
   ASSERT_EQ(node->type, xnn_node_type_multiply2);
   ASSERT_EQ(node->compute_type, xnn_compute_type_qu8);
+  ASSERT_EQ(node->activation.output_min, output_min);
+  ASSERT_EQ(node->activation.output_max, output_max);
+  ASSERT_EQ(node->num_inputs, 2);
+  ASSERT_EQ(node->inputs[0], input1_id);
+  ASSERT_EQ(node->inputs[1], input2_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(Multiply2TestF16, define)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(3, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  uint32_t input1_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input1_dims.size(), input1_dims.data(), nullptr,
+                          /*external_id=*/0, /*flags=*/0, &input1_id));
+  ASSERT_NE(input1_id, XNN_INVALID_NODE_ID);
+
+  uint32_t input2_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input2_dims.size(), input2_dims.data(), nullptr,
+                          /*external_id=*/0, /*flags=*/0, &input2_id));
+  ASSERT_NE(input2_id, XNN_INVALID_NODE_ID);
+
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_tensor_value(
+      subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr, XNN_INVALID_VALUE_ID, /*flags=*/0, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_multiply2(subgraph, output_min, output_max, input1_id, input2_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_multiply2);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
   ASSERT_EQ(node->activation.output_min, output_min);
   ASSERT_EQ(node->activation.output_max, output_max);
   ASSERT_EQ(node->num_inputs, 2);
@@ -324,6 +374,75 @@ TEST_F(Multiply2TestQU8, matches_operator_api)
                           subgraph, xnn_datatype_quint8, output_zero_point, output_scale, output_dims.size(),
                           output_dims.data(), nullptr, /*external_id=*/2,
                           /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_multiply2(subgraph, output_min, output_max, input1_id, input2_id, output_id, /*flags=*/0));
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 3> external = {
+    xnn_external_value{input1_id, input1.data()}, xnn_external_value{input2_id, input2.data()},
+    xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  ASSERT_EQ(subgraph_output, operator_output);
+}
+
+TEST_F(Multiply2TestF16, matches_operator_api)
+{
+  std::generate(input1.begin(), input1.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::generate(input2.begin(), input2.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_operator_t op = nullptr;
+
+  // Call operator API.
+  ASSERT_EQ(xnn_status_success, xnn_create_multiply_nd_f16(output_min, output_max, 0, &op));
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  ASSERT_EQ(
+    xnn_status_success, xnn_reshape_multiply_nd_f16(
+                          op, input1_dims.size(), input1_dims.data(), input2_dims.size(), input2_dims.data(),
+                          /*threadpool=*/nullptr));
+
+  ASSERT_EQ(
+    xnn_status_success, xnn_setup_multiply_nd_f16(op, input1.data(), input2.data(), operator_output.data()));
+
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(3, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  uint32_t input1_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input1_dims.size(), input1_dims.data(), nullptr,
+                          /*external_id=*/0, /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input1_id));
+  ASSERT_NE(input1_id, XNN_INVALID_NODE_ID);
+
+  uint32_t input2_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input2_dims.size(), input2_dims.data(), nullptr,
+                          /*external_id=*/1, /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input2_id));
+  ASSERT_NE(input2_id, XNN_INVALID_NODE_ID);
+
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_tensor_value(
+      subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr, /*external_id=*/2,
+      /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
   ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
 
   ASSERT_EQ(

--- a/test/negate.cc
+++ b/test/negate.cc
@@ -11,15 +11,53 @@
 #include <memory>
 #include <random>
 
+#include <fp16/fp16.h>
+#include <gtest/gtest.h>
+
 #include <xnnpack.h>
 #include <xnnpack/node-type.h>
 #include <xnnpack/operator.h>
 #include <xnnpack/subgraph.h>
 
 #include "subgraph-unary-tester.h"
-#include <gtest/gtest.h>
 
+using NegateTestF16 = UnaryTest<uint16_t>;
 using NegateTestF32 = UnaryTest<float>;
+
+TEST_F(NegateTestF16, define)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, 0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, 1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(xnn_status_success, xnn_define_negate(subgraph, input_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_negate);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
+  ASSERT_EQ(node->num_inputs, 1);
+  ASSERT_EQ(node->inputs[0], input_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
 
 TEST_F(NegateTestF32, define)
 {
@@ -54,6 +92,61 @@ TEST_F(NegateTestF32, define)
   ASSERT_EQ(node->num_outputs, 1);
   ASSERT_EQ(node->outputs[0], output_id);
   ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(NegateTestF16, matches_operator_api)
+{
+  std::uniform_real_distribution<float> f32dist(-1.0f, 1.0f);
+  std::generate(input.begin(), input.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  // Call operator API.
+  xnn_operator_t op = nullptr;
+  const xnn_status status = xnn_create_negate_nc_f16(/*flags=*/0, &op);
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  ASSERT_EQ(xnn_status_success, xnn_reshape_negate_nc_f16(op, batch_size, channels, channels, channels, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_setup_negate_nc_f16(op, input.data(), operator_output.data()));
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, /*external_id=*/0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, /*external_id=*/1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_define_negate(subgraph, input_id, output_id, /*flags=*/0));
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 2> external = {
+    xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  ASSERT_EQ(subgraph_output, operator_output);
 }
 
 TEST_F(NegateTestF32, matches_operator_api)

--- a/test/prelu.cc
+++ b/test/prelu.cc
@@ -13,6 +13,7 @@
 #include <random>
 #include <vector>
 
+#include <fp16/fp16.h>
 #include <gtest/gtest.h>
 
 #include <xnnpack.h>
@@ -20,7 +21,11 @@
 #include <xnnpack/operator.h>
 #include <xnnpack/subgraph.h>
 
-class PreluTestF32 : public ::testing::Test {
+template <
+  typename InputType,
+  typename WeightType = InputType,
+  typename OutputType = InputType>
+class PreluTest : public ::testing::Test {
 protected:
   void SetUp() override
   {
@@ -32,10 +37,10 @@ protected:
     batch_size = input_dims[0] * input_dims[1] * input_dims[2];
     channels = input_dims[3];
     slope_dims = {channels};
-    input = std::vector<float>(XNN_EXTRA_BYTES / sizeof(float) + NumElements(input_dims));
-    slope = std::vector<float>(channels);
-    operator_output = std::vector<float>(NumElements(output_dims));
-    subgraph_output = std::vector<float>(operator_output.size());
+    input = std::vector<InputType>(XNN_EXTRA_BYTES / sizeof(InputType) + NumElements(input_dims));
+    slope = std::vector<WeightType>(channels);
+    operator_output = std::vector<OutputType>(NumElements(output_dims));
+    subgraph_output = std::vector<OutputType>(operator_output.size());
   }
 
   std::vector<size_t> RandomShape(size_t num_dims)
@@ -57,13 +62,59 @@ protected:
   std::vector<size_t> output_dims;
   std::vector<size_t> input_dims;
   std::vector<size_t> slope_dims;
-  std::vector<float> input;
-  std::vector<float> slope;
-  std::vector<float> operator_output;
-  std::vector<float> subgraph_output;
+  std::vector<InputType> input;
+  std::vector<WeightType> slope;
+  std::vector<OutputType> operator_output;
+  std::vector<OutputType> subgraph_output;
   size_t channels;
   size_t batch_size;
 };
+
+using PreluTestF16 = PreluTest<uint16_t, float>;
+using PreluTestF32 = PreluTest<float>;
+
+TEST_F(PreluTestF16, define)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/3, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  uint32_t input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input_dims.size(), input_dims.data(), nullptr, 0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  uint32_t slope_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp32, slope_dims.size(), slope_dims.data(), slope.data(), 1,
+                          /*flags=*/0, &slope_id));
+  ASSERT_NE(slope_id, XNN_INVALID_NODE_ID);
+
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input_dims.size(), input_dims.data(), nullptr, 2,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(xnn_status_success, xnn_define_prelu(subgraph, input_id, slope_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_prelu);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
+  ASSERT_EQ(node->num_inputs, 2);
+  ASSERT_EQ(node->inputs[0], input_id);
+  ASSERT_EQ(node->inputs[1], slope_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
 
 TEST_F(PreluTestF32, define)
 {
@@ -106,6 +157,79 @@ TEST_F(PreluTestF32, define)
   ASSERT_EQ(node->num_outputs, 1);
   ASSERT_EQ(node->outputs[0], output_id);
   ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(PreluTestF16, matches_operator_api)
+{
+  std::uniform_real_distribution<float> f32idist(-1.0f, 1.0f);
+  std::uniform_real_distribution<float> f32wdist(0.25f, 0.75f);
+  std::generate(input.begin(), input.end(), [&]() { return fp16_ieee_from_fp32_value(f32idist(rng)); });
+  std::generate(slope.begin(), slope.end(), [&]() { return f32wdist(rng); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  // Call operator API.
+  xnn_operator_t op = nullptr;
+  const xnn_status status =
+    xnn_create_prelu_nc_f16(channels, channels, channels, slope.data(), XNN_FLAG_FP32_STATIC_WEIGHTS, nullptr, nullptr, &op);
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_reshape_prelu_nc_f16(op, batch_size, /*threadpool=*/nullptr));
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_setup_prelu_nc_f16(op, input.data(), operator_output.data()));
+
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/3, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+  uint32_t input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input_dims.size(), input_dims.data(), nullptr, /*external_id=*/0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  uint32_t slope_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_tensor_value(
+      subgraph, xnn_datatype_fp32, slope_dims.size(), slope_dims.data(), slope.data(), /*external_id=*/1,
+      /*flags=*/0, &slope_id));
+  ASSERT_NE(slope_id, XNN_INVALID_NODE_ID);
+
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_tensor_value(
+      subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr, /*external_id=*/2,
+      /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_define_prelu(subgraph, input_id, slope_id, output_id, /*flags=*/0));
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 2> external = {
+    xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  ASSERT_EQ(subgraph_output, operator_output);
 }
 
 TEST_F(PreluTestF32, matches_operator_api)

--- a/test/rope.cc
+++ b/test/rope.cc
@@ -14,12 +14,13 @@
 #include <random>     // For std::random_device, std::mt19937, std::uniform_real_distribution.
 #include <vector>     // For std::vector.
 
+#include <fp16/fp16.h>
+#include <gtest/gtest.h>
+
 #include <xnnpack.h>
 #include <xnnpack/operator.h>
 #include <xnnpack/requantization.h>
 #include <xnnpack/subgraph.h>
-
-#include <gtest/gtest.h>
 
 template <class T> class RoPETestBase : public ::testing::Test {
 protected:
@@ -61,7 +62,53 @@ protected:
   std::vector<T> subgraph_output;
 };
 
+using RoPETestF16 = RoPETestBase<uint16_t>;
 using RoPETestF32 = RoPETestBase<float>;
+
+TEST_F(RoPETestF16, define)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(3, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  uint32_t input_id = XNN_INVALID_NODE_ID;
+  const std::array<size_t, 4> input_dims{{batch_size, tokens, heads, channels}};
+  ASSERT_EQ(xnn_status_success,
+    xnn_define_tensor_value(subgraph, xnn_datatype_fp16, input_dims.size(), input_dims.data(),
+                            /*data=*/nullptr, /*external_id=*/0, /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  uint32_t weights_id = XNN_INVALID_NODE_ID;
+  const std::array<size_t, 2> weights_dims{{max_tokens, channels}};
+  ASSERT_EQ(xnn_status_success,
+    xnn_define_tensor_value(subgraph, xnn_datatype_fp16, weights_dims.size(), weights_dims.data(),
+                            weights.data(), /*external_id=*/1, /*flags=*/0, &weights_id));
+
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+  const std::array<size_t, 4> output_dims{{batch_size, tokens, heads, channels}};
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr,
+                          /*external_id=*/2, /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(xnn_status_success,
+    xnn_define_rope(subgraph, max_tokens, input_id, weights_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_rope);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
+  ASSERT_EQ(node->params.rope.max_tokens, max_tokens);
+  ASSERT_EQ(node->num_inputs, 2);
+  ASSERT_EQ(node->inputs[0], input_id);
+  ASSERT_EQ(node->inputs[1], weights_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
 
 TEST_F(RoPETestF32, define)
 {
@@ -106,6 +153,86 @@ TEST_F(RoPETestF32, define)
   ASSERT_EQ(node->num_outputs, 1);
   ASSERT_EQ(node->outputs[0], output_id);
   ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(RoPETestF16, matches_operator_api)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_operator_t op = nullptr;
+
+  std::generate(input.begin(), input.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::generate(weights.begin(), weights.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+
+  const xnn_status status = xnn_create_rope_nthc_f16(max_tokens, /*flags=*/0, &op);
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  ASSERT_EQ(xnn_status_success,
+    xnn_reshape_rope_nthc_f16(op,
+      batch_size, tokens, heads, channels,
+      /*threadpool=*/nullptr));
+
+  ASSERT_EQ(xnn_status_success,
+    xnn_setup_rope_nthc_f16(op,
+      input.data(), weights.data(), operator_output.data()));
+
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(3, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  uint32_t input_id = XNN_INVALID_NODE_ID;
+  const std::array<size_t, 4> input_dims{{batch_size, tokens, heads, channels}};
+  ASSERT_EQ(xnn_status_success,
+    xnn_define_tensor_value(subgraph, xnn_datatype_fp16, input_dims.size(), input_dims.data(),
+                            /*data=*/nullptr, /*external_id=*/0, /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  uint32_t weights_id = XNN_INVALID_NODE_ID;
+  const std::array<size_t, 2> weights_dims{{max_tokens, channels}};
+  ASSERT_EQ(xnn_status_success,
+    xnn_define_tensor_value(subgraph, xnn_datatype_fp16, weights_dims.size(), weights_dims.data(),
+                            weights.data(), /*external_id=*/1, /*flags=*/0, &weights_id));
+
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+  const std::array<size_t, 4> output_dims{{batch_size, tokens, heads, channels}};
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(),
+                          /*data=*/nullptr, /*external_id=*/2, /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(xnn_status_success,
+    xnn_define_rope(subgraph, max_tokens, input_id, weights_id, output_id, /*flags=*/0));
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+
+  const std::array<xnn_external_value, 2> external{{
+    xnn_external_value{input_id, input.data()},
+    xnn_external_value{output_id, subgraph_output.data()}
+  }};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  // Check outputs match.
+  for (size_t i = 0; i < operator_output.size(); i++) {
+    ASSERT_EQ(subgraph_output[i], operator_output[i]);
+  }
 }
 
 TEST_F(RoPETestF32, matches_operator_api)

--- a/test/sigmoid.cc
+++ b/test/sigmoid.cc
@@ -10,16 +10,19 @@
 #include <memory>
 #include <random>
 
+#include <fp16/fp16.h>
+#include <gtest/gtest.h>
+
 #include <xnnpack.h>
 #include <xnnpack/node-type.h>
 #include <xnnpack/operator.h>
 #include <xnnpack/subgraph.h>
 
 #include "subgraph-unary-tester.h"
-#include <gtest/gtest.h>
 
 using SigmoidTestQS8 = UnaryTest<int8_t>;
 using SigmoidTestQU8 = UnaryTest<uint8_t>;
+using SigmoidTestF16 = UnaryTest<uint16_t>;
 using SigmoidTestF32 = UnaryTest<float>;
 
 TEST_F(SigmoidTestQS8, define)
@@ -95,6 +98,44 @@ TEST_F(SigmoidTestQU8, define)
   const struct xnn_node* node = &subgraph->nodes[0];
   ASSERT_EQ(node->type, xnn_node_type_sigmoid);
   ASSERT_EQ(node->compute_type, xnn_compute_type_qu8);
+  ASSERT_EQ(node->num_inputs, 1);
+  ASSERT_EQ(node->inputs[0], input_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(SigmoidTestF16, define)
+{
+  std::uniform_real_distribution<float> f32dist(-255.0f, 255.0f);
+  std::generate(input.begin(), input.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, 0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, 1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(xnn_status_success, xnn_define_sigmoid(subgraph, input_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_sigmoid);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
   ASSERT_EQ(node->num_inputs, 1);
   ASSERT_EQ(node->inputs[0], input_id);
   ASSERT_EQ(node->num_outputs, 1);
@@ -255,6 +296,59 @@ TEST_F(SigmoidTestQU8, matches_operator_api)
   ASSERT_NE(nullptr, runtime);
   std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
 
+  std::array<xnn_external_value, 2> external = {
+    xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  ASSERT_EQ(subgraph_output, operator_output);
+}
+
+TEST_F(SigmoidTestF16, matches_operator_api)
+{
+  std::uniform_real_distribution<float> f32dist(-25.0f, 25.0f);
+  std::generate(input.begin(), input.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  // Call operator API.
+  xnn_operator_t op = nullptr;
+  const xnn_status status = xnn_create_sigmoid_nc_f16(/*flags=*/0, &op);
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  ASSERT_EQ(xnn_status_success, xnn_reshape_sigmoid_nc_f16(op, batch_size, channels, channels, channels, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_setup_sigmoid_nc_f16(op, input.data(), operator_output.data()));
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, /*external_id=*/0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, /*external_id=*/1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_define_sigmoid(subgraph, input_id, output_id, /*flags=*/0));
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
   std::array<xnn_external_value, 2> external = {
     xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
   ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));

--- a/test/softmax.cc
+++ b/test/softmax.cc
@@ -11,16 +11,55 @@
 #include <memory>
 #include <random>
 
+#include <fp16/fp16.h>
+#include <gtest/gtest.h>
+
 #include <xnnpack.h>
 #include <xnnpack/node-type.h>
 #include <xnnpack/operator.h>
 #include <xnnpack/subgraph.h>
 
 #include "subgraph-unary-tester.h"
-#include <gtest/gtest.h>
 
+using SoftmaxTestF16 =
+  UnaryTest<uint16_t, /*OutputType=*/uint16_t, /*min_dim=*/1, /*max_dim=*/XNN_MAX_TENSOR_DIMS, /*pad_output=*/true>;
 using SoftmaxTestF32 =
   UnaryTest<float, /*OutputType=*/float, /*min_dim=*/1, /*max_dim=*/XNN_MAX_TENSOR_DIMS, /*pad_output=*/true>;
+
+TEST_F(SoftmaxTestF16, define)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, 0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, 1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(xnn_status_success, xnn_define_softmax(subgraph, input_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_softmax);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
+  ASSERT_EQ(node->num_inputs, 1);
+  ASSERT_EQ(node->inputs[0], input_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
 
 TEST_F(SoftmaxTestF32, define)
 {
@@ -55,6 +94,67 @@ TEST_F(SoftmaxTestF32, define)
   ASSERT_EQ(node->num_outputs, 1);
   ASSERT_EQ(node->outputs[0], output_id);
   ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(SoftmaxTestF16, matches_operator_api)
+{
+  // Choose such range that expf(x[i]) overflows, but expf(x[i] - x_max) doesn't.
+  // However, the range is still narrow enough that single-precision exp doesn't overflow.
+  std::uniform_real_distribution<float> f32dist(90.0f, 100.0f);
+  std::generate(input.begin(), input.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  // Call operator API.
+  xnn_operator_t op = nullptr;
+  const xnn_status status = xnn_create_softmax_nc_f16(channels, channels, channels, /*flags=*/0, &op);
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  ASSERT_EQ(xnn_status_success, xnn_reshape_softmax_nc_f16(op, batch_size, /*threadpool=*/nullptr));
+
+  ASSERT_EQ(xnn_status_success, xnn_setup_softmax_nc_f16(op, input.data(), operator_output.data()));
+
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, /*external_id=*/0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, /*external_id=*/1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_define_softmax(subgraph, input_id, output_id, /*flags=*/0));
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 2> external = {
+    xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  for (size_t i = 0; i < num_output_elements; i++) {
+    ASSERT_EQ(subgraph_output[i], operator_output[i]) << "element " << i << " / " << num_output_elements;
+  }
 }
 
 TEST_F(SoftmaxTestF32, matches_operator_api)

--- a/test/softmax.cc
+++ b/test/softmax.cc
@@ -109,7 +109,7 @@ TEST_F(SoftmaxTestF16, matches_operator_api)
 
   // Call operator API.
   xnn_operator_t op = nullptr;
-  const xnn_status status = xnn_create_softmax_nc_f16(channels, channels, channels, /*flags=*/0, &op);
+  const xnn_status status = xnn_create_softmax_nc_f16(/*flags=*/0, &op);
   if (status == xnn_status_unsupported_hardware) {
     GTEST_SKIP();
   }
@@ -118,7 +118,7 @@ TEST_F(SoftmaxTestF16, matches_operator_api)
   ASSERT_NE(nullptr, op);
   std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
 
-  ASSERT_EQ(xnn_status_success, xnn_reshape_softmax_nc_f16(op, batch_size, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_reshape_softmax_nc_f16(op, channels, channels, channels, batch_size, /*threadpool=*/nullptr));
 
   ASSERT_EQ(xnn_status_success, xnn_setup_softmax_nc_f16(op, input.data(), operator_output.data()));
 

--- a/test/space-to-depth-2d.cc
+++ b/test/space-to-depth-2d.cc
@@ -12,6 +12,7 @@
 #include <random>
 #include <vector>
 
+#include <fp16/fp16.h>
 #include <gtest/gtest.h>
 
 #include <xnnpack.h>
@@ -23,6 +24,7 @@
 
 using SpaceToDepth2DTestQS8 = UnaryTest<int8_t, int8_t, /*min_dim=*/4, /*max_dim=*/4>;
 using SpaceToDepth2DTestQU8 = UnaryTest<uint8_t, uint8_t, /*min_dim=*/4, /*max_dim=*/4>;
+using SpaceToDepth2DTestF16 = UnaryTest<uint16_t, uint16_t, /*min_dim=*/4, /*max_dim=*/4>;
 using SpaceToDepth2DTestF32 = UnaryTest<float, float, /*min_dim=*/4, /*max_dim=*/4>;
 
 TEST_F(SpaceToDepth2DTestQS8, define)
@@ -113,6 +115,49 @@ TEST_F(SpaceToDepth2DTestQU8, define)
   const struct xnn_node* node = &subgraph->nodes[0];
   ASSERT_EQ(node->type, xnn_node_type_space_to_depth_2d);
   ASSERT_EQ(node->compute_type, xnn_compute_type_qu8);
+  ASSERT_EQ(node->params.space_to_depth_2d.block_size, block_size);
+  ASSERT_EQ(node->num_inputs, 1);
+  ASSERT_EQ(node->inputs[0], input_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(SpaceToDepth2DTestF16, define)
+{
+  const size_t block_size = 2 + (u8dist(rng) % 13);
+  std::vector<size_t> output_dims = dims;
+  output_dims[3] *= block_size * block_size;
+  dims[1] *= block_size;
+  dims[2] *= block_size;
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, 0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr, 1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_space_to_depth_2d(subgraph, block_size, input_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_space_to_depth_2d);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
   ASSERT_EQ(node->params.space_to_depth_2d.block_size, block_size);
   ASSERT_EQ(node->num_inputs, 1);
   ASSERT_EQ(node->inputs[0], input_id);
@@ -303,6 +348,79 @@ TEST_F(SpaceToDepth2DTestQU8, matches_operator_api)
                           subgraph, xnn_datatype_quint8, output_zero_point, output_scale, dims.size(),
                           output_dims.data(), nullptr, /*external_id=*/1, /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT,
                           &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_space_to_depth_2d(subgraph, block_size, input_id, output_id, /*flags=*/0));
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+
+  std::array<xnn_external_value, 2> external = {
+    xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  EXPECT_EQ(subgraph_output, operator_output);
+}
+
+TEST_F(SpaceToDepth2DTestF16, matches_operator_api)
+{
+  std::vector<size_t> output_dims = dims;
+  const size_t block_size = 2 + (u8dist(rng) % 11);
+  output_dims[3] *= block_size * block_size;
+  dims[1] *= block_size;
+  dims[2] *= block_size;
+  AllocateInputsAndOutputs();
+
+  size_t input_channels = dims[3];
+
+  size_t input_height = dims[1];
+  size_t input_width = dims[2];
+  size_t batch_size = dims[0];
+
+  std::generate(input.begin(), input.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+
+  // Call operator API.
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+  xnn_operator_t op = nullptr;
+  const xnn_status status = xnn_create_space_to_depth_nhwc_x16(block_size, /*flags=*/0, &op);
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  ASSERT_EQ(
+    xnn_status_success, xnn_reshape_space_to_depth_nhwc_x16(
+                          op, batch_size, input_height, input_width, input_channels,
+                          /*output_height_out=*/nullptr, /*output_width_out=*/nullptr, /*output_channels_out=*/nullptr,
+                          /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_setup_space_to_depth_nhwc_x16(op, input.data(), operator_output.data()));
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(),
+                          nullptr, /*external_id=*/0, /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), output_dims.data(),
+                          nullptr, /*external_id=*/1, /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
   ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
 
   ASSERT_EQ(

--- a/test/square-root.cc
+++ b/test/square-root.cc
@@ -11,15 +11,53 @@
 #include <memory>
 #include <random>
 
+#include <fp16/fp16.h>
+#include <gtest/gtest.h>
+
 #include <xnnpack.h>
 #include <xnnpack/node-type.h>
 #include <xnnpack/operator.h>
 #include <xnnpack/subgraph.h>
 
 #include "subgraph-unary-tester.h"
-#include <gtest/gtest.h>
 
+using SquareRootTestF16 = UnaryTest<uint16_t>;
 using SquareRootTestF32 = UnaryTest<float>;
+
+TEST_F(SquareRootTestF16, define)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, 0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, 1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(xnn_status_success, xnn_define_square_root(subgraph, input_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_square_root);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
+  ASSERT_EQ(node->num_inputs, 1);
+  ASSERT_EQ(node->inputs[0], input_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
 
 TEST_F(SquareRootTestF32, define)
 {
@@ -54,6 +92,62 @@ TEST_F(SquareRootTestF32, define)
   ASSERT_EQ(node->num_outputs, 1);
   ASSERT_EQ(node->outputs[0], output_id);
   ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(SquareRootTestF16, matches_operator_api)
+{
+  std::uniform_real_distribution<float> f32dist(0.1f, 5.0f);
+  std::generate(input.begin(), input.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  // Call operator API.
+  xnn_operator_t op = nullptr;
+  const xnn_status status =
+    xnn_create_square_root_nc_f16(/*flags=*/0, &op);
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  ASSERT_EQ(xnn_status_success, xnn_reshape_square_root_nc_f16(op, batch_size, channels, channels, channels, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_setup_square_root_nc_f16(op, input.data(), operator_output.data()));
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, /*external_id=*/0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, /*external_id=*/1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_define_square_root(subgraph, input_id, output_id, /*flags=*/0));
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 2> external = {
+    xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  ASSERT_EQ(subgraph_output, operator_output);
 }
 
 TEST_F(SquareRootTestF32, matches_operator_api)

--- a/test/square.cc
+++ b/test/square.cc
@@ -11,15 +11,53 @@
 #include <memory>
 #include <random>
 
+#include <fp16/fp16.h>
+#include <gtest/gtest.h>
+
 #include <xnnpack.h>
 #include <xnnpack/node-type.h>
 #include <xnnpack/operator.h>
 #include <xnnpack/subgraph.h>
 
 #include "subgraph-unary-tester.h"
-#include <gtest/gtest.h>
 
+using SquareTestF16 = UnaryTest<uint16_t>;
 using SquareTestF32 = UnaryTest<float>;
+
+TEST_F(SquareTestF16, define)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, 0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, 1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(xnn_status_success, xnn_define_square(subgraph, input_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_square);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
+  ASSERT_EQ(node->num_inputs, 1);
+  ASSERT_EQ(node->inputs[0], input_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
 
 TEST_F(SquareTestF32, define)
 {
@@ -54,6 +92,62 @@ TEST_F(SquareTestF32, define)
   ASSERT_EQ(node->num_outputs, 1);
   ASSERT_EQ(node->outputs[0], output_id);
   ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(SquareTestF16, matches_operator_api)
+{
+  std::uniform_real_distribution<float> f32dist(-255.0f, 255.0f);
+  std::generate(input.begin(), input.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  // Call operator API.
+  xnn_operator_t op = nullptr;
+  const xnn_status status =
+    xnn_create_square_nc_f16(/*flags=*/0, &op);
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  ASSERT_EQ(xnn_status_success, xnn_reshape_square_nc_f16(op, batch_size, channels, channels, channels, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_setup_square_nc_f16(op, input.data(), operator_output.data()));
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, /*external_id=*/0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, /*external_id=*/1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_define_square(subgraph, input_id, output_id, /*flags=*/0));
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 2> external = {
+    xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  ASSERT_EQ(subgraph_output, operator_output);
 }
 
 TEST_F(SquareTestF32, matches_operator_api)

--- a/test/squared-difference.cc
+++ b/test/squared-difference.cc
@@ -15,15 +15,63 @@
 #include <random>
 #include <vector>
 
+#include <fp16/fp16.h>
+#include <gtest/gtest.h>
+
 #include <xnnpack.h>
 #include <xnnpack/node-type.h>
 #include <xnnpack/operator.h>
 #include <xnnpack/subgraph.h>
 
 #include "subgraph-binary-tester.h"
-#include <gtest/gtest.h>
 
+using SquaredDifferenceTestF16 = BinaryTest<uint16_t>;
 using SquaredDifferenceTestF32 = BinaryTest<float>;
+
+TEST_F(SquaredDifferenceTestF16, define)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(3, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  uint32_t input1_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input1_dims.size(), input1_dims.data(), nullptr,
+                          /*external_id=*/0, /*flags=*/0, &input1_id));
+  ASSERT_NE(input1_id, XNN_INVALID_NODE_ID);
+
+  uint32_t input2_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input2_dims.size(), input2_dims.data(), nullptr,
+                          /*external_id=*/0, /*flags=*/0, &input2_id));
+  ASSERT_NE(input2_id, XNN_INVALID_NODE_ID);
+
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_tensor_value(
+      subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr, XNN_INVALID_VALUE_ID, /*flags=*/0, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_squared_difference(subgraph, input1_id, input2_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_squared_difference);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
+  ASSERT_EQ(node->num_inputs, 2);
+  ASSERT_EQ(node->inputs[0], input1_id);
+  ASSERT_EQ(node->inputs[1], input2_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
 
 TEST_F(SquaredDifferenceTestF32, define)
 {
@@ -68,6 +116,76 @@ TEST_F(SquaredDifferenceTestF32, define)
   ASSERT_EQ(node->num_outputs, 1);
   ASSERT_EQ(node->outputs[0], output_id);
   ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(SquaredDifferenceTestF16, matches_operator_api)
+{
+  std::generate(input1.begin(), input1.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::generate(input2.begin(), input2.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_operator_t op = nullptr;
+
+  // Call operator API.
+  ASSERT_EQ(xnn_status_success, xnn_create_squared_difference_nd_f16(0, &op));
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  ASSERT_EQ(
+    xnn_status_success, xnn_reshape_squared_difference_nd_f16(
+                          op, input1_dims.size(), input1_dims.data(), input2_dims.size(), input2_dims.data(),
+                          /*threadpool=*/nullptr));
+
+  ASSERT_EQ(
+    xnn_status_success, xnn_setup_squared_difference_nd_f16(op, input1.data(), input2.data(), operator_output.data()));
+
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(3, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  uint32_t input1_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input1_dims.size(), input1_dims.data(), nullptr,
+                          /*external_id=*/0, /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input1_id));
+  ASSERT_NE(input1_id, XNN_INVALID_NODE_ID);
+
+  uint32_t input2_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input2_dims.size(), input2_dims.data(), nullptr,
+                          /*external_id=*/1, /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input2_id));
+  ASSERT_NE(input2_id, XNN_INVALID_NODE_ID);
+
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_tensor_value(
+      subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr, /*external_id=*/2,
+      /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_squared_difference(subgraph, input1_id, input2_id, output_id, /*flags=*/0));
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 3> external = {
+    xnn_external_value{input1_id, input1.data()}, xnn_external_value{input2_id, input2.data()},
+    xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  // Check outputs match.
+  ASSERT_EQ(subgraph_output, operator_output);
 }
 
 TEST_F(SquaredDifferenceTestF32, matches_operator_api)

--- a/test/static-constant-pad.cc
+++ b/test/static-constant-pad.cc
@@ -12,6 +12,7 @@
 #include <random>      // For std::random_device, std::mt19937, std::uniform_real_distribution.
 #include <vector>      // For std::vector.
 
+#include <fp16/fp16.h>
 #include <gtest/gtest.h>
 
 #include <xnnpack.h>
@@ -20,10 +21,10 @@
 #include <xnnpack/subgraph.h>
 
 #include "subgraph-unary-tester.h"
-#include <fp16/fp16.h>
 
 using StaticConstantPadTestInt8 = UnaryTest<int8_t>;
 using StaticConstantPadTestUint8 = UnaryTest<uint8_t>;
+using StaticConstantPadTestF16 = UnaryTest<uint16_t>;
 using StaticConstantPadTestF32 = UnaryTest<float>;
 
 TEST_F(StaticConstantPadTestInt8, define)
@@ -123,6 +124,56 @@ TEST_F(StaticConstantPadTestUint8, define)
     ASSERT_EQ(node->params.static_pad.post_paddings[i], post_paddings[i]);
   }
   ASSERT_EQ(node->params.static_pad.padding_value, quantized_padding_value);
+  ASSERT_EQ(node->num_inputs, 1);
+  ASSERT_EQ(node->inputs[0], input_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(StaticConstantPadTestF16, define)
+{
+  std::array<size_t, XNN_MAX_TENSOR_DIMS> pre_paddings;
+  std::array<size_t, XNN_MAX_TENSOR_DIMS> post_paddings;
+  std::fill(pre_paddings.begin(), pre_paddings.begin() + dims.size(), dim_dist(rng));
+  std::fill(post_paddings.begin(), post_paddings.begin() + dims.size(), dim_dist(rng));
+  uint16_t padding_value = f32dist(rng);
+  uint32_t padding_value_as_bits = fp16_ieee_from_fp32_value(padding_value);
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, 0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, 1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_static_constant_pad(
+      subgraph, pre_paddings.data(), post_paddings.data(), padding_value, input_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_static_constant_pad);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
+  for (size_t i = 0; i < dims.size(); i++) {
+    ASSERT_EQ(node->params.static_pad.pre_paddings[i], pre_paddings[i]);
+    ASSERT_EQ(node->params.static_pad.post_paddings[i], post_paddings[i]);
+  }
+  ASSERT_EQ(node->params.static_pad.padding_value, padding_value_as_bits);
   ASSERT_EQ(node->num_inputs, 1);
   ASSERT_EQ(node->inputs[0], input_id);
   ASSERT_EQ(node->num_outputs, 1);
@@ -310,6 +361,79 @@ TEST_F(StaticConstantPadTestUint8, matches_operator_api)
     xnn_status_success,
     xnn_define_quantized_tensor_value(
       subgraph, xnn_datatype_quint8, zero_point, scale, output_dims.size(), output_dims.data(), nullptr, 1,
+      /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_static_constant_pad(
+      subgraph, pre_paddings.data(), post_paddings.data(), padding_value, input_id, output_id, /*flags=*/0));
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 2> external = {
+    xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  ASSERT_EQ(subgraph_output, operator_output);
+}
+
+TEST_F(StaticConstantPadTestF16, matches_operator_api)
+{
+  std::array<size_t, XNN_MAX_TENSOR_DIMS> pre_paddings;
+  std::array<size_t, XNN_MAX_TENSOR_DIMS> post_paddings;
+  std::fill(pre_paddings.begin(), pre_paddings.begin() + dims.size(), dim_dist(rng));
+  std::fill(post_paddings.begin(), post_paddings.begin() + dims.size(), dim_dist(rng));
+  float padding_value = f32dist(rng);
+  uint32_t padding_value_as_u32 = fp16_ieee_from_fp32_value(padding_value);
+  std::vector<size_t> output_dims = dims;
+  for (size_t i = 0; i < dims.size(); i++) {
+    output_dims[i] = pre_paddings[i] + output_dims[i] + post_paddings[i];
+  }
+  // Output sizes
+  operator_output = std::vector<uint16_t>(NumElements(output_dims));
+  subgraph_output = std::vector<uint16_t>(operator_output.size());
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(std::nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(std::nanf("")));
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  // Call operator API.
+  xnn_operator_t op = nullptr;
+  const xnn_status status = xnn_create_constant_pad_nd_x16(&padding_value_as_u32, /*flags=*/0, &op);
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_reshape_constant_pad_nd_x16(
+      op, dims.size(), dims.data(), pre_paddings.data(), post_paddings.data(), /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_setup_constant_pad_nd_x16(op, input.data(), operator_output.data()));
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, 0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_tensor_value(
+      subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr, 1,
       /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
   ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
 

--- a/test/static-mean.cc
+++ b/test/static-mean.cc
@@ -14,14 +14,15 @@
 #include <random>     // For std::random_device, std::mt19937, std::uniform_real_distribution.
 #include <vector>     // For std::vector.
 
+#include <fp16/fp16.h>
+#include <gtest/gtest.h>
+
 #include <xnnpack.h>
 #include <xnnpack/aligned-allocator.h>
 #include <xnnpack/common.h>
 #include <xnnpack/node-type.h>
 #include <xnnpack/operator.h>
 #include <xnnpack/subgraph.h>
-
-#include <gtest/gtest.h>
 
 
 namespace xnnpack {
@@ -77,7 +78,50 @@ protected:
   std::vector<T> subgraph_output;
 };
 
+using MeanTestF16 = MeanTestBase<uint16_t>;
 using MeanTestF32 = MeanTestBase<float>;
+
+TEST_F(MeanTestF16, define)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  uint32_t input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(xnn_status_success,
+    xnn_define_tensor_value(subgraph, xnn_datatype_fp16, input_shape.size(), input_shape.data(),
+                            nullptr, /*external_id=*/0, /*flags=*/0, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(xnn_status_success,
+    xnn_define_tensor_value(subgraph, xnn_datatype_fp16, output_shape.size(), output_shape.data(),
+                            nullptr, /*external_id=*/1, /*flags=*/0, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(xnn_status_success,
+    xnn_define_static_mean(
+      subgraph,
+      reduction_axes.size(), reduction_axes.data(),
+      input_id, output_id,
+      /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_static_mean);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
+  ASSERT_EQ(node->params.reduce.num_reduction_axes, reduction_axes.size());
+  for (size_t i = 0; i < reduction_axes.size(); i++) {
+    ASSERT_EQ(node->params.reduce.reduction_axes[i], reduction_axes[i]);
+  }
+  ASSERT_EQ(node->num_inputs, 1);
+  ASSERT_EQ(node->inputs[0], input_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
 
 TEST_F(MeanTestF32, define)
 {
@@ -119,6 +163,83 @@ TEST_F(MeanTestF32, define)
   ASSERT_EQ(node->num_outputs, 1);
   ASSERT_EQ(node->outputs[0], output_id);
   ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(MeanTestF16, matches_operator_api)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_operator_t op = nullptr;
+
+  std::generate(input.begin(), input.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+
+  // Call operator API.
+  const xnn_status status = xnn_create_mean_nd_f16(/*flags=*/0, &op);
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  size_t workspace_size = 0;
+  size_t workspace_alignment = 0;
+  ASSERT_EQ(xnn_status_success,
+    xnn_reshape_mean_nd_f16(op,
+      reduction_axes.size(), reduction_axes.data(),
+      input_shape.size(), input_shape.data(),
+      &workspace_size, &workspace_alignment,
+      /*threadpool=*/nullptr));
+  ASSERT_LE(workspace_alignment, XNN_ALLOCATION_ALIGNMENT);
+
+  std::vector<char, AlignedAllocator<char, XNN_ALLOCATION_ALIGNMENT>> workspace(workspace_size);
+  ASSERT_EQ(xnn_status_success, xnn_setup_mean_nd_f16(op, workspace.data(), input.data(), operator_output.data()));
+
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  uint32_t input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(xnn_status_success,
+    xnn_define_tensor_value(subgraph, xnn_datatype_fp16, input_shape.size(), input_shape.data(),
+                            nullptr, /*external_id=*/0, XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(xnn_status_success,
+    xnn_define_tensor_value(subgraph, xnn_datatype_fp16, output_shape.size(), output_shape.data(),
+                            nullptr, /*external_id=*/1, XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(xnn_status_success,
+    xnn_define_static_mean(
+      subgraph,
+      reduction_axes.size(), reduction_axes.data(),
+      input_id, output_id,
+      /*flags=*/0));
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+
+  const std::array<xnn_external_value, 2> external = {
+    xnn_external_value{input_id, input.data()},
+    xnn_external_value{output_id, subgraph_output.data()}
+  };
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  // Check outputs match.
+  for (size_t i = 0; i < operator_output.size(); i++) {
+    ASSERT_EQ(subgraph_output[i], operator_output[i]);
+  }
 }
 
 TEST_F(MeanTestF32, matches_operator_api)

--- a/test/static-reshape.cc
+++ b/test/static-reshape.cc
@@ -12,13 +12,15 @@
 #include <random>      // For std::random_device, std::mt19937, std::uniform_real_distribution.
 #include <vector>      // For std::vector.
 
+#include <fp16/fp16.h>
+#include <gtest/gtest.h>
+
 #include <xnnpack.h>
 #include <xnnpack/node-type.h>
 #include <xnnpack/operator.h>
 #include <xnnpack/subgraph.h>
 
 #include "subgraph-unary-tester.h"
-#include <gtest/gtest.h>
 
 template <typename InputType, typename OutputType = InputType,
           size_t min_dim = 0, size_t max_dim = XNN_MAX_TENSOR_DIMS,
@@ -62,6 +64,7 @@ class StaticReshapeTest
 
 using StaticReshapeTestInt8 = StaticReshapeTest<int8_t>;
 using StaticReshapeTestUint8 = StaticReshapeTest<uint8_t>;
+using StaticReshapeTestF16 = StaticReshapeTest<uint16_t>;
 using StaticReshapeTestF32 = StaticReshapeTest<float>;
 
 TEST_F(StaticReshapeTestInt8, define)
@@ -133,6 +136,40 @@ TEST_F(StaticReshapeTestUint8, define)
   const struct xnn_node* node = &subgraph->nodes[0];
   ASSERT_EQ(node->type, xnn_node_type_static_reshape);
   ASSERT_EQ(node->compute_type, xnn_compute_type_qu8);
+  ASSERT_EQ(node->num_inputs, 1);
+  ASSERT_EQ(node->inputs[0], input_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(StaticReshapeTestF16, define)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(0, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+  uint32_t input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_tensor_value(
+      subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, XNN_INVALID_VALUE_ID, /*flags=*/0, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_tensor_value(
+      subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, XNN_INVALID_VALUE_ID, /*flags=*/0, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(xnn_status_success, xnn_define_static_reshape(subgraph, dims.size(), dims.data(), input_id, output_id, 0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_static_reshape);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
   ASSERT_EQ(node->num_inputs, 1);
   ASSERT_EQ(node->inputs[0], input_id);
   ASSERT_EQ(node->num_outputs, 1);
@@ -292,6 +329,64 @@ TEST_F(StaticReshapeTestUint8, matches_operator_api)
   ASSERT_NE(nullptr, runtime);
   std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
 
+  std::array<xnn_external_value, 2> external = {
+    xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  ASSERT_EQ(subgraph_output, operator_output);
+}
+
+TEST_F(StaticReshapeTestF16, matches_operator_api)
+{
+  std::generate(input.begin(), input.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+
+  std::vector<size_t> output_dims = dims;
+  std::shuffle(output_dims.begin(), output_dims.end(), rng);
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  // Call operator API.
+  xnn_operator_t op = nullptr;
+  xnn_status status = xnn_create_copy_nc_x16(/*flags=*/0, &op);
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+  size_t batch_size = NumElements(dims);
+  ASSERT_EQ(xnn_status_success, xnn_reshape_copy_nc_x16(op, batch_size, 1, 1, 1, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_setup_copy_nc_x16(op, input.data(), operator_output.data()));
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  ASSERT_NE(nullptr, subgraph);
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+  uint32_t input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, /*external_id=*/0,
+                          XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr,
+                          /*external_id=*/1, XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_static_reshape(subgraph, output_dims.size(), output_dims.data(), input_id, output_id, /*flags=*/0));
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
   std::array<xnn_external_value, 2> external = {
     xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
   ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));

--- a/test/static-resize-bilinear-2d.cc
+++ b/test/static-resize-bilinear-2d.cc
@@ -388,7 +388,7 @@ TEST_F(StaticResizeBilinear2DTestF16, matches_operator_api)
 
   // Call operator API.
   xnn_operator_t op = nullptr;
-  const xnn_status status = xnn_create_resize_bilinear2d_nhwc_f16(channels, channels, channels, /*flags=*/0, &op);
+  const xnn_status status = xnn_create_resize_bilinear2d_nhwc_f16(output_height, output_width, /*flags=*/0, &op);
   std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
 
   if (status == xnn_status_unsupported_hardware) {
@@ -402,7 +402,7 @@ TEST_F(StaticResizeBilinear2DTestF16, matches_operator_api)
   ASSERT_EQ(
     xnn_status_success,
     xnn_reshape_resize_bilinear2d_nhwc_f16(
-      op, batch_size, input_height, input_width, output_height, output_width,
+      op, batch_size, input_height, input_width, channels, channels, channels,
       &workspace_size, &workspace_alignment, /*threadpool=*/nullptr));
   ASSERT_EQ(workspace_size, 0);
   ASSERT_EQ(workspace_alignment, 1);

--- a/test/static-resize-bilinear-2d.cc
+++ b/test/static-resize-bilinear-2d.cc
@@ -13,11 +13,12 @@
 #include <random>     // For std::random_device, std::mt19937, std::uniform_real_distribution.
 #include <vector>     // For std::vector.
 
+#include <fp16/fp16.h>
+#include <gtest/gtest.h>
+
 #include <xnnpack.h>
 #include <xnnpack/operator.h>
 #include <xnnpack/subgraph.h>
-
-#include <gtest/gtest.h>
 
 template <class T> class StaticResizeBilinear2DTestBase : public ::testing::Test {
 protected:
@@ -81,6 +82,7 @@ protected:
 
 using StaticResizeBilinear2DTestQS8 = StaticResizeBilinear2DTestBase<int8_t>;
 using StaticResizeBilinear2DTestQU8 = StaticResizeBilinear2DTestBase<uint8_t>;
+using StaticResizeBilinear2DTestF16 = StaticResizeBilinear2DTestBase<uint16_t>;
 using StaticResizeBilinear2DTestF32 = StaticResizeBilinear2DTestBase<float>;
 
 TEST_F(StaticResizeBilinear2DTestQS8, define)
@@ -152,6 +154,45 @@ TEST_F(StaticResizeBilinear2DTestQU8, define)
   const struct xnn_node* node = &subgraph->nodes[0];
   ASSERT_EQ(node->type, xnn_node_type_static_resize_bilinear_2d);
   ASSERT_EQ(node->compute_type, xnn_compute_type_qu8);
+  ASSERT_EQ(node->params.static_resize.new_height, output_height);
+  ASSERT_EQ(node->params.static_resize.new_width, output_width);
+  ASSERT_EQ(node->num_inputs, 1);
+  ASSERT_EQ(node->inputs[0], input_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(StaticResizeBilinear2DTestF16, define)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  uint32_t input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input_dims.size(), input_dims.data(), nullptr,
+                          /*external_id=*/0, /*flags=*/0, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr,
+                          /*external_id=*/1, /*flags=*/0, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_static_resize_bilinear_2d(subgraph, output_height, output_width, input_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_static_resize_bilinear_2d);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
   ASSERT_EQ(node->params.static_resize.new_height, output_height);
   ASSERT_EQ(node->params.static_resize.new_width, output_width);
   ASSERT_EQ(node->num_inputs, 1);
@@ -321,6 +362,71 @@ TEST_F(StaticResizeBilinear2DTestQU8, matches_operator_api)
     xnn_status_success, xnn_define_quantized_tensor_value(
                           subgraph, xnn_datatype_quint8, output_zero_point, output_scale, output_dims.size(),
                           output_dims.data(), nullptr, /*external_id=*/1, XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_static_resize_bilinear_2d(subgraph, output_height, output_width, input_id, output_id, /*flags=*/0));
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 2> external = {
+    xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  ASSERT_EQ(subgraph_output, operator_output);
+}
+
+TEST_F(StaticResizeBilinear2DTestF16, matches_operator_api)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+  std::generate(input.begin(), input.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(std::nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(std::nanf("")));
+
+  // Call operator API.
+  xnn_operator_t op = nullptr;
+  const xnn_status status = xnn_create_resize_bilinear2d_nhwc_f16(channels, channels, channels, /*flags=*/0, &op);
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+  size_t workspace_size = SIZE_MAX;
+  size_t workspace_alignment = SIZE_MAX;
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_reshape_resize_bilinear2d_nhwc_f16(
+      op, batch_size, input_height, input_width, output_height, output_width,
+      &workspace_size, &workspace_alignment, /*threadpool=*/nullptr));
+  ASSERT_EQ(workspace_size, 0);
+  ASSERT_EQ(workspace_alignment, 1);
+  ASSERT_EQ(xnn_status_success, xnn_setup_resize_bilinear2d_nhwc_f16(op, /*workspace=*/nullptr, input.data(), operator_output.data()));
+
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  uint32_t input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input_dims.size(), input_dims.data(), nullptr, /*external_id=*/0,
+                          XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr,
+                          /*external_id=*/1, XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
   ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
   ASSERT_EQ(
     xnn_status_success,

--- a/test/static-slice.cc
+++ b/test/static-slice.cc
@@ -11,10 +11,11 @@
 #include <tuple>
 #include <vector>
 
-#include "subgraph-unary-tester.h"
-
+#include <fp16/fp16.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
+#include "subgraph-unary-tester.h"
 
 template <typename T> class StaticSliceTest : public UnaryTest<T, T, /*min_dim=*/1> {
 public:
@@ -66,6 +67,7 @@ protected:
 
 using StaticSliceTestQS8 = StaticSliceTest<int8_t>;
 using StaticSliceTestQU8 = StaticSliceTest<uint8_t>;
+using StaticSliceTestF16 = StaticSliceTest<uint16_t>;
 using StaticSliceTestF32 = StaticSliceTest<float>;
 
 TEST_F(StaticSliceTestQS8, define)
@@ -154,9 +156,48 @@ TEST_F(StaticSliceTestQU8, define)
   EXPECT_THAT(inferrable_sizes, testing::ElementsAreArray(node->params.slice.sizes, dims.size()));
 }
 
+TEST_F(StaticSliceTestF16, define)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, 0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, sizes.size(), sizes.data(), nullptr, 1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_static_slice(subgraph, dims.size(), offsets.data(), sizes.data(), input_id, output_id, /*flags=*/0));
+
+  EXPECT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  EXPECT_EQ(node->type, xnn_node_type_static_slice);
+  EXPECT_EQ(node->compute_type, xnn_compute_type_fp16);
+  EXPECT_EQ(node->num_inputs, 1);
+  EXPECT_EQ(node->inputs[0], input_id);
+  EXPECT_EQ(node->num_outputs, 1);
+  EXPECT_EQ(node->outputs[0], output_id);
+  EXPECT_EQ(node->flags, 0);
+  EXPECT_EQ(node->params.slice.num_dims, dims.size());
+  EXPECT_THAT(offsets, testing::ElementsAreArray(node->params.slice.offsets, dims.size()));
+  EXPECT_THAT(sizes, testing::ElementsAreArray(node->params.slice.sizes, dims.size()));
+}
+
 TEST_F(StaticSliceTestF32, define)
 {
-
   ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
 
   xnn_subgraph_t subgraph = nullptr;
@@ -305,6 +346,63 @@ TEST_F(StaticSliceTestQU8, matches_operator_api)
   ASSERT_EQ(
     xnn_status_success,
     xnn_define_static_slice(subgraph, dims.size(), offsets.data(), inferrable_sizes.data(), input_id, output_id, /*flags=*/0));
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 2> external = {
+    xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  EXPECT_EQ(subgraph_output, operator_output);
+}
+
+TEST_F(StaticSliceTestF16, matches_operator_api)
+{
+  std::generate(input.begin(), input.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  // Call operator API.
+  xnn_operator_t op = nullptr;
+  xnn_status status = xnn_create_slice_nd_x16(/*flags=*/0, &op);
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_reshape_slice_nd_x16(op, dims.size(), dims.data(), offsets.data(), sizes.data(), /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_setup_slice_nd_x16(op, input.data(), operator_output.data()));
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, 0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, sizes.size(), sizes.data(), nullptr, 1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_static_slice(subgraph, dims.size(), offsets.data(), sizes.data(), input_id, output_id, /*flags=*/0));
   xnn_runtime_t runtime = nullptr;
   ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
   ASSERT_NE(nullptr, runtime);

--- a/test/static-transpose.cc
+++ b/test/static-transpose.cc
@@ -12,16 +12,19 @@
 #include <numeric>
 #include <random>
 
+#include <fp16/fp16.h>
+#include <gtest/gtest.h>
+
 #include <xnnpack.h>
 #include <xnnpack/node-type.h>
 #include <xnnpack/operator.h>
 #include <xnnpack/subgraph.h>
 
 #include "subgraph-unary-tester.h"
-#include <gtest/gtest.h>
 
 using StaticTransposeTestQS8 = UnaryTest<int8_t, int8_t, /*min_dim=*/1>;
 using StaticTransposeTestQU8 = UnaryTest<uint8_t, uint8_t, /*min_dim=*/1>;
+using StaticTransposeTestF16 = UnaryTest<uint16_t, uint16_t, /*min_dim=*/1>;
 using StaticTransposeTestF32 = UnaryTest<float, float, /*min_dim=*/1>;
 
 namespace {
@@ -128,6 +131,49 @@ TEST_F(StaticTransposeTestQU8, define)
   const struct xnn_node* node = &subgraph->nodes[0];
   ASSERT_EQ(node->type, xnn_node_type_static_transpose);
   ASSERT_EQ(node->compute_type, xnn_compute_type_qu8);
+  for (size_t i = 0; i < dims.size(); i++) {
+    ASSERT_EQ(node->params.transpose.perm[i], perm[i]);
+  }
+  ASSERT_EQ(node->num_inputs, 1);
+  ASSERT_EQ(node->inputs[0], input_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(StaticTransposeTestF16, define)
+{
+  std::vector<size_t> perm = RandomPermutation(dims, rng);
+  std::vector<size_t> output_dims = PermuteInputDimensions(dims, perm);
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, 0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr, 1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_static_transpose(subgraph, perm.size(), perm.data(), input_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_static_transpose);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
   for (size_t i = 0; i < dims.size(); i++) {
     ASSERT_EQ(node->params.transpose.perm[i], perm[i]);
   }
@@ -301,6 +347,67 @@ TEST_F(StaticTransposeTestQU8, matches_operator_api)
   ASSERT_NE(nullptr, runtime);
   std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
 
+  std::array<xnn_external_value, 2> external = {
+    xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  ASSERT_EQ(subgraph_output, operator_output);
+}
+
+TEST_F(StaticTransposeTestF16, matches_operator_api)
+{
+  std::generate(input.begin(), input.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+  std::vector<size_t> perm = RandomPermutation(dims, rng);
+  std::vector<size_t> output_dims = PermuteInputDimensions(dims, perm);
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  // Call operator API.
+  xnn_operator_t op = nullptr;
+  const xnn_status status = xnn_create_transpose_nd_x16(/*flags=*/0, &op);
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_reshape_transpose_nd_x16(op, dims.size(), dims.data(), perm.data(), /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_setup_transpose_nd_x16(op, input.data(), operator_output.data()));
+
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, /*external_id=*/0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, /*external_id=*/1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_static_transpose(subgraph, perm.size(), perm.data(), input_id, output_id, /*flags=*/0));
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
   std::array<xnn_external_value, 2> external = {
     xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
   ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));

--- a/test/subtract2.cc
+++ b/test/subtract2.cc
@@ -11,16 +11,19 @@
 #include <memory>
 #include <vector>
 
+#include <fp16/fp16.h>
+#include <gtest/gtest.h>
+
 #include <xnnpack.h>
 #include <xnnpack/node-type.h>
 #include <xnnpack/operator.h>
 #include <xnnpack/subgraph.h>
 
 #include "subgraph-binary-tester.h"
-#include <gtest/gtest.h>
 
 using Subtract2TestQS8 = BinaryTest<int8_t>;
 using Subtract2TestQU8 = BinaryTest<uint8_t>;
+using Subtract2TestF16 = BinaryTest<uint16_t>;
 using Subtract2TestF32 = BinaryTest<float>;
 
 TEST_F(Subtract2TestQS8, define)
@@ -125,6 +128,53 @@ TEST_F(Subtract2TestQU8, define)
   const struct xnn_node* node = &subgraph->nodes[0];
   ASSERT_EQ(node->type, xnn_node_type_subtract);
   ASSERT_EQ(node->compute_type, xnn_compute_type_qu8);
+  ASSERT_EQ(node->activation.output_min, output_min);
+  ASSERT_EQ(node->activation.output_max, output_max);
+  ASSERT_EQ(node->num_inputs, 2);
+  ASSERT_EQ(node->inputs[0], input1_id);
+  ASSERT_EQ(node->inputs[1], input2_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(Subtract2TestF16, define)
+{
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(3, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  uint32_t input1_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input1_dims.size(), input1_dims.data(), nullptr,
+                          /*external_id=*/0, /*flags=*/0, &input1_id));
+  ASSERT_NE(input1_id, XNN_INVALID_NODE_ID);
+
+  uint32_t input2_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input2_dims.size(), input2_dims.data(), nullptr,
+                          /*external_id=*/0, /*flags=*/0, &input2_id));
+  ASSERT_NE(input2_id, XNN_INVALID_NODE_ID);
+
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr,
+                          XNN_INVALID_VALUE_ID, /*flags=*/0, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_subtract(subgraph, output_min, output_max, input1_id, input2_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_subtract);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
   ASSERT_EQ(node->activation.output_min, output_min);
   ASSERT_EQ(node->activation.output_max, output_max);
   ASSERT_EQ(node->num_inputs, 2);
@@ -331,6 +381,76 @@ TEST_F(Subtract2TestQU8, matches_operator_api)
                           subgraph, xnn_datatype_quint8, output_zero_point, output_scale, output_dims.size(),
                           output_dims.data(), nullptr, /*external_id=*/2,
                           /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_subtract(subgraph, output_min, output_max, input1_id, input2_id, output_id, /*flags=*/0));
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
+  std::array<xnn_external_value, 3> external = {
+    xnn_external_value{input1_id, input1.data()}, xnn_external_value{input2_id, input2.data()},
+    xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  ASSERT_EQ(subgraph_output, operator_output);
+}
+
+TEST_F(Subtract2TestF16, matches_operator_api)
+{
+  std::generate(input1.begin(), input1.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::generate(input2.begin(), input2.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+  std::fill(operator_output.begin(), operator_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+  std::fill(subgraph_output.begin(), subgraph_output.end(), fp16_ieee_from_fp32_value(nanf("")));
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_operator_t op = nullptr;
+
+  // Call operator API.
+  ASSERT_EQ(xnn_status_success, xnn_create_subtract_nd_f16(output_min, output_max, 0, &op));
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  ASSERT_EQ(
+    xnn_status_success, xnn_reshape_subtract_nd_f16(
+                          op, input1_dims.size(), input1_dims.data(), input2_dims.size(), input2_dims.data(),
+                          /*threadpool=*/nullptr));
+
+  ASSERT_EQ(
+    xnn_status_success, xnn_setup_subtract_nd_f16(
+                          op, input1.data(), input2.data(), operator_output.data()));
+
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(3, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  uint32_t input1_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input1_dims.size(), input1_dims.data(), nullptr,
+                          /*external_id=*/0, /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input1_id));
+  ASSERT_NE(input1_id, XNN_INVALID_NODE_ID);
+
+  uint32_t input2_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, input2_dims.size(), input2_dims.data(), nullptr,
+                          /*external_id=*/1, /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input2_id));
+  ASSERT_NE(input2_id, XNN_INVALID_NODE_ID);
+
+  uint32_t output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success,
+    xnn_define_tensor_value(
+      subgraph, xnn_datatype_fp16, output_dims.size(), output_dims.data(), nullptr, /*external_id=*/2,
+      /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
   ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
 
   ASSERT_EQ(

--- a/test/tanh.cc
+++ b/test/tanh.cc
@@ -10,16 +10,19 @@
 #include <memory>
 #include <random>
 
+#include <fp16/fp16.h>
+#include <gtest/gtest.h>
+
 #include <xnnpack.h>
 #include <xnnpack/node-type.h>
 #include <xnnpack/operator.h>
 #include <xnnpack/subgraph.h>
 
 #include "subgraph-unary-tester.h"
-#include <gtest/gtest.h>
 
 using TanhTestQS8 = UnaryTest<int8_t>;
 using TanhTestQU8 = UnaryTest<uint8_t>;
+using TanhTestF16 = UnaryTest<uint16_t>;
 using TanhTestF32 = UnaryTest<float>;
 
 TEST_F(TanhTestQS8, define)
@@ -95,6 +98,44 @@ TEST_F(TanhTestQU8, define)
   const struct xnn_node* node = &subgraph->nodes[0];
   ASSERT_EQ(node->type, xnn_node_type_tanh);
   ASSERT_EQ(node->compute_type, xnn_compute_type_qu8);
+  ASSERT_EQ(node->num_inputs, 1);
+  ASSERT_EQ(node->inputs[0], input_id);
+  ASSERT_EQ(node->num_outputs, 1);
+  ASSERT_EQ(node->outputs[0], output_id);
+  ASSERT_EQ(node->flags, 0);
+}
+
+TEST_F(TanhTestF16, define)
+{
+  std::uniform_real_distribution<float> f32dist(-10.0f, 10.0f);
+  std::generate(input.begin(), input.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, 0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, 1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  ASSERT_EQ(xnn_status_success, xnn_define_tanh(subgraph, input_id, output_id, /*flags=*/0));
+
+  ASSERT_EQ(subgraph->num_nodes, 1);
+  const struct xnn_node* node = &subgraph->nodes[0];
+  ASSERT_EQ(node->type, xnn_node_type_tanh);
+  ASSERT_EQ(node->compute_type, xnn_compute_type_fp16);
   ASSERT_EQ(node->num_inputs, 1);
   ASSERT_EQ(node->inputs[0], input_id);
   ASSERT_EQ(node->num_outputs, 1);
@@ -255,6 +296,59 @@ TEST_F(TanhTestQU8, matches_operator_api)
   ASSERT_NE(nullptr, runtime);
   std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
 
+  std::array<xnn_external_value, 2> external = {
+    xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
+  ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));
+  ASSERT_EQ(xnn_status_success, xnn_invoke_runtime(runtime));
+
+  ASSERT_EQ(subgraph_output, operator_output);
+}
+
+TEST_F(TanhTestF16, matches_operator_api)
+{
+  std::uniform_real_distribution<float> f32dist(-10.0f, 10.0f);
+  std::generate(input.begin(), input.end(), [&]() { return fp16_ieee_from_fp32_value(f32dist(rng)); });
+
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  // Call operator API.
+  xnn_operator_t op = nullptr;
+  const xnn_status status = xnn_create_tanh_nc_f16(/*flags=*/0, &op);
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+
+  ASSERT_EQ(xnn_status_success, status);
+  ASSERT_NE(nullptr, op);
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> auto_op(op, xnn_delete_operator);
+
+  ASSERT_EQ(xnn_status_success, xnn_reshape_tanh_nc_f16(op, batch_size, channels, channels, channels, /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_status_success, xnn_setup_tanh_nc_f16(op, input.data(), operator_output.data()));
+  ASSERT_EQ(xnn_status_success, xnn_run_operator(op, /*threadpool=*/nullptr));
+
+  // Call subgraph API.
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(/*external_value_ids=*/2, /*flags=*/0, &subgraph));
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(subgraph, xnn_delete_subgraph);
+  input_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, /*external_id=*/0,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+  ASSERT_NE(input_id, XNN_INVALID_NODE_ID);
+
+  output_id = XNN_INVALID_NODE_ID;
+  ASSERT_EQ(
+    xnn_status_success, xnn_define_tensor_value(
+                          subgraph, xnn_datatype_fp16, dims.size(), dims.data(), nullptr, /*external_id=*/1,
+                          /*flags=*/XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+  ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
+
+  xnn_runtime_t runtime = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_define_tanh(subgraph, input_id, output_id, /*flags=*/0));
+  ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
+  ASSERT_NE(nullptr, runtime);
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(runtime, xnn_delete_runtime);
   std::array<xnn_external_value, 2> external = {
     xnn_external_value{input_id, input.data()}, xnn_external_value{output_id, subgraph_output.data()}};
   ASSERT_EQ(xnn_status_success, xnn_setup_runtime(runtime, external.size(), external.data()));


### PR DESCRIPTION
As per previous design discussions, update subgraph node definition methods to allow for FP16 inputs. Add test coverage for FP16 support using subgraph API.

Tested building with cmake and running tests via cmake:
```
cmake --build . -j32 && ctest -j32 --output-on-failure
...
100% tests passed, 0 tests failed out of 382
```

This is a fairly large PR, so feel free to suggest that I break it up, if preferred for easier review. As an additional note, I did notice that there is a significant amount of boilerplate code in many of the tests, I've followed the example of existing FP32/Q8 tests, but would be happy to refactor to reduce code duplication, if desired.

Also, bazel build appears to be broken (local errors match error in CI bazel build), so I have not tested via bazel. If that issue is resolved, I can go ahead and verify that it builds and runs via bazel.