### PR TITLE
XNN_FLAG_KEEP_DIM --> XNN_FLAG_REDUCE_DIM

### DIFF
--- a/include/xnnpack.h
+++ b/include/xnnpack.h
@@ -85,8 +85,8 @@ extern "C" {
 /// Use transient indirection buffer to reduce memory footprint
 #define XNN_FLAG_TRANSIENT_INDIRECTION_BUFFER 0x00000020
 
-/// Retain reduced dimensions with length 1.
-#define XNN_FLAG_KEEP_DIMS 0x00000040
+/// Reduce the dimensions.
+#define XNN_FLAG_REDUCE_DIMS 0x00000040
 
 /// The number of entries in an array of xnn_dynamic_quantization_params that XNNPACK may read beyond array bounds.
 /// The caller must allocate at least this many extra xnn_dynamic_quantization_params before passing the array to XNNPACK.
@@ -620,7 +620,7 @@ enum xnn_status xnn_define_depth_to_space(
 /// @param output_id - Value ID for the output tensor. The output tensor must be a dense tensor with 2 or more
 ///                    dimensions defined in the @a subgraph.
 /// @param flags - binary features of the 1D Global Average Pooling Node. The only currently supported value is
-///                XNN_FLAG_KEEP_DIMS.
+///                XNN_FLAG_REDUCE_DIMS.
 enum xnn_status xnn_define_global_average_pooling_1d(
   xnn_subgraph_t subgraph,
   float output_min,
@@ -640,7 +640,7 @@ enum xnn_status xnn_define_global_average_pooling_1d(
 /// @param output_id - Value ID for the output tensor. The output tensor must be a dense tensor with 3 or more
 ///                    dimensions defined in the @a subgraph.
 /// @param flags - binary features of the 2D Global Average Pooling Node. The only currently supported value is
-///                XNN_FLAG_KEEP_DIMS.
+///                XNN_FLAG_REDUCE_DIMS.
 enum xnn_status xnn_define_global_average_pooling_2d(
   xnn_subgraph_t subgraph,
   float output_min,
@@ -659,7 +659,7 @@ enum xnn_status xnn_define_global_average_pooling_2d(
 /// @param output_id - Value ID for the output tensor. The output tensor must be a dense tensor with 2 or more
 ///                    dimensions defined in the @a subgraph.
 /// @param flags - binary features of the 1D Global Sum Pooling Node. The only currently supported value is
-///                XNN_FLAG_KEEP_DIMS.
+///                XNN_FLAG_REDUCE_DIMS.
 enum xnn_status xnn_define_global_sum_pooling_1d(
   xnn_subgraph_t subgraph,
   float output_min,
@@ -679,7 +679,7 @@ enum xnn_status xnn_define_global_sum_pooling_1d(
 /// @param output_id - Value ID for the output tensor. The output tensor must be a dense tensor with 3 or more
 ///                    dimensions defined in the @a subgraph.
 /// @param flags - binary features of the 2D Global Sum Pooling Node. The only currently supported value is
-///                XNN_FLAG_KEEP_DIMS.
+///                XNN_FLAG_REDUCE_DIMS.
 enum xnn_status xnn_define_global_sum_pooling_2d(
   xnn_subgraph_t subgraph,
   float output_min,
@@ -1196,9 +1196,9 @@ enum xnn_status xnn_define_static_constant_pad(
 ///                   @a num_reduction_axes dimensions defined in the @a subgraph.
 /// @param output_id - Value ID for the output tensor. The output tensor must be a dense tensor defined in the
 ///                    @a subgraph with @a num_reduction_axes fewer dimensions than the input tensor (if
-///                    XNN_FLAG_KEEP_DIMS is not specified), or has same dimension rank but the dimension at
-///                    @a reduction_axes reduced to 1 (if XNN_FLAG_KEEP_DIMS is specified).
-/// @param flags - binary features of the Mean Node. The only currently supported value is XNN_FLAG_KEEP_DIMS
+///                    XNN_FLAG_REDUCE_DIMS isspecified), or has same dimension rank but the dimension at
+///                    @a reduction_axes reduced to 1 (if XNN_FLAG_REDUCE_DIMS is not specified).
+/// @param flags - binary features of the Mean Node. The only currently supported value is XNN_FLAG_REDUCE_DIMS
 enum xnn_status xnn_define_static_mean(
   xnn_subgraph_t subgraph,
   size_t num_reduction_axes,

--- a/include/xnnpack.h
+++ b/include/xnnpack.h
@@ -1196,7 +1196,7 @@ enum xnn_status xnn_define_static_constant_pad(
 ///                   @a num_reduction_axes dimensions defined in the @a subgraph.
 /// @param output_id - Value ID for the output tensor. The output tensor must be a dense tensor defined in the
 ///                    @a subgraph with @a num_reduction_axes fewer dimensions than the input tensor (if
-///                    XNN_FLAG_REDUCE_DIMS isspecified), or has same dimension rank but the dimension at
+///                    XNN_FLAG_REDUCE_DIMS is specified), or has same dimension rank but the dimension at
 ///                    @a reduction_axes reduced to 1 (if XNN_FLAG_REDUCE_DIMS is not specified).
 /// @param flags - binary features of the Mean Node. The only currently supported value is XNN_FLAG_REDUCE_DIMS
 enum xnn_status xnn_define_static_mean(

--- a/src/subgraph/global-average-pooling.c
+++ b/src/subgraph/global-average-pooling.c
@@ -213,7 +213,10 @@ static enum xnn_status reshape_global_average_pooling_operator(
   struct xnn_value* output_value = values + output_id;
 
   memcpy(&output_value->shape.dim[0], &values[input_id].shape.dim[0], num_batch_dims);
-  if (opdata->operator_objects[0]->flags & XNN_FLAG_KEEP_DIMS) {
+  if (opdata->operator_objects[0]->flags & XNN_FLAG_REDUCE_DIMS) {
+    output_value->shape.dim[num_batch_dims] = channel_dim;
+    output_value->shape.num_dims = num_batch_dims + 1;
+  } else {
     output_value->shape.num_dims = num_input_dims;
     output_value->shape.dim[num_input_dims - 1] = channel_dim;
     switch (opdata->type) {
@@ -227,9 +230,6 @@ static enum xnn_status reshape_global_average_pooling_operator(
       default:
         XNN_UNREACHABLE;
     }
-  } else {
-    output_value->shape.dim[num_batch_dims] = channel_dim;
-    output_value->shape.num_dims = num_batch_dims + 1;
   }
   const size_t new_size = xnn_tensor_get_size(output_value);
   if (new_size > output_value->size || opdata->workspace_size > old_workspace_size) {

--- a/src/subgraph/global-sum-pooling.c
+++ b/src/subgraph/global-sum-pooling.c
@@ -115,7 +115,10 @@ static enum xnn_status reshape_global_sum_pooling_operator(
   struct xnn_value* output_value = values + output_id;
 
   memcpy(&output_value->shape.dim[0], &values[input_id].shape.dim[0], num_batch_dims);
-  if (opdata->operator_objects[0]->flags & XNN_FLAG_KEEP_DIMS) {
+  if (opdata->operator_objects[0]->flags & XNN_FLAG_REDUCE_DIMS) {
+    output_value->shape.dim[num_batch_dims] = channel_dim;
+    output_value->shape.num_dims = num_batch_dims + 1;
+  } else {
     output_value->shape.num_dims = num_input_dims;
     output_value->shape.dim[num_input_dims - 1] = channel_dim;
     switch (opdata->type) {
@@ -129,9 +132,6 @@ static enum xnn_status reshape_global_sum_pooling_operator(
       default:
         XNN_UNREACHABLE;
     }
-  } else {
-    output_value->shape.dim[num_batch_dims] = channel_dim;
-    output_value->shape.num_dims = num_batch_dims + 1;
   }
   const size_t new_size = xnn_tensor_get_size(output_value);
   if (new_size > output_value->size || opdata->workspace_size > old_workspace_size) {

--- a/test/global-average-pooling-1d.cc
+++ b/test/global-average-pooling-1d.cc
@@ -546,7 +546,7 @@ TEST_F(GlobalAveragePooling1DTestF32, matches_operator_api)
   ASSERT_EQ(subgraph_output, operator_output);
 }
 
-TEST_F(GlobalAveragePooling1DTestF32, reshape_output_no_keep_dims)
+TEST_F(GlobalAveragePooling1DTestF32, reshape_output_reduce_dims)
 {
   ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
 
@@ -570,7 +570,7 @@ TEST_F(GlobalAveragePooling1DTestF32, reshape_output_no_keep_dims)
   ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
   ASSERT_EQ(
     xnn_status_success,
-    xnn_define_global_average_pooling_1d(subgraph, output_min, output_max, input_id, output_id, /*flags=*/0));
+    xnn_define_global_average_pooling_1d(subgraph, output_min, output_max, input_id, output_id, /*flags=*/XNN_FLAG_REDUCE_DIMS));
 
   xnn_runtime_t runtime = nullptr;
   ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
@@ -609,7 +609,7 @@ TEST_F(GlobalAveragePooling1DTestF32, reshape_output_no_keep_dims)
   ASSERT_EQ(output_shape->dim[num_input_dims - 2], input_dims[num_input_dims - 1]);
 }
 
-TEST_F(GlobalAveragePooling1DTestF32, reshape_output_keep_dims)
+TEST_F(GlobalAveragePooling1DTestF32, reshape_output_no_reduce_dims)
 {
   ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
 
@@ -633,7 +633,7 @@ TEST_F(GlobalAveragePooling1DTestF32, reshape_output_keep_dims)
   ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
   ASSERT_EQ(
     xnn_status_success,
-    xnn_define_global_average_pooling_1d(subgraph, output_min, output_max, input_id, output_id, XNN_FLAG_KEEP_DIMS));
+    xnn_define_global_average_pooling_1d(subgraph, output_min, output_max, input_id, output_id, /*flags=*/0));
 
   xnn_runtime_t runtime = nullptr;
   ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));

--- a/test/global-average-pooling-2d.cc
+++ b/test/global-average-pooling-2d.cc
@@ -544,7 +544,7 @@ TEST_F(GlobalAveragePooling2DTestF32, matches_operator_api)
   ASSERT_EQ(subgraph_output, operator_output);
 }
 
-TEST_F(GlobalAveragePooling2DTestF32, reshape_output_no_keep_dims)
+TEST_F(GlobalAveragePooling2DTestF32, reshape_output_reduce_dims)
 {
   ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
 
@@ -568,7 +568,7 @@ TEST_F(GlobalAveragePooling2DTestF32, reshape_output_no_keep_dims)
   ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
   ASSERT_EQ(
     xnn_status_success,
-    xnn_define_global_average_pooling_2d(subgraph, output_min, output_max, input_id, output_id, /*flags=*/0));
+    xnn_define_global_average_pooling_2d(subgraph, output_min, output_max, input_id, output_id, /*flags=*/XNN_FLAG_REDUCE_DIMS));
 
   xnn_runtime_t runtime = nullptr;
   ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
@@ -607,7 +607,7 @@ TEST_F(GlobalAveragePooling2DTestF32, reshape_output_no_keep_dims)
   ASSERT_EQ(output_shape->dim[num_input_dims - 3], input_dims[num_input_dims - 1]);
 }
 
-TEST_F(GlobalAveragePooling2DTestF32, reshape_output_keep_dims)
+TEST_F(GlobalAveragePooling2DTestF32, reshape_output_no_reduce_dims)
 {
   ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
 
@@ -631,7 +631,7 @@ TEST_F(GlobalAveragePooling2DTestF32, reshape_output_keep_dims)
   ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
   ASSERT_EQ(
     xnn_status_success,
-    xnn_define_global_average_pooling_2d(subgraph, output_min, output_max, input_id, output_id, XNN_FLAG_KEEP_DIMS));
+    xnn_define_global_average_pooling_2d(subgraph, output_min, output_max, input_id, output_id, /*flags=*/0));
 
   xnn_runtime_t runtime = nullptr;
   ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));

--- a/test/global-sum-pooling-1d.cc
+++ b/test/global-sum-pooling-1d.cc
@@ -301,7 +301,7 @@ TEST_F(GlobalSumPooling1DTestF32, matches_operator_api)
   ASSERT_EQ(subgraph_output, operator_output);
 }
 
-TEST_F(GlobalSumPooling1DTestF32, reshape_output_no_keep_dims)
+TEST_F(GlobalSumPooling1DTestF32, reshape_output_reduce_dims)
 {
   ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
 
@@ -325,7 +325,7 @@ TEST_F(GlobalSumPooling1DTestF32, reshape_output_no_keep_dims)
   ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
   ASSERT_EQ(
     xnn_status_success,
-    xnn_define_global_sum_pooling_1d(subgraph, output_min, output_max, input_id, output_id, /*flags=*/0));
+    xnn_define_global_sum_pooling_1d(subgraph, output_min, output_max, input_id, output_id, /*flags=*/XNN_FLAG_REDUCE_DIMS));
 
   xnn_runtime_t runtime = nullptr;
   ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
@@ -364,7 +364,7 @@ TEST_F(GlobalSumPooling1DTestF32, reshape_output_no_keep_dims)
   ASSERT_EQ(output_shape->dim[num_input_dims - 2], input_dims[num_input_dims - 1]);
 }
 
-TEST_F(GlobalSumPooling1DTestF32, reshape_output_keep_dims)
+TEST_F(GlobalSumPooling1DTestF32, reshape_output_no_reduce_dims)
 {
   ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
 
@@ -388,7 +388,7 @@ TEST_F(GlobalSumPooling1DTestF32, reshape_output_keep_dims)
   ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
   ASSERT_EQ(
     xnn_status_success,
-    xnn_define_global_sum_pooling_1d(subgraph, output_min, output_max, input_id, output_id, XNN_FLAG_KEEP_DIMS));
+    xnn_define_global_sum_pooling_1d(subgraph, output_min, output_max, input_id, output_id, /*flags=*/0));
 
   xnn_runtime_t runtime = nullptr;
   ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));

--- a/test/global-sum-pooling-2d.cc
+++ b/test/global-sum-pooling-2d.cc
@@ -300,7 +300,7 @@ TEST_F(GlobalSumPooling2DTestF32, matches_operator_api)
   ASSERT_EQ(subgraph_output, operator_output);
 }
 
-TEST_F(GlobalSumPooling2DTestF32, reshape_output_no_keep_dims)
+TEST_F(GlobalSumPooling2DTestF32, reshape_output_reduce_dims)
 {
   ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
 
@@ -324,7 +324,7 @@ TEST_F(GlobalSumPooling2DTestF32, reshape_output_no_keep_dims)
   ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
   ASSERT_EQ(
     xnn_status_success,
-    xnn_define_global_sum_pooling_2d(subgraph, output_min, output_max, input_id, output_id, /*flags=*/0));
+    xnn_define_global_sum_pooling_2d(subgraph, output_min, output_max, input_id, output_id, /*flags=*/XNN_FLAG_REDUCE_DIMS));
 
   xnn_runtime_t runtime = nullptr;
   ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
@@ -363,7 +363,7 @@ TEST_F(GlobalSumPooling2DTestF32, reshape_output_no_keep_dims)
   ASSERT_EQ(output_shape->dim[num_input_dims - 3], input_dims[num_input_dims - 1]);
 }
 
-TEST_F(GlobalSumPooling2DTestF32, reshape_output_keep_dims)
+TEST_F(GlobalSumPooling2DTestF32, reshape_output_no_reduce_dims)
 {
   ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
 
@@ -387,7 +387,7 @@ TEST_F(GlobalSumPooling2DTestF32, reshape_output_keep_dims)
   ASSERT_NE(output_id, XNN_INVALID_NODE_ID);
   ASSERT_EQ(
     xnn_status_success,
-    xnn_define_global_sum_pooling_2d(subgraph, output_min, output_max, input_id, output_id, XNN_FLAG_KEEP_DIMS));
+    xnn_define_global_sum_pooling_2d(subgraph, output_min, output_max, input_id, output_id, 0));
 
   xnn_runtime_t runtime = nullptr;
   ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));

--- a/test/static-mean.cc
+++ b/test/static-mean.cc
@@ -319,7 +319,7 @@ TEST_F(MeanTestF32, matches_operator_api)
   }
 }
 
-TEST_F(MeanTestF32, reshape_output_keep_dims)
+TEST_F(MeanTestF32, reshape_output_no_reduce_dims)
 {
   ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
 
@@ -345,7 +345,7 @@ TEST_F(MeanTestF32, reshape_output_keep_dims)
       subgraph,
       reduction_axes.size(), reduction_axes.data(),
       input_id, output_id,
-      /*flags=*/XNN_FLAG_KEEP_DIMS));
+      /*flags=*/0));
 
   xnn_runtime_t runtime = nullptr;
   ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));
@@ -401,7 +401,7 @@ TEST_F(MeanTestF32, reshape_output_keep_dims)
   }
 }
 
-TEST_F(MeanTestF32, reshape_output_no_keep_dims)
+TEST_F(MeanTestF32, reshape_output_reduce_dims)
 {
   ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
 
@@ -427,7 +427,7 @@ TEST_F(MeanTestF32, reshape_output_no_keep_dims)
       subgraph,
       reduction_axes.size(), reduction_axes.data(),
       input_id, output_id,
-      /*flags=*/0));
+      /*flags=*/XNN_FLAG_REDUCE_DIMS));
 
   xnn_runtime_t runtime = nullptr;
   ASSERT_EQ(xnn_status_success, xnn_create_runtime_v3(subgraph, nullptr, nullptr, /*flags=*/0, &runtime));


### PR DESCRIPTION
KEEP_DIM flag breaks backwards compatibility as global sum pooling, global avg pooling, and static mean now reduce dims by default. 

Instead I recommend switching the flag to xnn_flag_reduce_dim to opt-in to dim reducing so that prior behavior remains the same.