### PR TITLE
Update test scrpit for riscv LMUL size 1

### DIFF
--- a/test/f16-vclamp.cc
+++ b/test/f16-vclamp.cc
@@ -174,6 +174,24 @@
       .Test(xnn_f16_vclamp_ukernel__rvvfp16arith_u1v, xnn_init_f16_minmax_fp16arith_params);
   }
 
+  TEST(F16_VCLAMP__RVVFP16ARITH_U1V, batch_div_1v) {
+    TEST_REQUIRES_RISCV_VECTOR_FP16_ARITH;
+    for (size_t batch_size = 2 * xnn_init_hardware_config()->vlenb / sizeof(uint16_t); batch_size < 10 * xnn_init_hardware_config()->vlenb / sizeof(uint16_t); batch_size += 1 * xnn_init_hardware_config()->vlenb / sizeof(uint16_t)) {
+      VUnaryMicrokernelTester()
+        .batch_size(batch_size)
+        .Test(xnn_f16_vclamp_ukernel__rvvfp16arith_u1v, xnn_init_f16_minmax_fp16arith_params);
+    }
+  }
+
+  TEST(F16_VCLAMP__RVVFP16ARITH_U1V, batch_lt_1v) {
+    TEST_REQUIRES_RISCV_VECTOR_FP16_ARITH;
+    for (size_t batch_size = 1; batch_size < 1 * xnn_init_hardware_config()->vlenb / sizeof(uint16_t); batch_size++) {
+      VUnaryMicrokernelTester()
+        .batch_size(batch_size)
+        .Test(xnn_f16_vclamp_ukernel__rvvfp16arith_u1v, xnn_init_f16_minmax_fp16arith_params);
+    }
+  }
+
   TEST(F16_VCLAMP__RVVFP16ARITH_U1V, batch_gt_1v) {
     TEST_REQUIRES_RISCV_VECTOR_FP16_ARITH;
     for (size_t batch_size = 1 * xnn_init_hardware_config()->vlenb / sizeof(uint16_t) + 1; batch_size < 10 * xnn_init_hardware_config()->vlenb / sizeof(uint16_t); batch_size++) {

--- a/test/f32-vabs.cc
+++ b/test/f32-vabs.cc
@@ -126,6 +126,24 @@
       .Test(xnn_f32_vabs_ukernel__rvv_u1v);
   }
 
+  TEST(F32_VABS__RVV_U1V, batch_div_1v) {
+    TEST_REQUIRES_RISCV_VECTOR;
+    for (size_t batch_size = 2 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size < 10 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size += 1 * xnn_init_hardware_config()->vlenb / sizeof(float)) {
+      VUnaryMicrokernelTester()
+        .batch_size(batch_size)
+        .Test(xnn_f32_vabs_ukernel__rvv_u1v);
+    }
+  }
+
+  TEST(F32_VABS__RVV_U1V, batch_lt_1v) {
+    TEST_REQUIRES_RISCV_VECTOR;
+    for (size_t batch_size = 1; batch_size < 1 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size++) {
+      VUnaryMicrokernelTester()
+        .batch_size(batch_size)
+        .Test(xnn_f32_vabs_ukernel__rvv_u1v);
+    }
+  }
+
   TEST(F32_VABS__RVV_U1V, batch_gt_1v) {
     TEST_REQUIRES_RISCV_VECTOR;
     for (size_t batch_size = 1 * xnn_init_hardware_config()->vlenb / sizeof(float) + 1; batch_size < 10 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size++) {

--- a/test/f32-vclamp.cc
+++ b/test/f32-vclamp.cc
@@ -245,6 +245,24 @@
       .Test(xnn_f32_vclamp_ukernel__rvv_u1v, xnn_init_f32_minmax_scalar_params);
   }
 
+  TEST(F32_VCLAMP__RVV_U1V, batch_div_1v) {
+    TEST_REQUIRES_RISCV_VECTOR;
+    for (size_t batch_size = 2 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size < 10 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size += 1 * xnn_init_hardware_config()->vlenb / sizeof(float)) {
+      VUnaryMicrokernelTester()
+        .batch_size(batch_size)
+        .Test(xnn_f32_vclamp_ukernel__rvv_u1v, xnn_init_f32_minmax_scalar_params);
+    }
+  }
+
+  TEST(F32_VCLAMP__RVV_U1V, batch_lt_1v) {
+    TEST_REQUIRES_RISCV_VECTOR;
+    for (size_t batch_size = 1; batch_size < 1 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size++) {
+      VUnaryMicrokernelTester()
+        .batch_size(batch_size)
+        .Test(xnn_f32_vclamp_ukernel__rvv_u1v, xnn_init_f32_minmax_scalar_params);
+    }
+  }
+
   TEST(F32_VCLAMP__RVV_U1V, batch_gt_1v) {
     TEST_REQUIRES_RISCV_VECTOR;
     for (size_t batch_size = 1 * xnn_init_hardware_config()->vlenb / sizeof(float) + 1; batch_size < 10 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size++) {

--- a/test/f32-vhswish.cc
+++ b/test/f32-vhswish.cc
@@ -173,6 +173,24 @@
       .Test(xnn_f32_vhswish_ukernel__rvv_u1v, xnn_init_f32_hswish_scalar_params);
   }
 
+  TEST(F32_VHSWISH__RVV_U1V, batch_div_1v) {
+    TEST_REQUIRES_RISCV_VECTOR;
+    for (size_t batch_size = 2 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size < 10 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size += 1 * xnn_init_hardware_config()->vlenb / sizeof(float)) {
+      VUnaryMicrokernelTester()
+        .batch_size(batch_size)
+        .Test(xnn_f32_vhswish_ukernel__rvv_u1v, xnn_init_f32_hswish_scalar_params);
+    }
+  }
+
+  TEST(F32_VHSWISH__RVV_U1V, batch_lt_1v) {
+    TEST_REQUIRES_RISCV_VECTOR;
+    for (size_t batch_size = 1; batch_size < 1 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size++) {
+      VUnaryMicrokernelTester()
+        .batch_size(batch_size)
+        .Test(xnn_f32_vhswish_ukernel__rvv_u1v, xnn_init_f32_hswish_scalar_params);
+    }
+  }
+
   TEST(F32_VHSWISH__RVV_U1V, batch_gt_1v) {
     TEST_REQUIRES_RISCV_VECTOR;
     for (size_t batch_size = 1 * xnn_init_hardware_config()->vlenb / sizeof(float) + 1; batch_size < 10 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size++) {

--- a/test/f32-vneg.cc
+++ b/test/f32-vneg.cc
@@ -126,6 +126,24 @@
       .Test(xnn_f32_vneg_ukernel__rvv_u1v);
   }
 
+  TEST(F32_VNEG__RVV_U1V, batch_div_1v) {
+    TEST_REQUIRES_RISCV_VECTOR;
+    for (size_t batch_size = 2 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size < 10 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size += 1 * xnn_init_hardware_config()->vlenb / sizeof(float)) {
+      VUnaryMicrokernelTester()
+        .batch_size(batch_size)
+        .Test(xnn_f32_vneg_ukernel__rvv_u1v);
+    }
+  }
+
+  TEST(F32_VNEG__RVV_U1V, batch_lt_1v) {
+    TEST_REQUIRES_RISCV_VECTOR;
+    for (size_t batch_size = 1; batch_size < 1 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size++) {
+      VUnaryMicrokernelTester()
+        .batch_size(batch_size)
+        .Test(xnn_f32_vneg_ukernel__rvv_u1v);
+    }
+  }
+
   TEST(F32_VNEG__RVV_U1V, batch_gt_1v) {
     TEST_REQUIRES_RISCV_VECTOR;
     for (size_t batch_size = 1 * xnn_init_hardware_config()->vlenb / sizeof(float) + 1; batch_size < 10 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size++) {

--- a/test/f32-vsqr.cc
+++ b/test/f32-vsqr.cc
@@ -126,6 +126,24 @@
       .Test(xnn_f32_vsqr_ukernel__rvv_u1v);
   }
 
+  TEST(F32_VSQR__RVV_U1V, batch_div_1v) {
+    TEST_REQUIRES_RISCV_VECTOR;
+    for (size_t batch_size = 2 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size < 10 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size += 1 * xnn_init_hardware_config()->vlenb / sizeof(float)) {
+      VUnaryMicrokernelTester()
+        .batch_size(batch_size)
+        .Test(xnn_f32_vsqr_ukernel__rvv_u1v);
+    }
+  }
+
+  TEST(F32_VSQR__RVV_U1V, batch_lt_1v) {
+    TEST_REQUIRES_RISCV_VECTOR;
+    for (size_t batch_size = 1; batch_size < 1 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size++) {
+      VUnaryMicrokernelTester()
+        .batch_size(batch_size)
+        .Test(xnn_f32_vsqr_ukernel__rvv_u1v);
+    }
+  }
+
   TEST(F32_VSQR__RVV_U1V, batch_gt_1v) {
     TEST_REQUIRES_RISCV_VECTOR;
     for (size_t batch_size = 1 * xnn_init_hardware_config()->vlenb / sizeof(float) + 1; batch_size < 10 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size++) {

--- a/test/f32-vsqrt.cc
+++ b/test/f32-vsqrt.cc
@@ -257,6 +257,24 @@
       .Test(xnn_f32_vsqrt_ukernel__rvv_sqrt_u1v);
   }
 
+  TEST(F32_VSQRT__RVV_SQRT_U1V, batch_div_1v) {
+    TEST_REQUIRES_RISCV_VECTOR;
+    for (size_t batch_size = 2 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size < 10 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size += 1 * xnn_init_hardware_config()->vlenb / sizeof(float)) {
+      VUnaryMicrokernelTester()
+        .batch_size(batch_size)
+        .Test(xnn_f32_vsqrt_ukernel__rvv_sqrt_u1v);
+    }
+  }
+
+  TEST(F32_VSQRT__RVV_SQRT_U1V, batch_lt_1v) {
+    TEST_REQUIRES_RISCV_VECTOR;
+    for (size_t batch_size = 1; batch_size < 1 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size++) {
+      VUnaryMicrokernelTester()
+        .batch_size(batch_size)
+        .Test(xnn_f32_vsqrt_ukernel__rvv_sqrt_u1v);
+    }
+  }
+
   TEST(F32_VSQRT__RVV_SQRT_U1V, batch_gt_1v) {
     TEST_REQUIRES_RISCV_VECTOR;
     for (size_t batch_size = 1 * xnn_init_hardware_config()->vlenb / sizeof(float) + 1; batch_size < 10 * xnn_init_hardware_config()->vlenb / sizeof(float); batch_size++) {

--- a/test/qs8-vmul-minmax-fp32.cc
+++ b/test/qs8-vmul-minmax-fp32.cc
@@ -2236,6 +2236,28 @@
       .Test(xnn_qs8_vmul_minmax_fp32_ukernel__rvv_u1v, xnn_init_qs8_mul_minmax_fp32_scalar_params, xnn_qs8_requantize_fp32);
   }
 
+  TEST(QS8_VMUL_MINMAX_FP32__RVV_U1V, batch_div_1v) {
+    TEST_REQUIRES_RISCV_VECTOR;
+    for (size_t batch_size = 2 * xnn_init_hardware_config()->vlenb / sizeof(int8_t);
+                batch_size < 10 * xnn_init_hardware_config()->vlenb / sizeof(int8_t);
+                batch_size += 1 * xnn_init_hardware_config()->vlenb / sizeof(int8_t)) {
+      VBinaryMicrokernelTester()
+        .batch_size(batch_size)
+        .Test(xnn_qs8_vmul_minmax_fp32_ukernel__rvv_u1v, xnn_init_qs8_mul_minmax_fp32_scalar_params, xnn_qs8_requantize_fp32);
+    }
+  }
+
+  TEST(QS8_VMUL_MINMAX_FP32__RVV_U1V, batch_lt_1v) {
+    TEST_REQUIRES_RISCV_VECTOR;
+    for (size_t batch_size = 1 * xnn_init_hardware_config()->vlenb / sizeof(int8_t);
+                batch_size < 1 * xnn_init_hardware_config()->vlenb / sizeof(int8_t);
+                batch_size++) {
+      VBinaryMicrokernelTester()
+        .batch_size(batch_size)
+        .Test(xnn_qs8_vmul_minmax_fp32_ukernel__rvv_u1v, xnn_init_qs8_mul_minmax_fp32_scalar_params, xnn_qs8_requantize_fp32);
+    }
+  }
+
   TEST(QS8_VMUL_MINMAX_FP32__RVV_U1V, batch_gt_1v) {
     TEST_REQUIRES_RISCV_VECTOR;
     for (size_t batch_size = 2 * xnn_init_hardware_config()->vlenb / sizeof(int8_t);

--- a/test/qs8-vmulc-minmax-fp32.cc
+++ b/test/qs8-vmulc-minmax-fp32.cc
@@ -1946,6 +1946,28 @@
       .Test(xnn_qs8_vmulc_minmax_fp32_ukernel__rvv_u1v, xnn_init_qs8_mul_minmax_fp32_scalar_params, xnn_qs8_requantize_fp32);
   }
 
+  TEST(QS8_VMULC_MINMAX_FP32__RVV_U1V, batch_div_1v) {
+    TEST_REQUIRES_RISCV_VECTOR;
+    for (size_t batch_size = 2 * xnn_init_hardware_config()->vlenb / sizeof(int8_t);
+                batch_size < 10 * xnn_init_hardware_config()->vlenb / sizeof(int8_t);
+                batch_size += 1 * xnn_init_hardware_config()->vlenb / sizeof(int8_t)) {
+      VBinaryCMicrokernelTester()
+        .batch_size(batch_size)
+        .Test(xnn_qs8_vmulc_minmax_fp32_ukernel__rvv_u1v, xnn_init_qs8_mul_minmax_fp32_scalar_params, xnn_qs8_requantize_fp32);
+    }
+  }
+
+  TEST(QS8_VMULC_MINMAX_FP32__RVV_U1V, batch_lt_1v) {
+    TEST_REQUIRES_RISCV_VECTOR;
+    for (size_t batch_size = 1 * xnn_init_hardware_config()->vlenb / sizeof(int8_t);
+                batch_size < 1 * xnn_init_hardware_config()->vlenb / sizeof(int8_t);
+                batch_size++) {
+      VBinaryCMicrokernelTester()
+        .batch_size(batch_size)
+        .Test(xnn_qs8_vmulc_minmax_fp32_ukernel__rvv_u1v, xnn_init_qs8_mul_minmax_fp32_scalar_params, xnn_qs8_requantize_fp32);
+    }
+  }
+
   TEST(QS8_VMULC_MINMAX_FP32__RVV_U1V, batch_gt_1v) {
     TEST_REQUIRES_RISCV_VECTOR;
     for (size_t batch_size = 2 * xnn_init_hardware_config()->vlenb / sizeof(int8_t);

--- a/test/qu8-vmul-minmax-fp32.cc
+++ b/test/qu8-vmul-minmax-fp32.cc
@@ -2236,6 +2236,28 @@
       .Test(xnn_qu8_vmul_minmax_fp32_ukernel__rvv_u1v, xnn_init_qu8_mul_minmax_fp32_scalar_params, xnn_qu8_requantize_fp32);
   }
 
+  TEST(QU8_VMUL_MINMAX_FP32__RVV_U1V, batch_div_1v) {
+    TEST_REQUIRES_RISCV_VECTOR;
+    for (size_t batch_size = 2 * xnn_init_hardware_config()->vlenb / sizeof(uint8_t);
+                batch_size < 10 * xnn_init_hardware_config()->vlenb / sizeof(uint8_t);
+                batch_size += 1 * xnn_init_hardware_config()->vlenb / sizeof(uint8_t)) {
+      VBinaryMicrokernelTester()
+        .batch_size(batch_size)
+        .Test(xnn_qu8_vmul_minmax_fp32_ukernel__rvv_u1v, xnn_init_qu8_mul_minmax_fp32_scalar_params, xnn_qu8_requantize_fp32);
+    }
+  }
+
+  TEST(QU8_VMUL_MINMAX_FP32__RVV_U1V, batch_lt_1v) {
+    TEST_REQUIRES_RISCV_VECTOR;
+    for (size_t batch_size = 1 * xnn_init_hardware_config()->vlenb / sizeof(uint8_t);
+                batch_size < 1 * xnn_init_hardware_config()->vlenb / sizeof(uint8_t);
+                batch_size++) {
+      VBinaryMicrokernelTester()
+        .batch_size(batch_size)
+        .Test(xnn_qu8_vmul_minmax_fp32_ukernel__rvv_u1v, xnn_init_qu8_mul_minmax_fp32_scalar_params, xnn_qu8_requantize_fp32);
+    }
+  }
+
   TEST(QU8_VMUL_MINMAX_FP32__RVV_U1V, batch_gt_1v) {
     TEST_REQUIRES_RISCV_VECTOR;
     for (size_t batch_size = 2 * xnn_init_hardware_config()->vlenb / sizeof(uint8_t);

--- a/test/qu8-vmulc-minmax-fp32.cc
+++ b/test/qu8-vmulc-minmax-fp32.cc
@@ -1946,6 +1946,28 @@
       .Test(xnn_qu8_vmulc_minmax_fp32_ukernel__rvv_u1v, xnn_init_qu8_mul_minmax_fp32_scalar_params, xnn_qu8_requantize_fp32);
   }
 
+  TEST(QU8_VMULC_MINMAX_FP32__RVV_U1V, batch_div_1v) {
+    TEST_REQUIRES_RISCV_VECTOR;
+    for (size_t batch_size = 2 * xnn_init_hardware_config()->vlenb / sizeof(uint8_t);
+                batch_size < 10 * xnn_init_hardware_config()->vlenb / sizeof(uint8_t);
+                batch_size += 1 * xnn_init_hardware_config()->vlenb / sizeof(uint8_t)) {
+      VBinaryCMicrokernelTester()
+        .batch_size(batch_size)
+        .Test(xnn_qu8_vmulc_minmax_fp32_ukernel__rvv_u1v, xnn_init_qu8_mul_minmax_fp32_scalar_params, xnn_qu8_requantize_fp32);
+    }
+  }
+
+  TEST(QU8_VMULC_MINMAX_FP32__RVV_U1V, batch_lt_1v) {
+    TEST_REQUIRES_RISCV_VECTOR;
+    for (size_t batch_size = 1 * xnn_init_hardware_config()->vlenb / sizeof(uint8_t);
+                batch_size < 1 * xnn_init_hardware_config()->vlenb / sizeof(uint8_t);
+                batch_size++) {
+      VBinaryCMicrokernelTester()
+        .batch_size(batch_size)
+        .Test(xnn_qu8_vmulc_minmax_fp32_ukernel__rvv_u1v, xnn_init_qu8_mul_minmax_fp32_scalar_params, xnn_qu8_requantize_fp32);
+    }
+  }
+
   TEST(QU8_VMULC_MINMAX_FP32__RVV_U1V, batch_gt_1v) {
     TEST_REQUIRES_RISCV_VECTOR;
     for (size_t batch_size = 2 * xnn_init_hardware_config()->vlenb / sizeof(uint8_t);

--- a/test/x32-packw.cc
+++ b/test/x32-packw.cc
@@ -8425,6 +8425,34 @@ TEST(X32_PACKW_GEMM_GOI_X16__SCALAR_INT_U4, null_bias) {
     }
   }
 
+  TEST(X32_PACKW_GEMM_GOI_X1V__RVV_U2, n_div_1v) {
+    TEST_REQUIRES_RISCV_VECTOR;
+    for (size_t k = 1; k < 4; k++) {
+      PackWMicrokernelTester()
+        .n(2 * xnn_init_hardware_config()->vlenb / sizeof(uint32_t))
+        .k(k)
+        .nr(1 * xnn_init_hardware_config()->vlenb / sizeof(uint32_t))
+        .kr(1)
+        .sr(1)
+        .Test(xnn_x32_packw_gemm_goi_ukernel_x1v__rvv_u2);
+    }
+  }
+
+  TEST(X32_PACKW_GEMM_GOI_X1V__RVV_U2, n_lt_1v) {
+    TEST_REQUIRES_RISCV_VECTOR;
+    for (size_t k = 1; k < 4; k++) {
+      for (size_t n = 1; n < 1 * xnn_init_hardware_config()->vlenb / sizeof(uint32_t); n++) {
+        PackWMicrokernelTester()
+          .n(n)
+          .k(k)
+          .nr(1 * xnn_init_hardware_config()->vlenb / sizeof(uint32_t))
+          .kr(1)
+          .sr(1)
+          .Test(xnn_x32_packw_gemm_goi_ukernel_x1v__rvv_u2);
+      }
+    }
+  }
+
   TEST(X32_PACKW_GEMM_GOI_X1V__RVV_U2, n_gt_1v) {
     TEST_REQUIRES_RISCV_VECTOR;
     for (size_t k = 1; k < 4; k++) {
@@ -8547,6 +8575,34 @@ TEST(X32_PACKW_GEMM_GOI_X16__SCALAR_INT_U4, null_bias) {
     }
   }
 
+  TEST(X32_PACKW_GEMM_GOI_X1V__RVV_U4, n_div_1v) {
+    TEST_REQUIRES_RISCV_VECTOR;
+    for (size_t k = 1; k < 8; k++) {
+      PackWMicrokernelTester()
+        .n(2 * xnn_init_hardware_config()->vlenb / sizeof(uint32_t))
+        .k(k)
+        .nr(1 * xnn_init_hardware_config()->vlenb / sizeof(uint32_t))
+        .kr(1)
+        .sr(1)
+        .Test(xnn_x32_packw_gemm_goi_ukernel_x1v__rvv_u4);
+    }
+  }
+
+  TEST(X32_PACKW_GEMM_GOI_X1V__RVV_U4, n_lt_1v) {
+    TEST_REQUIRES_RISCV_VECTOR;
+    for (size_t k = 1; k < 8; k++) {
+      for (size_t n = 1; n < 1 * xnn_init_hardware_config()->vlenb / sizeof(uint32_t); n++) {
+        PackWMicrokernelTester()
+          .n(n)
+          .k(k)
+          .nr(1 * xnn_init_hardware_config()->vlenb / sizeof(uint32_t))
+          .kr(1)
+          .sr(1)
+          .Test(xnn_x32_packw_gemm_goi_ukernel_x1v__rvv_u4);
+      }
+    }
+  }
+
   TEST(X32_PACKW_GEMM_GOI_X1V__RVV_U4, n_gt_1v) {
     TEST_REQUIRES_RISCV_VECTOR;
     for (size_t k = 1; k < 8; k++) {
@@ -8666,6 +8722,34 @@ TEST(X32_PACKW_GEMM_GOI_X16__SCALAR_INT_U4, null_bias) {
         .kr(1)
         .sr(1)
         .Test(xnn_x32_packw_gemm_goi_ukernel_x1v__rvv_u8);
+    }
+  }
+
+  TEST(X32_PACKW_GEMM_GOI_X1V__RVV_U8, n_div_1v) {
+    TEST_REQUIRES_RISCV_VECTOR;
+    for (size_t k = 1; k < 16; k++) {
+      PackWMicrokernelTester()
+        .n(2 * xnn_init_hardware_config()->vlenb / sizeof(uint32_t))
+        .k(k)
+        .nr(1 * xnn_init_hardware_config()->vlenb / sizeof(uint32_t))
+        .kr(1)
+        .sr(1)
+        .Test(xnn_x32_packw_gemm_goi_ukernel_x1v__rvv_u8);
+    }
+  }
+
+  TEST(X32_PACKW_GEMM_GOI_X1V__RVV_U8, n_lt_1v) {
+    TEST_REQUIRES_RISCV_VECTOR;
+    for (size_t k = 1; k < 16; k++) {
+      for (size_t n = 1; n < 1 * xnn_init_hardware_config()->vlenb / sizeof(uint32_t); n++) {
+        PackWMicrokernelTester()
+          .n(n)
+          .k(k)
+          .nr(1 * xnn_init_hardware_config()->vlenb / sizeof(uint32_t))
+          .kr(1)
+          .sr(1)
+          .Test(xnn_x32_packw_gemm_goi_ukernel_x1v__rvv_u8);
+      }
     }
   }
 

--- a/tools/generate-packw-test.py
+++ b/tools/generate-packw-test.py
@@ -129,7 +129,7 @@ TEST(${TEST_NAME}, n_eq_${NR}${NR_SUFFIX}) {
   }
 }
 
-$if NR > 1:
+$if NR > 1 or NR_SCALE != "":
   TEST(${TEST_NAME}, n_div_${NR}${NR_SUFFIX}) {
     $if ISA_CHECK:
       ${ISA_CHECK};

--- a/tools/generate-raddstoreexpminusmax-test.py
+++ b/tools/generate-raddstoreexpminusmax-test.py
@@ -46,7 +46,7 @@ TEST(${TEST_NAME}, elements_eq_${ELEMENTS_TILE}${ELEMENTS_SUFFIX}) {
     .Test(${TEST_FUNCTION}, ${INIT_FUNCTION});
 }
 
-$if ELEMENTS_TILE > 1:
+$if ELEMENTS_TILE > 1 or ELEMENTS_SCALE != "":
   TEST(${TEST_NAME}, elements_div_${ELEMENTS_TILE}${ELEMENTS_SUFFIX}) {
     $if ISA_CHECK:
       ${ISA_CHECK};

--- a/tools/generate-vbinary-test.py
+++ b/tools/generate-vbinary-test.py
@@ -81,7 +81,7 @@ TEST(${TEST_NAME}, batch_eq_${BATCH_TILE}${BATCH_SUFFIX}) {
     .Test(${", ".join(TEST_ARGS)});
 }
 
-$if BATCH_TILE > 1:
+$if BATCH_TILE > 1 or BATCH_SCALE != "":
   TEST(${TEST_NAME}, batch_div_${BATCH_TILE}${BATCH_SUFFIX}) {
     $if ISA_CHECK:
       ${ISA_CHECK};

--- a/tools/generate-vunary-test.py
+++ b/tools/generate-vunary-test.py
@@ -98,7 +98,7 @@ TEST(${TEST_NAME}, batch_eq_${BATCH_TILE}${BATCH_SUFFIX}) {
     .Test(${", ".join(TEST_ARGS)});
 }
 
-$if BATCH_TILE > 1:
+$if BATCH_TILE > 1 or BATCH_SCALE != "":
   TEST(${TEST_NAME}, batch_div_${BATCH_TILE}${BATCH_SUFFIX}) {
     $if ISA_CHECK:
       ${ISA_CHECK};


### PR DESCRIPTION
Update test scripts of packw, raddstoreexpminusmax, vbinary and vunary. The change will include the test cases for LMUL size 1.