### PR TITLE
fc_qc8w should use qcint32 bias

### DIFF
--- a/src/subgraph/fully-connected.c
+++ b/src/subgraph/fully-connected.c
@@ -700,7 +700,7 @@ static inline enum xnn_compute_type validate_datatypes_with_bias(
       {
         return xnn_compute_type_qd8_to_fp16;
       } else if (input_datatype == xnn_datatype_qint8 &&
-          bias_datatype == xnn_datatype_qint32 &&
+          bias_datatype == xnn_datatype_qcint32 &&
           output_datatype == xnn_datatype_qint8)
       {
         return xnn_compute_type_qc8;
@@ -950,6 +950,7 @@ enum xnn_status xnn_define_fully_connected(
       case xnn_datatype_fp16:
       case xnn_datatype_fp32:
       case xnn_datatype_qint32:
+      case xnn_datatype_qcint32:
         break;
       default:
         xnn_log_error(

--- a/test/fully-connected.cc
+++ b/test/fully-connected.cc
@@ -171,8 +171,8 @@ TEST_F(FullyConnectedTestQC8, define)
 
   uint32_t bias_id = XNN_INVALID_VALUE_ID;
   ASSERT_EQ(
-    xnn_status_success, xnn_define_quantized_tensor_value(
-                          subgraph, xnn_datatype_qint32, 0, 1.0f, bias_dims.size(), bias_dims.data(), bias.data(),
+    xnn_status_success, xnn_define_channelwise_quantized_tensor_value(
+                          subgraph, xnn_datatype_qcint32, scale.data(), bias_dims.size(), 0, bias_dims.data(), bias.data(),
                           /*external_id=*/2, /*flags=*/0, &bias_id));
 
   uint32_t output_id = XNN_INVALID_VALUE_ID;
@@ -759,8 +759,8 @@ TEST_F(FullyConnectedTestQC8, matches_operator_api)
 
   uint32_t bias_id = XNN_INVALID_VALUE_ID;
   ASSERT_EQ(
-    xnn_status_success, xnn_define_quantized_tensor_value(
-                          subgraph, xnn_datatype_qint32, 0, kernel_scale, bias_dims.size(), bias_dims.data(),
+    xnn_status_success, xnn_define_channelwise_quantized_tensor_value(
+                          subgraph, xnn_datatype_qcint32, requantization_scales.data(), bias_dims.size(), 0, bias_dims.data(),
                           bias.data(), /*external_id=*/2, /*flags=*/0, &bias_id));
 
   uint32_t output_id = XNN_INVALID_VALUE_ID;


### PR DESCRIPTION
In the subgraph APIs, FC Layer supports:

input: qs8
weights: qc8
bias: qint32

However, based on what is cone for qc8 filters in convolution, I believe it should be:

input: qs8
weights: qc8
bias: _**qcint32**_