### PR TITLE
Disable some warnings for Bazel builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -58,3 +58,8 @@ build:macos_arm64 --cpu=darwin_arm64
 
 # Disable Bzlmod for every Bazel command
 common --enable_bzlmod=false
+
+# Disable some warnings to allow a warning-free build
+build --cxxopt='-Wno-sign-compare'
+build --cxxopt='-Wno-comment'
+build --cxxopt='-Wno-psabi'


### PR DESCRIPTION
This allows Bazel builds to be "clean" from distracting warnings that don't appear in the CMake builds.