### PR TITLE
use runtime threadpool when reshaping ops

### DIFF
--- a/src/runtime.c
+++ b/src/runtime.c
@@ -693,7 +693,7 @@ enum xnn_status xnn_reshape_runtime(
     assert(opdata->reshape != NULL);
     xnn_log_debug("reshaping operator %u (%s)", opdata_id,
                   xnn_operator_type_to_string(opdata->operator_objects[0]->type));
-    enum xnn_status status = opdata->reshape(opdata, runtime->values, runtime->num_values, /*threadpool=*/NULL);
+    enum xnn_status status = opdata->reshape(opdata, runtime->values, runtime->num_values, runtime->threadpool);
     if (status == xnn_status_reallocation_required) {
       reallocation_required = true;
     } else if (status != xnn_status_success) {


### PR DESCRIPTION
As Title

was having some issues when pthreadpool was set to null here, so made this change. Let me know if this works/passes CI.

@alankelly 