### PR TITLE
Add common --enable_bzlmod=false to .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -55,3 +55,6 @@ build:macos --apple_platform_type=macos
 
 build:macos_arm64 --config=macos
 build:macos_arm64 --cpu=darwin_arm64
+
+# Disable Bzlmod for every Bazel command
+common --enable_bzlmod=false


### PR DESCRIPTION
Bazel 7.x defaults to expecting MODULE.bazel instead of WORKSPACE unless you specify this flag. XNNPACK should probably migrate to this new scheme, but for now, to avoid the warning (and the creation of a dummy MODULE.bazel file), let's just set this flag to silence it.

(Longer-term, the project should probably migrate to the newer scheme; I looked into doing that but some details of the migration are unclear to me at this time, especially regarding support for the android_sdk/ndk_repository rules.)