### PR TITLE
Fix Bazel build for bench subdir

### DIFF
--- a/bench/BUILD.bazel
+++ b/bench/BUILD.bazel
@@ -669,7 +669,6 @@ xnnpack_benchmark(
     srcs = [
         "f32-gemm-minmax.cc",
         "gemm.h",
-        "google/gemm.h",
     ],
     copts = xnnpack_optional_ruy_copts(),
     deps = MICROKERNEL_BENCHMARK_DEPS + [
@@ -685,7 +684,6 @@ xnnpack_benchmark(
     srcs = [
         "f32-gemm-goi-minmax.cc",
         "gemm.h",
-        "google/gemm.h",
     ],
     copts = xnnpack_optional_ruy_copts(),
     deps = MICROKERNEL_BENCHMARK_DEPS + [
@@ -1242,7 +1240,6 @@ xnnpack_cc_library(
     name = "spmm_benchmark",
     hdrs = [
         "gemm.h",
-        "google/gemm.h",
         "spmm-benchmark.h",
     ],
     deps = MICROKERNEL_BENCHMARK_DEPS + [


### PR DESCRIPTION
Several targets were including a nonexistent file in `srcs`, meaning they would not build properly. The file they (apparently) want to include is already in the deps set, so simple removal of these srcs fixes the build. (Perhaps this is a wart that appeared from a Google -> GitHub change migration?)