### PR TITLE
Update test and benchmark generation for blockwise kr>2

### DIFF
--- a/bench/qd8-f16-qb4w-gemm.cc
+++ b/bench/qd8-f16-qb4w-gemm.cc
@@ -7,14 +7,16 @@
 //   Specification: test/qd8-f16-qb4w-gemm-minmax.yaml
 //   Generator: tools/generate-gemm-test.py
 
-#include <benchmark/benchmark.h>
-#include "bench/gemm-benchmark.h"
-#include "bench/utils.h"
-
+#include <xnnpack/common.h>
 #include <xnnpack/isa-checks.h>
 #include <xnnpack/gemm.h>
 #include <xnnpack/microfnptr.h>
 #include <xnnpack/microparams-init.h>
+#include <xnnpack/pack.h>
+
+#include <benchmark/benchmark.h>
+#include "bench/gemm-benchmark.h"
+#include "bench/utils.h"
 
 
 static void qd8_f16_qb4w_gemm_minmax_ukernel_1x2__scalar(benchmark::State& state, const char* net) {

--- a/bench/qd8-f32-qb4w-gemm.cc
+++ b/bench/qd8-f32-qb4w-gemm.cc
@@ -7,14 +7,16 @@
 //   Specification: test/qd8-f32-qb4w-gemm-minmax.yaml
 //   Generator: tools/generate-gemm-test.py
 
-#include <benchmark/benchmark.h>
-#include "bench/gemm-benchmark.h"
-#include "bench/utils.h"
-
+#include <xnnpack/common.h>
 #include <xnnpack/isa-checks.h>
 #include <xnnpack/gemm.h>
 #include <xnnpack/microfnptr.h>
 #include <xnnpack/microparams-init.h>
+#include <xnnpack/pack.h>
+
+#include <benchmark/benchmark.h>
+#include "bench/gemm-benchmark.h"
+#include "bench/utils.h"
 
 
 static void qd8_f32_qb4w_gemm_minmax_ukernel_1x2__scalar(benchmark::State& state, const char* net) {

--- a/scripts/generate-tests.sh
+++ b/scripts/generate-tests.sh
@@ -75,9 +75,11 @@ tools/generate-gemm-test.py --spec test/qu8-gemm-minmax-fp32.yaml --output-test 
 tools/generate-gemm-test.py --spec test/qu8-gemm-minmax-rndnu.yaml --output-test test/qu8-gemm-minmax-rndnu.cc --output-test test/qu8-gemm-minmax-rndnu-2.cc --output-bench bench/qu8-gemm-rndnu.cc &
 
 tools/generate-gemm-test.py --spec test/qd8-f16-qc4w-gemm-minmax.yaml --output-test test/qd8-f16-qc4w-gemm-minmax.cc  --output-test test/qd8-f16-qc4w-gemm-minmax-2.cc  --output-test test/qd8-f16-qc4w-gemm-minmax-3.cc  --output-test test/qd8-f16-qc4w-gemm-minmax-4.cc --output-bench bench/qd8-f16-qc4w-gemm.cc &
+tools/generate-gemm-test.py --spec test/qd8-f16-qb4w-gemm-minmax.yaml --output-test test/qd8-f16-qb4w-gemm-minmax.cc --output-bench bench/qd8-f16-qb4w-gemm.cc &
 tools/generate-gemm-test.py --spec test/qd8-f16-qc8w-gemm-minmax.yaml --output-test test/qd8-f16-qc8w-gemm-minmax.cc --output-test test/qd8-f16-qc8w-gemm-minmax-2.cc --output-test test/qd8-f16-qc8w-gemm-minmax-3.cc --output-test test/qd8-f16-qc8w-gemm-minmax-4.cc --output-bench bench/qd8-f16-qc8w-gemm.cc &
 tools/generate-gemm-test.py --spec test/qd8-f32-qc8w-gemm-minmax.yaml --output-test test/qd8-f32-qc8w-gemm-minmax.cc  --output-test test/qd8-f32-qc8w-gemm-minmax-2.cc  --output-test test/qd8-f32-qc8w-gemm-minmax-3.cc  --output-test test/qd8-f32-qc8w-gemm-minmax-4.cc --output-bench bench/qd8-f32-qc8w-gemm.cc &
 tools/generate-gemm-test.py --spec test/qd8-f32-qc4w-gemm-minmax.yaml --output-test test/qd8-f32-qc4w-gemm-minmax.cc  --output-test test/qd8-f32-qc4w-gemm-minmax-2.cc  --output-test test/qd8-f32-qc4w-gemm-minmax-3.cc  --output-test test/qd8-f32-qc4w-gemm-minmax-4.cc --output-bench bench/qd8-f32-qc4w-gemm.cc &
+tools/generate-gemm-test.py --spec test/qd8-f32-qb4w-gemm-minmax.yaml --output-test test/qd8-f32-qb4w-gemm-minmax.cc --output-bench bench/qd8-f32-qb4w-gemm.cc &
 
 tools/generate-gemm-test.py --spec test/qp8-f32-qc4w-gemm-minmax.yaml --output-test test/qp8-f32-qc4w-gemm-minmax.cc --output-bench bench/qp8-f32-qc4w-gemm.cc &
 

--- a/test/gemm-microkernel-tester.cc
+++ b/test/gemm-microkernel-tester.cc
@@ -52,27 +52,27 @@ TEST_P(GemmTest, Test) {
 
   // Loop over the `k`, `m`, and `n` values, if required.
   for (size_t k = params.loop_k_.from; k <= params.loop_k_.to;
-       k = NextPrime(k + params.loop_k_.step)) {
+       k = params.loop_k_.next(k)) {
     if (params.loop_k_.is_set) {
       tester.k(k);
     }
     for (size_t m = params.loop_m_.from; m <= params.loop_m_.to;
-         m += params.loop_m_.step) {
+         m = params.loop_m_.next(m)) {
       if (params.loop_m_.is_set) {
         tester.m(m);
       }
       for (size_t n = params.loop_n_.from; n <= params.loop_n_.to;
-           n  = NextPrime(n + params.loop_n_.step)) {
+           n = params.loop_n_.next(n)) {
         if (params.loop_n_.is_set) {
           tester.n(n);
         }
         for (size_t zi = params.loop_zi_.from; zi <= params.loop_zi_.to;
-             zi += params.loop_zi_.step) {
+             zi = params.loop_zi_.next(zi)) {
           if (params.loop_zi_.is_set) {
             tester.zero_index(zi);
           }
           for (size_t bzp = params.loop_bzp_.from; bzp <= params.loop_bzp_.to;
-               bzp += params.loop_bzp_.step) {
+               bzp = params.loop_bzp_.next(bzp)) {
             if (params.loop_bzp_.is_set) {
               tester.b_zero_point(bzp);
             }

--- a/test/gemm-microkernel-tester.h
+++ b/test/gemm-microkernel-tester.h
@@ -10,6 +10,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <functional>
 #include <string>
 
@@ -32,6 +33,25 @@
 #include <xnnpack/post-operation.h>
 #endif  // XNN_PLATFORM_JIT
 
+inline bool IsPrime(size_t n) {
+    if (n == 1 || n == 2) {
+      return true;
+    }
+    for (size_t k = 3; k * k <= n; k += 2) {
+      if (n % k == 0) {
+        return false;
+      }
+    }
+    return true;
+}
+
+inline size_t NextPrime(size_t n) {
+    n = (n + 1) | static_cast<size_t>(1);
+    while (!IsPrime(n)) {
+      n++;
+    }
+    return n;
+}
 
 class GemmMicrokernelTester {
  public:
@@ -496,14 +516,32 @@ class GemmMicrokernelTester {
   bool relu_{false};
 };
 
+enum class LoopStepType {
+  Linear,
+  NextPrime
+};
+
 struct LoopParams {
   LoopParams() = default;
-  explicit LoopParams(size_t from, size_t to, size_t step)
-      : is_set(true), from(from), to(to), step(step) {}
+  explicit LoopParams(size_t from, size_t to, size_t step, LoopStepType step_type)
+      : is_set(true), from(from), to(to), step(step), step_type(step_type) {}
   bool is_set = false;
   size_t from = 1;
   size_t to = 1;
   size_t step = 1;
+  LoopStepType step_type = LoopStepType::Linear;
+
+  size_t next(size_t n) const {
+    switch (step_type) {
+      case LoopStepType::Linear:
+        return n + step;
+      case LoopStepType::NextPrime:
+        return NextPrime(n + step);
+      default:
+        std::cerr << "Unknown loop step type " << static_cast<int>(step_type) << std::endl;
+        std::abort();
+    }
+  }
 };
 
 struct GemmTestParams {
@@ -516,28 +554,28 @@ struct GemmTestParams {
         isa_check(isa_check) {}
 
   // Setters for the loops over `k`, `m`, and `n`.
-  GemmTestParams& loop_k(size_t from, size_t to, size_t step = 1) {
-    loop_k_ = LoopParams(from, to, step);
+  GemmTestParams& loop_k(size_t from, size_t to, size_t step = 1, LoopStepType step_type = LoopStepType::NextPrime) {
+    loop_k_ = LoopParams(from, to, step, step_type);
     return *this;
   }
-  GemmTestParams& loop_m(size_t from, size_t to, size_t step = 1) {
-    loop_m_ = LoopParams(from, to, step);
+  GemmTestParams& loop_m(size_t from, size_t to, size_t step = 1, LoopStepType step_type = LoopStepType::Linear) {
+    loop_m_ = LoopParams(from, to, step, step_type);
     return *this;
   }
-  GemmTestParams& loop_n(size_t from, size_t to, size_t step = 1) {
-    loop_n_ = LoopParams(from, to, step);
+  GemmTestParams& loop_n(size_t from, size_t to, size_t step = 1, LoopStepType step_type = LoopStepType::NextPrime) {
+    loop_n_ = LoopParams(from, to, step, step_type);
     return *this;
   }
-  GemmTestParams& loop_zi(size_t from, size_t to, size_t step = 1) {
-    loop_zi_ = LoopParams(from, to, step);
+  GemmTestParams& loop_zi(size_t from, size_t to, size_t step = 1, LoopStepType step_type = LoopStepType::Linear) {
+    loop_zi_ = LoopParams(from, to, step, step_type);
     return *this;
   }
-  GemmTestParams& loop_bzp(size_t from, size_t to, size_t step = 1) {
-    loop_bzp_ = LoopParams(from, to, step);
+  GemmTestParams& loop_bzp(size_t from, size_t to, size_t step = 1, LoopStepType step_type = LoopStepType::Linear) {
+    loop_bzp_ = LoopParams(from, to, step, step_type);
     return *this;
   }
-  GemmTestParams& loop_bl(size_t from, size_t to, size_t step = 1) {
-    loop_bl_ = LoopParams(from, to, step);
+  GemmTestParams& loop_bl(size_t from, size_t to, size_t step = 1, LoopStepType step_type = LoopStepType::Linear) {
+    loop_bl_ = LoopParams(from, to, step, step_type);
     return *this;
   }
 
@@ -554,23 +592,3 @@ struct GemmTestParams {
 };
 
 using GemmTest = testing::TestWithParam<GemmTestParams>;
-
-inline bool IsPrime(size_t n) {
-    if (n == 1 || n == 2) {
-      return true;
-    }
-    for (size_t k = 3; k * k <= n; k += 2) {
-      if (n % k == 0) {
-        return false;
-      }
-    }
-    return true;
-}
-
-inline size_t NextPrime(size_t n) {
-    n = (n + 1) | static_cast<size_t>(1);
-    while (!IsPrime(n)) {
-      n++;
-    }
-    return n;
-}

--- a/test/qd8-f16-qb4w-gemm-minmax.cc
+++ b/test/qd8-f16-qb4w-gemm-minmax.cc
@@ -10,11 +10,6 @@
 //   Specification: test/qd8-f16-qb4w-gemm-minmax.yaml
 //   Generator: tools/generate-gemm-test.py
 
-#include <cstddef>
-#include <functional>
-#include <string>
-#include <vector>
-
 #include <xnnpack/allocator.h>
 #include <xnnpack/common.h>
 #include <xnnpack/gemm.h>
@@ -22,8 +17,14 @@
 #include <xnnpack/isa-checks.h>
 #include <xnnpack/microparams-init.h>
 #include <xnnpack/pack.h>
+#include <xnnpack/packw.h>
 #include <xnnpack/ppmm.h>
 #include <xnnpack/requantization.h>
+
+#include <cstddef>
+#include <functional>
+#include <string>
+#include <vector>
 
 #include "gemm-microkernel-tester.h"
 #include <gtest/gtest.h>
@@ -94,280 +95,13 @@ std::vector<GemmTestParams> CreateTests1(
           .bl(kr * sr * 2)
       , test_func, isa_check)
       .loop_n(1, nr));
-  if (k_block > 1) {
-    gemm_tests.push_back(GemmTestParams(
-        "k_lt_" + akbs,
-        GemmMicrokernelTester()
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr)
-            .b_zero_point(8)
-            .bl(kr * sr * 2)
-        , test_func, isa_check)
-        .loop_k(1, adj_k_block - 1));
-    if (!is_igemm) {
-      gemm_tests.push_back(GemmTestParams(
-          "k_lt_" + akbs + "_strided_a",
-          GemmMicrokernelTester()
-              .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr)
-              .a_stride(NextPrime(adj_k_block + 1))
-              .b_zero_point(8)
-              .bl(kr * sr * 2)
-          , test_func, isa_check)
-          .loop_k(1, adj_k_block - 1));
-    }
-    gemm_tests.push_back(GemmTestParams(
-        "k_lt_" + akbs + "_subtile",
-        GemmMicrokernelTester()
-            .mr(mr).nr(nr).kr(kr).sr(sr).iterations(1)
-            .b_zero_point(8)
-            .bl(kr * sr * 2)
-        , test_func, isa_check)
-        .loop_k(1, adj_k_block - 1)
-        .loop_n(1, nr)
-        .loop_m(1, mr));
-  }
-  gemm_tests.push_back(GemmTestParams(
-      "k_gt_" + akbs,
-      GemmMicrokernelTester()
-          .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr)
-          .b_zero_point(8)
-          .bl(kr * sr * 2)
-      , test_func, isa_check)
-      .loop_k(adj_k_block + 1, adj_k_block * 2 - 1, k_block));
-  if (is_igemm) {
-    gemm_tests.push_back(GemmTestParams(
-        "k_gt_" + akbs + "_strided_a",
-        GemmMicrokernelTester()
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr)
-            .a_stride(NextPrime(adj_k_block * 2 + 1))
-            .b_zero_point(8)
-          .bl(kr * sr * 2)
-      , test_func, isa_check)
-      .loop_k(adj_k_block + 1, adj_k_block * 2 - 1, k_block));
-  }
-  gemm_tests.push_back(GemmTestParams(
-      "k_gt_" + akbs + "_subtile",
-      GemmMicrokernelTester()
-          .mr(mr).nr(nr).kr(kr).sr(sr).iterations(1)
-          .b_zero_point(8)
-          .bl(kr * sr * 2)
-      , test_func, isa_check)
-      .loop_k(adj_k_block + 1, adj_k_block * 2 - 1, k_block)
-      .loop_n(1, nr)
-      .loop_m(1, mr));
-  if (k_block > 1) {
-    gemm_tests.push_back(GemmTestParams(
-        "k_div_" + kbs,
-        GemmMicrokernelTester()
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr)
-            .b_zero_point(8)
-            .bl(kr * sr * 2)
-        , test_func, isa_check)
-        .loop_k(adj_k_block + k_block, k_block * 5, k_block));
-    if (is_igemm) {
-      gemm_tests.push_back(GemmTestParams(
-          "k_div_" + kbs + "_strided_a",
-          GemmMicrokernelTester()
-              .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr)
-              .a_stride(NextPrime(k_block * 3 + 1))
-              .b_zero_point(8)
-              .bl(kr * sr * 2)
-          , test_func, isa_check)
-          .loop_k(adj_k_block + k_block, k_block * 3, k_block));
-    }
-    gemm_tests.push_back(GemmTestParams(
-        "k_div_" + kbs + "_subtile",
-        GemmMicrokernelTester()
-            .mr(mr).nr(nr).kr(kr).sr(sr).iterations(1)
-            .b_zero_point(8)
-            .bl(kr * sr * 2)
-        , test_func, isa_check)
-        .loop_k(adj_k_block + k_block, k_block * 5, k_block)
-        .loop_n(1, nr)
-        .loop_m(1, mr));
-  }
-  gemm_tests.push_back(GemmTestParams(
-      "n_gt_" + nrs,
-      GemmMicrokernelTester()
-          .mr(mr).nr(nr).kr(kr).sr(sr).m(mr)
-          .b_zero_point(8)
-          .bl(kr * sr * 2)
-      , test_func, isa_check)
-      .loop_n(nr + 1, nr * 2 - 1)
-      .loop_k(1, k_block * 3, k_block + 1));
-  gemm_tests.push_back(GemmTestParams(
-      "n_gt_" + nrs + "_strided_cn",
-      GemmMicrokernelTester()
-          .mr(mr).nr(nr).kr(kr).sr(sr).m(mr)
-          .cn_stride(NextPrime(nr + 1))
-          .b_zero_point(8)
-          .bl(kr * sr * 2)
-          .bl(kr * sr * 2)
-      , test_func, isa_check)
-      .loop_n(nr + 1, nr * 2 - 1)
-      .loop_k(1, k_block * 3, k_block + 1));
-  if (!is_igemm) {
-    gemm_tests.push_back(GemmTestParams(
-        "n_gt_" + nrs + "_strided_a",
-        GemmMicrokernelTester()
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr)
-            .a_stride(NextPrime(k_block * 3 + 1))
-            .b_zero_point(8)
-            .bl(kr * sr * 2)
-        , test_func, isa_check)
-        .loop_n(nr + 1, nr * 2 - 1)
-        .loop_k(1, k_block * 3, k_block));
-  }
-  gemm_tests.push_back(GemmTestParams(
-      "n_gt_" + nrs + "_subtile",
-      GemmMicrokernelTester()
-          .mr(mr).nr(nr).kr(kr).sr(sr).iterations(1)
-          .b_zero_point(8)
-          .bl(kr * sr * 2)
-      , test_func, isa_check)
-      .loop_n(nr + 1, nr * 2 - 1)
-      .loop_k(1, k_block * 3, k_block + 1)
-      .loop_m(1, mr));
-  gemm_tests.push_back(GemmTestParams(
-      "n_div_" + nrs,
-      GemmMicrokernelTester()
-          .mr(mr).nr(nr).kr(kr).sr(sr).m(mr)
-          .b_zero_point(8)
-          .bl(kr * sr * 2)
-      , test_func, isa_check)
-      .loop_n(nr * 2, nr * 3, nr)
-      .loop_k(1, k_block * 3, k_block + 1));
-  gemm_tests.push_back(GemmTestParams(
-      "n_div_" + nrs + "_strided_cn",
-      GemmMicrokernelTester()
-          .mr(mr).nr(nr).kr(kr).sr(sr).m(mr)
-          .cn_stride(NextPrime(nr + 1))
-          .b_zero_point(8)
-          .bl(kr * sr * 2)
-      , test_func, isa_check)
-      .loop_n(nr * 2, nr * 3, nr)
-      .loop_k(1, k_block * 3, k_block + 1));
-  if (!is_igemm) {
-    gemm_tests.push_back(GemmTestParams(
-        "n_div_" + nrs + "_strided_a",
-        GemmMicrokernelTester()
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr)
-            .a_stride(NextPrime(k_block * 3 + 1))
-            .b_zero_point(8)
-            .bl(kr * sr * 2)
-        , test_func, isa_check)
-        .loop_n(nr * 2, nr * 3, nr)
-        .loop_k(1, k_block * 3, k_block));
-  }
-  gemm_tests.push_back(GemmTestParams(
-      "n_div_" + nrs + "_subtile",
-      GemmMicrokernelTester()
-          .mr(mr).nr(nr).kr(kr).sr(sr).iterations(1)
-          .b_zero_point(8)
-          .bl(kr * sr * 2)
-      , test_func, isa_check)
-      .loop_n(nr * 2, nr * 3, nr)
-      .loop_k(1, k_block * 3, k_block + 1)
-      .loop_m(1, mr));
-  if (is_igemm) {
-    gemm_tests.push_back(GemmTestParams(
-        "small_kernel",
-        GemmMicrokernelTester()
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).ks(3)
-            .b_zero_point(8)
-            .bl(kr * sr * 2)
-        , test_func, isa_check)
-        .loop_k(1, k_block * 3, k_block + 1));
-    gemm_tests.push_back(GemmTestParams(
-        "small_kernel_subtile",
-        GemmMicrokernelTester()
-            .mr(mr).nr(nr).kr(kr).sr(sr).ks(3).iterations(1)
-            .b_zero_point(8)
-            .bl(kr * sr * 2)
-        , test_func, isa_check)
-        .loop_k(1, k_block * 3, k_block + 1)
-        .loop_n(1, nr)
-        .loop_m(1, mr));
-    gemm_tests.push_back(GemmTestParams(
-        "n_gt_" + nrs + "_small_kernel",
-        GemmMicrokernelTester()
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).ks(3)
-            .b_zero_point(8)
-            .bl(kr * sr * 2)
-        , test_func, isa_check)
-        .loop_n(nr + 1, nr * 2 - 1)
-        .loop_k(1, k_block * 3, k_block + 1));
-    gemm_tests.push_back(GemmTestParams(
-        "n_div_" + nrs + "_small_kernel",
-        GemmMicrokernelTester()
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).ks(3)
-            .b_zero_point(8)
-            .bl(kr * sr * 2)
-        , test_func, isa_check)
-        .loop_n(nr * 2, nr * 3, nr)
-        .loop_k(1, k_block * 3, k_block + 1));
-  }
-  gemm_tests.push_back(GemmTestParams(
-      "strided_cm_subtile",
-      GemmMicrokernelTester()
-          .mr(mr).nr(nr).kr(kr).sr(sr)
-          .cm_stride(NextPrime(nr + 1))
-          .iterations(1)
-          .b_zero_point(8)
-          .bl(kr * sr * 2)
-      , test_func, isa_check)
-      .loop_k(1, k_block * 3, k_block + 1)
-      .loop_n(1, nr)
-      .loop_m(1, mr));
-  if (is_igemm) {
-    gemm_tests.push_back(GemmTestParams(
-        "a_offset",
-        GemmMicrokernelTester()
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).ks(3)
-            .a_offset(NextPrime(mr * k_block * 3 + 1))
-            .b_zero_point(8)
-            .bl(kr * sr * 2)
-        , test_func, isa_check)
-        .loop_k(1, k_block * 3, k_block + 1));
-    gemm_tests.push_back(GemmTestParams(
-        "zero",
-        GemmMicrokernelTester()
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).ks(3)
-            .a_offset(NextPrime(mr * k_block * 3 + 1))
-            .b_zero_point(8)
-            .bl(kr * sr * 2)
-        , test_func, isa_check)
-        .loop_k(1, k_block * 3, k_block + 1)
-        .loop_zi(0, mr - 1));
-  }
-  gemm_tests.push_back(GemmTestParams(
-      "qmin",
-      GemmMicrokernelTester()
-          .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).k(k_block).qmin(128)
-          .b_zero_point(8)
-          .bl(kr * sr * 2)
-      , test_func, isa_check));
-  gemm_tests.push_back(GemmTestParams(
-      "qmax",
-      GemmMicrokernelTester()
-          .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).k(k_block).qmax(128)
-          .b_zero_point(8)
-          .bl(kr * sr * 2)
-      , test_func, isa_check));
-  gemm_tests.push_back(GemmTestParams(
-      "strided_cm",
-      GemmMicrokernelTester()
-          .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).k(k_block)
-          .cm_stride(NextPrime(nr + 1))
-          .b_zero_point(8)
-          .bl(kr * sr * 2)
-      , test_func, isa_check));
   gemm_tests.push_back(GemmTestParams(
       "bl",
       GemmMicrokernelTester()
           .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).k(k_block * 12)
           .b_zero_point(8)
       , test_func, isa_check)
-      .loop_k(k_block, k_block * 12, k_block)
+      .loop_k(k_block, k_block * 12, k_block, LoopStepType::Linear)
       .loop_bl(2 * kr * sr, k_block * 12, 2 * kr * sr));
 
   return gemm_tests;

--- a/test/qd8-f32-qb4w-gemm-minmax.cc
+++ b/test/qd8-f32-qb4w-gemm-minmax.cc
@@ -10,11 +10,6 @@
 //   Specification: test/qd8-f32-qb4w-gemm-minmax.yaml
 //   Generator: tools/generate-gemm-test.py
 
-#include <cstddef>
-#include <functional>
-#include <string>
-#include <vector>
-
 #include <xnnpack/allocator.h>
 #include <xnnpack/common.h>
 #include <xnnpack/gemm.h>
@@ -22,8 +17,14 @@
 #include <xnnpack/isa-checks.h>
 #include <xnnpack/microparams-init.h>
 #include <xnnpack/pack.h>
+#include <xnnpack/packw.h>
 #include <xnnpack/ppmm.h>
 #include <xnnpack/requantization.h>
+
+#include <cstddef>
+#include <functional>
+#include <string>
+#include <vector>
 
 #include "gemm-microkernel-tester.h"
 #include <gtest/gtest.h>
@@ -94,280 +95,13 @@ std::vector<GemmTestParams> CreateTests1(
           .bl(kr * sr * 2)
       , test_func, isa_check)
       .loop_n(1, nr));
-  if (k_block > 1) {
-    gemm_tests.push_back(GemmTestParams(
-        "k_lt_" + akbs,
-        GemmMicrokernelTester()
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr)
-            .b_zero_point(8)
-            .bl(kr * sr * 2)
-        , test_func, isa_check)
-        .loop_k(1, adj_k_block - 1));
-    if (!is_igemm) {
-      gemm_tests.push_back(GemmTestParams(
-          "k_lt_" + akbs + "_strided_a",
-          GemmMicrokernelTester()
-              .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr)
-              .a_stride(NextPrime(adj_k_block + 1))
-              .b_zero_point(8)
-              .bl(kr * sr * 2)
-          , test_func, isa_check)
-          .loop_k(1, adj_k_block - 1));
-    }
-    gemm_tests.push_back(GemmTestParams(
-        "k_lt_" + akbs + "_subtile",
-        GemmMicrokernelTester()
-            .mr(mr).nr(nr).kr(kr).sr(sr).iterations(1)
-            .b_zero_point(8)
-            .bl(kr * sr * 2)
-        , test_func, isa_check)
-        .loop_k(1, adj_k_block - 1)
-        .loop_n(1, nr)
-        .loop_m(1, mr));
-  }
-  gemm_tests.push_back(GemmTestParams(
-      "k_gt_" + akbs,
-      GemmMicrokernelTester()
-          .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr)
-          .b_zero_point(8)
-          .bl(kr * sr * 2)
-      , test_func, isa_check)
-      .loop_k(adj_k_block + 1, adj_k_block * 2 - 1, k_block));
-  if (is_igemm) {
-    gemm_tests.push_back(GemmTestParams(
-        "k_gt_" + akbs + "_strided_a",
-        GemmMicrokernelTester()
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr)
-            .a_stride(NextPrime(adj_k_block * 2 + 1))
-            .b_zero_point(8)
-          .bl(kr * sr * 2)
-      , test_func, isa_check)
-      .loop_k(adj_k_block + 1, adj_k_block * 2 - 1, k_block));
-  }
-  gemm_tests.push_back(GemmTestParams(
-      "k_gt_" + akbs + "_subtile",
-      GemmMicrokernelTester()
-          .mr(mr).nr(nr).kr(kr).sr(sr).iterations(1)
-          .b_zero_point(8)
-          .bl(kr * sr * 2)
-      , test_func, isa_check)
-      .loop_k(adj_k_block + 1, adj_k_block * 2 - 1, k_block)
-      .loop_n(1, nr)
-      .loop_m(1, mr));
-  if (k_block > 1) {
-    gemm_tests.push_back(GemmTestParams(
-        "k_div_" + kbs,
-        GemmMicrokernelTester()
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr)
-            .b_zero_point(8)
-            .bl(kr * sr * 2)
-        , test_func, isa_check)
-        .loop_k(adj_k_block + k_block, k_block * 5, k_block));
-    if (is_igemm) {
-      gemm_tests.push_back(GemmTestParams(
-          "k_div_" + kbs + "_strided_a",
-          GemmMicrokernelTester()
-              .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr)
-              .a_stride(NextPrime(k_block * 3 + 1))
-              .b_zero_point(8)
-              .bl(kr * sr * 2)
-          , test_func, isa_check)
-          .loop_k(adj_k_block + k_block, k_block * 3, k_block));
-    }
-    gemm_tests.push_back(GemmTestParams(
-        "k_div_" + kbs + "_subtile",
-        GemmMicrokernelTester()
-            .mr(mr).nr(nr).kr(kr).sr(sr).iterations(1)
-            .b_zero_point(8)
-            .bl(kr * sr * 2)
-        , test_func, isa_check)
-        .loop_k(adj_k_block + k_block, k_block * 5, k_block)
-        .loop_n(1, nr)
-        .loop_m(1, mr));
-  }
-  gemm_tests.push_back(GemmTestParams(
-      "n_gt_" + nrs,
-      GemmMicrokernelTester()
-          .mr(mr).nr(nr).kr(kr).sr(sr).m(mr)
-          .b_zero_point(8)
-          .bl(kr * sr * 2)
-      , test_func, isa_check)
-      .loop_n(nr + 1, nr * 2 - 1)
-      .loop_k(1, k_block * 3, k_block + 1));
-  gemm_tests.push_back(GemmTestParams(
-      "n_gt_" + nrs + "_strided_cn",
-      GemmMicrokernelTester()
-          .mr(mr).nr(nr).kr(kr).sr(sr).m(mr)
-          .cn_stride(NextPrime(nr + 1))
-          .b_zero_point(8)
-          .bl(kr * sr * 2)
-          .bl(kr * sr * 2)
-      , test_func, isa_check)
-      .loop_n(nr + 1, nr * 2 - 1)
-      .loop_k(1, k_block * 3, k_block + 1));
-  if (!is_igemm) {
-    gemm_tests.push_back(GemmTestParams(
-        "n_gt_" + nrs + "_strided_a",
-        GemmMicrokernelTester()
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr)
-            .a_stride(NextPrime(k_block * 3 + 1))
-            .b_zero_point(8)
-            .bl(kr * sr * 2)
-        , test_func, isa_check)
-        .loop_n(nr + 1, nr * 2 - 1)
-        .loop_k(1, k_block * 3, k_block));
-  }
-  gemm_tests.push_back(GemmTestParams(
-      "n_gt_" + nrs + "_subtile",
-      GemmMicrokernelTester()
-          .mr(mr).nr(nr).kr(kr).sr(sr).iterations(1)
-          .b_zero_point(8)
-          .bl(kr * sr * 2)
-      , test_func, isa_check)
-      .loop_n(nr + 1, nr * 2 - 1)
-      .loop_k(1, k_block * 3, k_block + 1)
-      .loop_m(1, mr));
-  gemm_tests.push_back(GemmTestParams(
-      "n_div_" + nrs,
-      GemmMicrokernelTester()
-          .mr(mr).nr(nr).kr(kr).sr(sr).m(mr)
-          .b_zero_point(8)
-          .bl(kr * sr * 2)
-      , test_func, isa_check)
-      .loop_n(nr * 2, nr * 3, nr)
-      .loop_k(1, k_block * 3, k_block + 1));
-  gemm_tests.push_back(GemmTestParams(
-      "n_div_" + nrs + "_strided_cn",
-      GemmMicrokernelTester()
-          .mr(mr).nr(nr).kr(kr).sr(sr).m(mr)
-          .cn_stride(NextPrime(nr + 1))
-          .b_zero_point(8)
-          .bl(kr * sr * 2)
-      , test_func, isa_check)
-      .loop_n(nr * 2, nr * 3, nr)
-      .loop_k(1, k_block * 3, k_block + 1));
-  if (!is_igemm) {
-    gemm_tests.push_back(GemmTestParams(
-        "n_div_" + nrs + "_strided_a",
-        GemmMicrokernelTester()
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr)
-            .a_stride(NextPrime(k_block * 3 + 1))
-            .b_zero_point(8)
-            .bl(kr * sr * 2)
-        , test_func, isa_check)
-        .loop_n(nr * 2, nr * 3, nr)
-        .loop_k(1, k_block * 3, k_block));
-  }
-  gemm_tests.push_back(GemmTestParams(
-      "n_div_" + nrs + "_subtile",
-      GemmMicrokernelTester()
-          .mr(mr).nr(nr).kr(kr).sr(sr).iterations(1)
-          .b_zero_point(8)
-          .bl(kr * sr * 2)
-      , test_func, isa_check)
-      .loop_n(nr * 2, nr * 3, nr)
-      .loop_k(1, k_block * 3, k_block + 1)
-      .loop_m(1, mr));
-  if (is_igemm) {
-    gemm_tests.push_back(GemmTestParams(
-        "small_kernel",
-        GemmMicrokernelTester()
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).ks(3)
-            .b_zero_point(8)
-            .bl(kr * sr * 2)
-        , test_func, isa_check)
-        .loop_k(1, k_block * 3, k_block + 1));
-    gemm_tests.push_back(GemmTestParams(
-        "small_kernel_subtile",
-        GemmMicrokernelTester()
-            .mr(mr).nr(nr).kr(kr).sr(sr).ks(3).iterations(1)
-            .b_zero_point(8)
-            .bl(kr * sr * 2)
-        , test_func, isa_check)
-        .loop_k(1, k_block * 3, k_block + 1)
-        .loop_n(1, nr)
-        .loop_m(1, mr));
-    gemm_tests.push_back(GemmTestParams(
-        "n_gt_" + nrs + "_small_kernel",
-        GemmMicrokernelTester()
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).ks(3)
-            .b_zero_point(8)
-            .bl(kr * sr * 2)
-        , test_func, isa_check)
-        .loop_n(nr + 1, nr * 2 - 1)
-        .loop_k(1, k_block * 3, k_block + 1));
-    gemm_tests.push_back(GemmTestParams(
-        "n_div_" + nrs + "_small_kernel",
-        GemmMicrokernelTester()
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).ks(3)
-            .b_zero_point(8)
-            .bl(kr * sr * 2)
-        , test_func, isa_check)
-        .loop_n(nr * 2, nr * 3, nr)
-        .loop_k(1, k_block * 3, k_block + 1));
-  }
-  gemm_tests.push_back(GemmTestParams(
-      "strided_cm_subtile",
-      GemmMicrokernelTester()
-          .mr(mr).nr(nr).kr(kr).sr(sr)
-          .cm_stride(NextPrime(nr + 1))
-          .iterations(1)
-          .b_zero_point(8)
-          .bl(kr * sr * 2)
-      , test_func, isa_check)
-      .loop_k(1, k_block * 3, k_block + 1)
-      .loop_n(1, nr)
-      .loop_m(1, mr));
-  if (is_igemm) {
-    gemm_tests.push_back(GemmTestParams(
-        "a_offset",
-        GemmMicrokernelTester()
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).ks(3)
-            .a_offset(NextPrime(mr * k_block * 3 + 1))
-            .b_zero_point(8)
-            .bl(kr * sr * 2)
-        , test_func, isa_check)
-        .loop_k(1, k_block * 3, k_block + 1));
-    gemm_tests.push_back(GemmTestParams(
-        "zero",
-        GemmMicrokernelTester()
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).ks(3)
-            .a_offset(NextPrime(mr * k_block * 3 + 1))
-            .b_zero_point(8)
-            .bl(kr * sr * 2)
-        , test_func, isa_check)
-        .loop_k(1, k_block * 3, k_block + 1)
-        .loop_zi(0, mr - 1));
-  }
-  gemm_tests.push_back(GemmTestParams(
-      "qmin",
-      GemmMicrokernelTester()
-          .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).k(k_block).qmin(128)
-          .b_zero_point(8)
-          .bl(kr * sr * 2)
-      , test_func, isa_check));
-  gemm_tests.push_back(GemmTestParams(
-      "qmax",
-      GemmMicrokernelTester()
-          .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).k(k_block).qmax(128)
-          .b_zero_point(8)
-          .bl(kr * sr * 2)
-      , test_func, isa_check));
-  gemm_tests.push_back(GemmTestParams(
-      "strided_cm",
-      GemmMicrokernelTester()
-          .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).k(k_block)
-          .cm_stride(NextPrime(nr + 1))
-          .b_zero_point(8)
-          .bl(kr * sr * 2)
-      , test_func, isa_check));
   gemm_tests.push_back(GemmTestParams(
       "bl",
       GemmMicrokernelTester()
           .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).k(k_block * 12)
           .b_zero_point(8)
       , test_func, isa_check)
-      .loop_k(k_block, k_block * 12, k_block)
+      .loop_k(k_block, k_block * 12, k_block, LoopStepType::Linear)
       .loop_bl(2 * kr * sr, k_block * 12, 2 * kr * sr));
 
   return gemm_tests;

--- a/tools/generate-gemm-test.py
+++ b/tools/generate-gemm-test.py
@@ -244,464 +244,465 @@ std::vector<GemmTestParams> CreateTests(
         , test_func, isa_check)
         .loop_n(1, nr)
         .loop_m(1, mr));
-  if (k_block > 1) {
-    gemm_tests.push_back(GemmTestParams(
-        "k_lt_" + akbs,
-        GemmMicrokernelTester()
-            $if EXTENDED_WEIGHTS:
-              .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr)
-            $if KERNELTYPE in ['qb4w', 'qc4w']:
-              .b_zero_point(8)
-            $if KERNELTYPE in ['qb4w']:
-              .bl(kr * sr * 2)
-        , test_func, isa_check)
-        .loop_k(1, adj_k_block - 1));
-    if (!is_igemm) {
+  $if KERNELTYPE not in ['qb4w']:
+      if (k_block > 1) {
+        gemm_tests.push_back(GemmTestParams(
+            "k_lt_" + akbs,
+            GemmMicrokernelTester()
+                $if EXTENDED_WEIGHTS:
+                  .extended_weights(true)
+                .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr)
+                $if KERNELTYPE in ['qb4w', 'qc4w']:
+                  .b_zero_point(8)
+                $if KERNELTYPE in ['qb4w']:
+                  .bl(kr * sr * 2)
+            , test_func, isa_check)
+            .loop_k(1, adj_k_block - 1));
+        if (!is_igemm) {
+          gemm_tests.push_back(GemmTestParams(
+              "k_lt_" + akbs + "_strided_a",
+              GemmMicrokernelTester()
+                  $if EXTENDED_WEIGHTS:
+                    .extended_weights(true)
+                  .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr)
+                  .a_stride(NextPrime(adj_k_block + 1))
+                  $if KERNELTYPE in ['qb4w', 'qc4w']:
+                    .b_zero_point(8)
+                  $if KERNELTYPE in ['qb4w']:
+                    .bl(kr * sr * 2)
+              , test_func, isa_check)
+              .loop_k(1, adj_k_block - 1));
+        }
+        gemm_tests.push_back(GemmTestParams(
+            "k_lt_" + akbs + "_subtile",
+            GemmMicrokernelTester()
+                $if EXTENDED_WEIGHTS:
+                  .extended_weights(true)
+                .mr(mr).nr(nr).kr(kr).sr(sr).iterations(1)
+                $if KERNELTYPE in ['qb4w', 'qc4w']:
+                  .b_zero_point(8)
+                $if KERNELTYPE in ['qb4w']:
+                  .bl(kr * sr * 2)
+            , test_func, isa_check)
+            .loop_k(1, adj_k_block - 1)
+            .loop_n(1, nr)
+            .loop_m(1, mr));
+      }
       gemm_tests.push_back(GemmTestParams(
-          "k_lt_" + akbs + "_strided_a",
+          "k_gt_" + akbs,
           GemmMicrokernelTester()
               $if EXTENDED_WEIGHTS:
                 .extended_weights(true)
               .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr)
-              .a_stride(NextPrime(adj_k_block + 1))
               $if KERNELTYPE in ['qb4w', 'qc4w']:
                 .b_zero_point(8)
               $if KERNELTYPE in ['qb4w']:
                 .bl(kr * sr * 2)
           , test_func, isa_check)
-          .loop_k(1, adj_k_block - 1));
-    }
-    gemm_tests.push_back(GemmTestParams(
-        "k_lt_" + akbs + "_subtile",
-        GemmMicrokernelTester()
-            $if EXTENDED_WEIGHTS:
-              .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).iterations(1)
-            $if KERNELTYPE in ['qb4w', 'qc4w']:
-              .b_zero_point(8)
-            $if KERNELTYPE in ['qb4w']:
-              .bl(kr * sr * 2)
-        , test_func, isa_check)
-        .loop_k(1, adj_k_block - 1)
-        .loop_n(1, nr)
-        .loop_m(1, mr));
-  }
-  gemm_tests.push_back(GemmTestParams(
-      "k_gt_" + akbs,
-      GemmMicrokernelTester()
-          $if EXTENDED_WEIGHTS:
-            .extended_weights(true)
-          .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr)
-          $if KERNELTYPE in ['qb4w', 'qc4w']:
-            .b_zero_point(8)
-          $if KERNELTYPE in ['qb4w']:
-            .bl(kr * sr * 2)
-      , test_func, isa_check)
-      .loop_k(adj_k_block + 1, adj_k_block * 2 - 1, k_block));
-  if (is_igemm) {
-    gemm_tests.push_back(GemmTestParams(
-        "k_gt_" + akbs + "_strided_a",
-        GemmMicrokernelTester()
-            $if EXTENDED_WEIGHTS:
-              .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr)
-            .a_stride(NextPrime(adj_k_block * 2 + 1))
-            $if KERNELTYPE in ['qb4w', 'qc4w']:
-              .b_zero_point(8)
-          $if KERNELTYPE in ['qb4w']:
-            .bl(kr * sr * 2)
-      , test_func, isa_check)
-      .loop_k(adj_k_block + 1, adj_k_block * 2 - 1, k_block));
-  }
-  gemm_tests.push_back(GemmTestParams(
-      "k_gt_" + akbs + "_subtile",
-      GemmMicrokernelTester()
-          $if EXTENDED_WEIGHTS:
-            .extended_weights(true)
-          .mr(mr).nr(nr).kr(kr).sr(sr).iterations(1)
-          $if KERNELTYPE in ['qb4w', 'qc4w']:
-            .b_zero_point(8)
-          $if KERNELTYPE in ['qb4w']:
-            .bl(kr * sr * 2)
-      , test_func, isa_check)
-      .loop_k(adj_k_block + 1, adj_k_block * 2 - 1, k_block)
-      .loop_n(1, nr)
-      .loop_m(1, mr));
-  if (k_block > 1) {
-    gemm_tests.push_back(GemmTestParams(
-        "k_div_" + kbs,
-        GemmMicrokernelTester()
-            $if EXTENDED_WEIGHTS:
-              .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr)
-            $if KERNELTYPE in ['qb4w', 'qc4w']:
-              .b_zero_point(8)
-            $if KERNELTYPE in ['qb4w']:
-              .bl(kr * sr * 2)
-        , test_func, isa_check)
-        .loop_k(adj_k_block + k_block, k_block * 5, k_block));
-    if (is_igemm) {
+          .loop_k(adj_k_block + 1, adj_k_block * 2 - 1, k_block));
+      if (is_igemm) {
+        gemm_tests.push_back(GemmTestParams(
+            "k_gt_" + akbs + "_strided_a",
+            GemmMicrokernelTester()
+                $if EXTENDED_WEIGHTS:
+                  .extended_weights(true)
+                .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr)
+                .a_stride(NextPrime(adj_k_block * 2 + 1))
+                $if KERNELTYPE in ['qb4w', 'qc4w']:
+                  .b_zero_point(8)
+              $if KERNELTYPE in ['qb4w']:
+                .bl(kr * sr * 2)
+          , test_func, isa_check)
+          .loop_k(adj_k_block + 1, adj_k_block * 2 - 1, k_block));
+      }
       gemm_tests.push_back(GemmTestParams(
-          "k_div_" + kbs + "_strided_a",
+          "k_gt_" + akbs + "_subtile",
           GemmMicrokernelTester()
               $if EXTENDED_WEIGHTS:
                 .extended_weights(true)
-              .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr)
-              .a_stride(NextPrime(k_block * 3 + 1))
+              .mr(mr).nr(nr).kr(kr).sr(sr).iterations(1)
               $if KERNELTYPE in ['qb4w', 'qc4w']:
                 .b_zero_point(8)
               $if KERNELTYPE in ['qb4w']:
                 .bl(kr * sr * 2)
           , test_func, isa_check)
-          .loop_k(adj_k_block + k_block, k_block * 3, k_block));
-    }
-    gemm_tests.push_back(GemmTestParams(
-        "k_div_" + kbs + "_subtile",
-        GemmMicrokernelTester()
-            $if EXTENDED_WEIGHTS:
-              .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).iterations(1)
-            $if KERNELTYPE in ['qb4w', 'qc4w']:
-              .b_zero_point(8)
-            $if KERNELTYPE in ['qb4w']:
-              .bl(kr * sr * 2)
-        , test_func, isa_check)
-        .loop_k(adj_k_block + k_block, k_block * 5, k_block)
-        .loop_n(1, nr)
-        .loop_m(1, mr));
-  }
-  gemm_tests.push_back(GemmTestParams(
-      "n_gt_" + nrs,
-      GemmMicrokernelTester()
-          $if EXTENDED_WEIGHTS:
-            .extended_weights(true)
-          .mr(mr).nr(nr).kr(kr).sr(sr).m(mr)
-          $if KERNELTYPE in ['qb4w', 'qc4w']:
-            .b_zero_point(8)
-          $if KERNELTYPE in ['qb4w']:
-            .bl(kr * sr * 2)
-      , test_func, isa_check)
-      $if NR_SCALE != "":
-        .loop_n(nr + 1, nr * 2 - 1, 4)
-      $else:
-        .loop_n(nr + 1, nr * 2 - 1)
-      .loop_k(1, k_block * 3, k_block + 1));
-  $if JIT:
-    gemm_tests.push_back(GemmTestParams(
-        "unknown_nc_mod_nr",
-        GemmMicrokernelTester()
-            $if EXTENDED_WEIGHTS:
-              .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).known_nc_mod_nr(false)
-            $if KERNELTYPE in ['qb4w', 'qc4w']:
-              .b_zero_point(8)
-            $if KERNELTYPE in ['qb4w']:
-              .bl(kr * sr * 2)
-        , test_func, isa_check)
-        $if NR_SCALE != "":
-          .loop_n(1, nr * 2 - 1, 4)
-        $else:
-          .loop_n(1, nr * 2 - 1)
-        .loop_k(1, k_block * 3, k_block + 1));
-    gemm_tests.push_back(GemmTestParams(
-        "relu",
-        GemmMicrokernelTester()
-            $if EXTENDED_WEIGHTS:
-              .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).k(k_block).relu(true)
-            $if KERNELTYPE in ['qb4w', 'qc4w']:
-              .b_zero_point(8)
-            $if KERNELTYPE in ['qb4w']:
-              .bl(kr * sr * 2)
-        , test_func, isa_check));
-  $if DATATYPE != "qp8":
-    gemm_tests.push_back(GemmTestParams(
-        "n_gt_" + nrs + "_strided_cn",
-        GemmMicrokernelTester()
-            $if EXTENDED_WEIGHTS:
-              .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr)
-            .cn_stride(NextPrime(nr + 1))
-            $if KERNELTYPE in ['qb4w', 'qc4w']:
-              .b_zero_point(8)
-            $if KERNELTYPE in ['qb4w']:
-              .bl(kr * sr * 2)
-            $if KERNELTYPE in ['qb4w']:
-              .bl(kr * sr * 2)
-        , test_func, isa_check)
-        $if NR_SCALE != "":
-          .loop_n(nr + 1, nr * 2 - 1, 4)
-        $else:
-          .loop_n(nr + 1, nr * 2 - 1)
-        .loop_k(1, k_block * 3, k_block + 1));
-  if (!is_igemm) {
-    gemm_tests.push_back(GemmTestParams(
-        "n_gt_" + nrs + "_strided_a",
-        GemmMicrokernelTester()
-            $if EXTENDED_WEIGHTS:
-              .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr)
-            .a_stride(NextPrime(k_block * 3 + 1))
-            $if KERNELTYPE in ['qb4w', 'qc4w']:
-              .b_zero_point(8)
-            $if KERNELTYPE in ['qb4w']:
-              .bl(kr * sr * 2)
-        , test_func, isa_check)
-        $if NR_SCALE != "":
-          .loop_n(nr + 1, nr * 2 - 1, 4)
-        $else:
-          .loop_n(nr + 1, nr * 2 - 1)
-        .loop_k(1, k_block * 3, k_block));
-  }
-  gemm_tests.push_back(GemmTestParams(
-      "n_gt_" + nrs + "_subtile",
-      GemmMicrokernelTester()
-          $if EXTENDED_WEIGHTS:
-            .extended_weights(true)
-          .mr(mr).nr(nr).kr(kr).sr(sr).iterations(1)
-          $if KERNELTYPE in ['qb4w', 'qc4w']:
-            .b_zero_point(8)
-          $if KERNELTYPE in ['qb4w']:
-            .bl(kr * sr * 2)
-      , test_func, isa_check)
-      $if NR_SCALE != "":
-        .loop_n(nr + 1, nr * 2 - 1, 4)
-      $else:
-        .loop_n(nr + 1, nr * 2 - 1)
-      .loop_k(1, k_block * 3, k_block + 1)
-      .loop_m(1, mr));
-  gemm_tests.push_back(GemmTestParams(
-      "n_div_" + nrs,
-      GemmMicrokernelTester()
-          $if EXTENDED_WEIGHTS:
-            .extended_weights(true)
-          .mr(mr).nr(nr).kr(kr).sr(sr).m(mr)
-          $if KERNELTYPE in ['qb4w', 'qc4w']:
-            .b_zero_point(8)
-          $if KERNELTYPE in ['qb4w']:
-            .bl(kr * sr * 2)
-      , test_func, isa_check)
-      .loop_n(nr * 2, nr * 3, nr)
-      .loop_k(1, k_block * 3, k_block + 1));
-  $if DATATYPE != "qp8":
-    gemm_tests.push_back(GemmTestParams(
-        "n_div_" + nrs + "_strided_cn",
-        GemmMicrokernelTester()
-            $if EXTENDED_WEIGHTS:
-              .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr)
-            .cn_stride(NextPrime(nr + 1))
-            $if KERNELTYPE in ['qb4w', 'qc4w']:
-              .b_zero_point(8)
-            $if KERNELTYPE in ['qb4w']:
-              .bl(kr * sr * 2)
-        , test_func, isa_check)
-        .loop_n(nr * 2, nr * 3, nr)
-        .loop_k(1, k_block * 3, k_block + 1));
-  if (!is_igemm) {
-    gemm_tests.push_back(GemmTestParams(
-        "n_div_" + nrs + "_strided_a",
-        GemmMicrokernelTester()
-            $if EXTENDED_WEIGHTS:
-              .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr)
-            .a_stride(NextPrime(k_block * 3 + 1))
-            $if KERNELTYPE in ['qb4w', 'qc4w']:
-              .b_zero_point(8)
-            $if KERNELTYPE in ['qb4w']:
-              .bl(kr * sr * 2)
-        , test_func, isa_check)
-        .loop_n(nr * 2, nr * 3, nr)
-        .loop_k(1, k_block * 3, k_block));
-  }
-  gemm_tests.push_back(GemmTestParams(
-      "n_div_" + nrs + "_subtile",
-      GemmMicrokernelTester()
-          $if EXTENDED_WEIGHTS:
-            .extended_weights(true)
-          .mr(mr).nr(nr).kr(kr).sr(sr).iterations(1)
-          $if KERNELTYPE in ['qb4w', 'qc4w']:
-            .b_zero_point(8)
-          $if KERNELTYPE in ['qb4w']:
-            .bl(kr * sr * 2)
-      , test_func, isa_check)
-      .loop_n(nr * 2, nr * 3, nr)
-      .loop_k(1, k_block * 3, k_block + 1)
-      .loop_m(1, mr));
-  if (is_igemm) {
-    gemm_tests.push_back(GemmTestParams(
-        "small_kernel",
-        GemmMicrokernelTester()
-            $if EXTENDED_WEIGHTS:
-              .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).ks(3)
-            $if KERNELTYPE in ['qb4w', 'qc4w']:
-              .b_zero_point(8)
-            $if KERNELTYPE in ['qb4w']:
-              .bl(kr * sr * 2)
-        , test_func, isa_check)
-        .loop_k(1, k_block * 3, k_block + 1));
-    gemm_tests.push_back(GemmTestParams(
-        "small_kernel_subtile",
-        GemmMicrokernelTester()
-            $if EXTENDED_WEIGHTS:
-              .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).ks(3).iterations(1)
-            $if KERNELTYPE in ['qb4w', 'qc4w']:
-              .b_zero_point(8)
-            $if KERNELTYPE in ['qb4w']:
-              .bl(kr * sr * 2)
-        , test_func, isa_check)
-        .loop_k(1, k_block * 3, k_block + 1)
-        .loop_n(1, nr)
-        .loop_m(1, mr));
-    gemm_tests.push_back(GemmTestParams(
-        "n_gt_" + nrs + "_small_kernel",
-        GemmMicrokernelTester()
-            $if EXTENDED_WEIGHTS:
-              .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).ks(3)
-            $if KERNELTYPE in ['qb4w', 'qc4w']:
-              .b_zero_point(8)
-            $if KERNELTYPE in ['qb4w']:
-              .bl(kr * sr * 2)
-        , test_func, isa_check)
-        $if NR_SCALE != "":
-          .loop_n(nr + 1, nr * 2 - 1, 4)
-        $else:
-          .loop_n(nr + 1, nr * 2 - 1)
-        .loop_k(1, k_block * 3, k_block + 1));
-    gemm_tests.push_back(GemmTestParams(
-        "n_div_" + nrs + "_small_kernel",
-        GemmMicrokernelTester()
-            $if EXTENDED_WEIGHTS:
-              .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).ks(3)
-            $if KERNELTYPE in ['qb4w', 'qc4w']:
-              .b_zero_point(8)
-            $if KERNELTYPE in ['qb4w']:
-              .bl(kr * sr * 2)
-        , test_func, isa_check)
-        .loop_n(nr * 2, nr * 3, nr)
-        .loop_k(1, k_block * 3, k_block + 1));
-  }
-  gemm_tests.push_back(GemmTestParams(
-      "strided_cm_subtile",
-      GemmMicrokernelTester()
-          $if EXTENDED_WEIGHTS:
-            .extended_weights(true)
-          .mr(mr).nr(nr).kr(kr).sr(sr)
-          .cm_stride(NextPrime(nr + 1))
-          .iterations(1)
-          $if KERNELTYPE in ['qb4w', 'qc4w']:
-            .b_zero_point(8)
-          $if KERNELTYPE in ['qb4w']:
-            .bl(kr * sr * 2)
-      , test_func, isa_check)
-      .loop_k(1, k_block * 3, k_block + 1)
-      .loop_n(1, nr)
-      .loop_m(1, mr));
-  if (is_igemm) {
-    gemm_tests.push_back(GemmTestParams(
-        "a_offset",
-        GemmMicrokernelTester()
-            $if EXTENDED_WEIGHTS:
-              .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).ks(3)
-            .a_offset(NextPrime(mr * k_block * 3 + 1))
-            $if KERNELTYPE in ['qb4w', 'qc4w']:
-              .b_zero_point(8)
-            $if KERNELTYPE in ['qb4w']:
-              .bl(kr * sr * 2)
-        , test_func, isa_check)
-        .loop_k(1, k_block * 3, k_block + 1));
-    gemm_tests.push_back(GemmTestParams(
-        "zero",
-        GemmMicrokernelTester()
-            $if EXTENDED_WEIGHTS:
-              .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).ks(3)
-            .a_offset(NextPrime(mr * k_block * 3 + 1))
-            $if KERNELTYPE in ['qb4w', 'qc4w']:
-              .b_zero_point(8)
-            $if KERNELTYPE in ['qb4w']:
-              .bl(kr * sr * 2)
-        , test_func, isa_check)
-        .loop_k(1, k_block * 3, k_block + 1)
-        .loop_zi(0, mr - 1));
-  }
-  $if ACTIVATION == "MINMAX":
-    gemm_tests.push_back(GemmTestParams(
-        "qmin",
-        GemmMicrokernelTester()
-            $if EXTENDED_WEIGHTS:
-              .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).k(k_block).qmin(128)
-            $if KERNELTYPE in ['qb4w', 'qc4w']:
-              .b_zero_point(8)
-            $if KERNELTYPE in ['qb4w']:
-              .bl(kr * sr * 2)
-        , test_func, isa_check));
-    gemm_tests.push_back(GemmTestParams(
-        "qmax",
-        GemmMicrokernelTester()
-            $if EXTENDED_WEIGHTS:
-              .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).k(k_block).qmax(128)
-            $if KERNELTYPE in ['qb4w', 'qc4w']:
-              .b_zero_point(8)
-            $if KERNELTYPE in ['qb4w']:
-              .bl(kr * sr * 2)
-        , test_func, isa_check));
-  gemm_tests.push_back(GemmTestParams(
-      "strided_cm",
-      GemmMicrokernelTester()
-          $if EXTENDED_WEIGHTS:
-            .extended_weights(true)
-          .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).k(k_block)
-          .cm_stride(NextPrime(nr + 1))
-          $if KERNELTYPE in ['qb4w', 'qc4w']:
-            .b_zero_point(8)
-          $if KERNELTYPE in ['qb4w']:
-            .bl(kr * sr * 2)
-      , test_func, isa_check));
-  $if DATATYPE == "qu8":
-    gemm_tests.push_back(GemmTestParams(
-        "no_a_zero_point",
-        GemmMicrokernelTester()
-            $if EXTENDED_WEIGHTS:
-              .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).a_zero_point(0)
-        , test_func, isa_check)
-        .loop_k(1, k_block * 3, k_block + 1));
-  $if DATATYPE == "qu8":
-    gemm_tests.push_back(GemmTestParams(
-        "no_b_zero_point",
-        GemmMicrokernelTester()
-            $if EXTENDED_WEIGHTS:
-              .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).b_zero_point(0)
-        , test_func, isa_check)
-        .loop_k(1, k_block * 3, k_block + 1));
-    gemm_tests.push_back(GemmTestParams(
-        "b_zero_point",
-        GemmMicrokernelTester()
-            $if EXTENDED_WEIGHTS:
-              .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).k(k_block)
-        , test_func, isa_check)
-        .loop_bzp(0, 255));
-    gemm_tests.push_back(GemmTestParams(
-        "no_zero_point",
-        GemmMicrokernelTester()
-            $if EXTENDED_WEIGHTS:
-              .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr)
-            .a_zero_point(0)
-            .b_zero_point(0)
-        , test_func, isa_check)
-        .loop_k(1, k_block * 3, k_block + 1));
+          .loop_k(adj_k_block + 1, adj_k_block * 2 - 1, k_block)
+          .loop_n(1, nr)
+          .loop_m(1, mr));
+      if (k_block > 1) {
+        gemm_tests.push_back(GemmTestParams(
+            "k_div_" + kbs,
+            GemmMicrokernelTester()
+                $if EXTENDED_WEIGHTS:
+                  .extended_weights(true)
+                .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr)
+                $if KERNELTYPE in ['qb4w', 'qc4w']:
+                  .b_zero_point(8)
+                $if KERNELTYPE in ['qb4w']:
+                  .bl(kr * sr * 2)
+            , test_func, isa_check)
+            .loop_k(adj_k_block + k_block, k_block * 5, k_block));
+        if (is_igemm) {
+          gemm_tests.push_back(GemmTestParams(
+              "k_div_" + kbs + "_strided_a",
+              GemmMicrokernelTester()
+                  $if EXTENDED_WEIGHTS:
+                    .extended_weights(true)
+                  .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr)
+                  .a_stride(NextPrime(k_block * 3 + 1))
+                  $if KERNELTYPE in ['qb4w', 'qc4w']:
+                    .b_zero_point(8)
+                  $if KERNELTYPE in ['qb4w']:
+                    .bl(kr * sr * 2)
+              , test_func, isa_check)
+              .loop_k(adj_k_block + k_block, k_block * 3, k_block));
+        }
+        gemm_tests.push_back(GemmTestParams(
+            "k_div_" + kbs + "_subtile",
+            GemmMicrokernelTester()
+                $if EXTENDED_WEIGHTS:
+                  .extended_weights(true)
+                .mr(mr).nr(nr).kr(kr).sr(sr).iterations(1)
+                $if KERNELTYPE in ['qb4w', 'qc4w']:
+                  .b_zero_point(8)
+                $if KERNELTYPE in ['qb4w']:
+                  .bl(kr * sr * 2)
+            , test_func, isa_check)
+            .loop_k(adj_k_block + k_block, k_block * 5, k_block)
+            .loop_n(1, nr)
+            .loop_m(1, mr));
+      }
+      gemm_tests.push_back(GemmTestParams(
+          "n_gt_" + nrs,
+          GemmMicrokernelTester()
+              $if EXTENDED_WEIGHTS:
+                .extended_weights(true)
+              .mr(mr).nr(nr).kr(kr).sr(sr).m(mr)
+              $if KERNELTYPE in ['qb4w', 'qc4w']:
+                .b_zero_point(8)
+              $if KERNELTYPE in ['qb4w']:
+                .bl(kr * sr * 2)
+          , test_func, isa_check)
+          $if NR_SCALE != "":
+            .loop_n(nr + 1, nr * 2 - 1, 4)
+          $else:
+            .loop_n(nr + 1, nr * 2 - 1)
+          .loop_k(1, k_block * 3, k_block + 1));
+      $if JIT:
+        gemm_tests.push_back(GemmTestParams(
+            "unknown_nc_mod_nr",
+            GemmMicrokernelTester()
+                $if EXTENDED_WEIGHTS:
+                  .extended_weights(true)
+                .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).known_nc_mod_nr(false)
+                $if KERNELTYPE in ['qb4w', 'qc4w']:
+                  .b_zero_point(8)
+                $if KERNELTYPE in ['qb4w']:
+                  .bl(kr * sr * 2)
+            , test_func, isa_check)
+            $if NR_SCALE != "":
+              .loop_n(1, nr * 2 - 1, 4)
+            $else:
+              .loop_n(1, nr * 2 - 1)
+            .loop_k(1, k_block * 3, k_block + 1));
+        gemm_tests.push_back(GemmTestParams(
+            "relu",
+            GemmMicrokernelTester()
+                $if EXTENDED_WEIGHTS:
+                  .extended_weights(true)
+                .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).k(k_block).relu(true)
+                $if KERNELTYPE in ['qb4w', 'qc4w']:
+                  .b_zero_point(8)
+                $if KERNELTYPE in ['qb4w']:
+                  .bl(kr * sr * 2)
+            , test_func, isa_check));
+      $if DATATYPE != "qp8":
+        gemm_tests.push_back(GemmTestParams(
+            "n_gt_" + nrs + "_strided_cn",
+            GemmMicrokernelTester()
+                $if EXTENDED_WEIGHTS:
+                  .extended_weights(true)
+                .mr(mr).nr(nr).kr(kr).sr(sr).m(mr)
+                .cn_stride(NextPrime(nr + 1))
+                $if KERNELTYPE in ['qb4w', 'qc4w']:
+                  .b_zero_point(8)
+                $if KERNELTYPE in ['qb4w']:
+                  .bl(kr * sr * 2)
+                $if KERNELTYPE in ['qb4w']:
+                  .bl(kr * sr * 2)
+            , test_func, isa_check)
+            $if NR_SCALE != "":
+              .loop_n(nr + 1, nr * 2 - 1, 4)
+            $else:
+              .loop_n(nr + 1, nr * 2 - 1)
+            .loop_k(1, k_block * 3, k_block + 1));
+      if (!is_igemm) {
+        gemm_tests.push_back(GemmTestParams(
+            "n_gt_" + nrs + "_strided_a",
+            GemmMicrokernelTester()
+                $if EXTENDED_WEIGHTS:
+                  .extended_weights(true)
+                .mr(mr).nr(nr).kr(kr).sr(sr).m(mr)
+                .a_stride(NextPrime(k_block * 3 + 1))
+                $if KERNELTYPE in ['qb4w', 'qc4w']:
+                  .b_zero_point(8)
+                $if KERNELTYPE in ['qb4w']:
+                  .bl(kr * sr * 2)
+            , test_func, isa_check)
+            $if NR_SCALE != "":
+              .loop_n(nr + 1, nr * 2 - 1, 4)
+            $else:
+              .loop_n(nr + 1, nr * 2 - 1)
+            .loop_k(1, k_block * 3, k_block));
+      }
+      gemm_tests.push_back(GemmTestParams(
+          "n_gt_" + nrs + "_subtile",
+          GemmMicrokernelTester()
+              $if EXTENDED_WEIGHTS:
+                .extended_weights(true)
+              .mr(mr).nr(nr).kr(kr).sr(sr).iterations(1)
+              $if KERNELTYPE in ['qb4w', 'qc4w']:
+                .b_zero_point(8)
+              $if KERNELTYPE in ['qb4w']:
+                .bl(kr * sr * 2)
+          , test_func, isa_check)
+          $if NR_SCALE != "":
+            .loop_n(nr + 1, nr * 2 - 1, 4)
+          $else:
+            .loop_n(nr + 1, nr * 2 - 1)
+          .loop_k(1, k_block * 3, k_block + 1)
+          .loop_m(1, mr));
+      gemm_tests.push_back(GemmTestParams(
+          "n_div_" + nrs,
+          GemmMicrokernelTester()
+              $if EXTENDED_WEIGHTS:
+                .extended_weights(true)
+              .mr(mr).nr(nr).kr(kr).sr(sr).m(mr)
+              $if KERNELTYPE in ['qb4w', 'qc4w']:
+                .b_zero_point(8)
+              $if KERNELTYPE in ['qb4w']:
+                .bl(kr * sr * 2)
+          , test_func, isa_check)
+          .loop_n(nr * 2, nr * 3, nr)
+          .loop_k(1, k_block * 3, k_block + 1));
+      $if DATATYPE != "qp8":
+        gemm_tests.push_back(GemmTestParams(
+            "n_div_" + nrs + "_strided_cn",
+            GemmMicrokernelTester()
+                $if EXTENDED_WEIGHTS:
+                  .extended_weights(true)
+                .mr(mr).nr(nr).kr(kr).sr(sr).m(mr)
+                .cn_stride(NextPrime(nr + 1))
+                $if KERNELTYPE in ['qb4w', 'qc4w']:
+                  .b_zero_point(8)
+                $if KERNELTYPE in ['qb4w']:
+                  .bl(kr * sr * 2)
+            , test_func, isa_check)
+            .loop_n(nr * 2, nr * 3, nr)
+            .loop_k(1, k_block * 3, k_block + 1));
+      if (!is_igemm) {
+        gemm_tests.push_back(GemmTestParams(
+            "n_div_" + nrs + "_strided_a",
+            GemmMicrokernelTester()
+                $if EXTENDED_WEIGHTS:
+                  .extended_weights(true)
+                .mr(mr).nr(nr).kr(kr).sr(sr).m(mr)
+                .a_stride(NextPrime(k_block * 3 + 1))
+                $if KERNELTYPE in ['qb4w', 'qc4w']:
+                  .b_zero_point(8)
+                $if KERNELTYPE in ['qb4w']:
+                  .bl(kr * sr * 2)
+            , test_func, isa_check)
+            .loop_n(nr * 2, nr * 3, nr)
+            .loop_k(1, k_block * 3, k_block));
+      }
+      gemm_tests.push_back(GemmTestParams(
+          "n_div_" + nrs + "_subtile",
+          GemmMicrokernelTester()
+              $if EXTENDED_WEIGHTS:
+                .extended_weights(true)
+              .mr(mr).nr(nr).kr(kr).sr(sr).iterations(1)
+              $if KERNELTYPE in ['qb4w', 'qc4w']:
+                .b_zero_point(8)
+              $if KERNELTYPE in ['qb4w']:
+                .bl(kr * sr * 2)
+          , test_func, isa_check)
+          .loop_n(nr * 2, nr * 3, nr)
+          .loop_k(1, k_block * 3, k_block + 1)
+          .loop_m(1, mr));
+      if (is_igemm) {
+        gemm_tests.push_back(GemmTestParams(
+            "small_kernel",
+            GemmMicrokernelTester()
+                $if EXTENDED_WEIGHTS:
+                  .extended_weights(true)
+                .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).ks(3)
+                $if KERNELTYPE in ['qb4w', 'qc4w']:
+                  .b_zero_point(8)
+                $if KERNELTYPE in ['qb4w']:
+                  .bl(kr * sr * 2)
+            , test_func, isa_check)
+            .loop_k(1, k_block * 3, k_block + 1));
+        gemm_tests.push_back(GemmTestParams(
+            "small_kernel_subtile",
+            GemmMicrokernelTester()
+                $if EXTENDED_WEIGHTS:
+                  .extended_weights(true)
+                .mr(mr).nr(nr).kr(kr).sr(sr).ks(3).iterations(1)
+                $if KERNELTYPE in ['qb4w', 'qc4w']:
+                  .b_zero_point(8)
+                $if KERNELTYPE in ['qb4w']:
+                  .bl(kr * sr * 2)
+            , test_func, isa_check)
+            .loop_k(1, k_block * 3, k_block + 1)
+            .loop_n(1, nr)
+            .loop_m(1, mr));
+        gemm_tests.push_back(GemmTestParams(
+            "n_gt_" + nrs + "_small_kernel",
+            GemmMicrokernelTester()
+                $if EXTENDED_WEIGHTS:
+                  .extended_weights(true)
+                .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).ks(3)
+                $if KERNELTYPE in ['qb4w', 'qc4w']:
+                  .b_zero_point(8)
+                $if KERNELTYPE in ['qb4w']:
+                  .bl(kr * sr * 2)
+            , test_func, isa_check)
+            $if NR_SCALE != "":
+              .loop_n(nr + 1, nr * 2 - 1, 4)
+            $else:
+              .loop_n(nr + 1, nr * 2 - 1)
+            .loop_k(1, k_block * 3, k_block + 1));
+        gemm_tests.push_back(GemmTestParams(
+            "n_div_" + nrs + "_small_kernel",
+            GemmMicrokernelTester()
+                $if EXTENDED_WEIGHTS:
+                  .extended_weights(true)
+                .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).ks(3)
+                $if KERNELTYPE in ['qb4w', 'qc4w']:
+                  .b_zero_point(8)
+                $if KERNELTYPE in ['qb4w']:
+                  .bl(kr * sr * 2)
+            , test_func, isa_check)
+            .loop_n(nr * 2, nr * 3, nr)
+            .loop_k(1, k_block * 3, k_block + 1));
+      }
+      gemm_tests.push_back(GemmTestParams(
+          "strided_cm_subtile",
+          GemmMicrokernelTester()
+              $if EXTENDED_WEIGHTS:
+                .extended_weights(true)
+              .mr(mr).nr(nr).kr(kr).sr(sr)
+              .cm_stride(NextPrime(nr + 1))
+              .iterations(1)
+              $if KERNELTYPE in ['qb4w', 'qc4w']:
+                .b_zero_point(8)
+              $if KERNELTYPE in ['qb4w']:
+                .bl(kr * sr * 2)
+          , test_func, isa_check)
+          .loop_k(1, k_block * 3, k_block + 1)
+          .loop_n(1, nr)
+          .loop_m(1, mr));
+      if (is_igemm) {
+        gemm_tests.push_back(GemmTestParams(
+            "a_offset",
+            GemmMicrokernelTester()
+                $if EXTENDED_WEIGHTS:
+                  .extended_weights(true)
+                .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).ks(3)
+                .a_offset(NextPrime(mr * k_block * 3 + 1))
+                $if KERNELTYPE in ['qb4w', 'qc4w']:
+                  .b_zero_point(8)
+                $if KERNELTYPE in ['qb4w']:
+                  .bl(kr * sr * 2)
+            , test_func, isa_check)
+            .loop_k(1, k_block * 3, k_block + 1));
+        gemm_tests.push_back(GemmTestParams(
+            "zero",
+            GemmMicrokernelTester()
+                $if EXTENDED_WEIGHTS:
+                  .extended_weights(true)
+                .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).ks(3)
+                .a_offset(NextPrime(mr * k_block * 3 + 1))
+                $if KERNELTYPE in ['qb4w', 'qc4w']:
+                  .b_zero_point(8)
+                $if KERNELTYPE in ['qb4w']:
+                  .bl(kr * sr * 2)
+            , test_func, isa_check)
+            .loop_k(1, k_block * 3, k_block + 1)
+            .loop_zi(0, mr - 1));
+      }
+      $if ACTIVATION == "MINMAX":
+        gemm_tests.push_back(GemmTestParams(
+            "qmin",
+            GemmMicrokernelTester()
+                $if EXTENDED_WEIGHTS:
+                  .extended_weights(true)
+                .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).k(k_block).qmin(128)
+                $if KERNELTYPE in ['qb4w', 'qc4w']:
+                  .b_zero_point(8)
+                $if KERNELTYPE in ['qb4w']:
+                  .bl(kr * sr * 2)
+            , test_func, isa_check));
+        gemm_tests.push_back(GemmTestParams(
+            "qmax",
+            GemmMicrokernelTester()
+                $if EXTENDED_WEIGHTS:
+                  .extended_weights(true)
+                .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).k(k_block).qmax(128)
+                $if KERNELTYPE in ['qb4w', 'qc4w']:
+                  .b_zero_point(8)
+                $if KERNELTYPE in ['qb4w']:
+                  .bl(kr * sr * 2)
+            , test_func, isa_check));
+      gemm_tests.push_back(GemmTestParams(
+          "strided_cm",
+          GemmMicrokernelTester()
+              $if EXTENDED_WEIGHTS:
+                .extended_weights(true)
+              .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).k(k_block)
+              .cm_stride(NextPrime(nr + 1))
+              $if KERNELTYPE in ['qb4w', 'qc4w']:
+                .b_zero_point(8)
+              $if KERNELTYPE in ['qb4w']:
+                .bl(kr * sr * 2)
+          , test_func, isa_check));
+      $if DATATYPE == "qu8":
+        gemm_tests.push_back(GemmTestParams(
+            "no_a_zero_point",
+            GemmMicrokernelTester()
+                $if EXTENDED_WEIGHTS:
+                  .extended_weights(true)
+                .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).a_zero_point(0)
+            , test_func, isa_check)
+            .loop_k(1, k_block * 3, k_block + 1));
+      $if DATATYPE == "qu8":
+        gemm_tests.push_back(GemmTestParams(
+            "no_b_zero_point",
+            GemmMicrokernelTester()
+                $if EXTENDED_WEIGHTS:
+                  .extended_weights(true)
+                .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).b_zero_point(0)
+            , test_func, isa_check)
+            .loop_k(1, k_block * 3, k_block + 1));
+        gemm_tests.push_back(GemmTestParams(
+            "b_zero_point",
+            GemmMicrokernelTester()
+                $if EXTENDED_WEIGHTS:
+                  .extended_weights(true)
+                .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).k(k_block)
+            , test_func, isa_check)
+            .loop_bzp(0, 255));
+        gemm_tests.push_back(GemmTestParams(
+            "no_zero_point",
+            GemmMicrokernelTester()
+                $if EXTENDED_WEIGHTS:
+                  .extended_weights(true)
+                .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr)
+                .a_zero_point(0)
+                .b_zero_point(0)
+            , test_func, isa_check)
+            .loop_k(1, k_block * 3, k_block + 1));
   $if KERNELTYPE in ['qb4w']:
     gemm_tests.push_back(GemmTestParams(
         "bl",
@@ -711,7 +712,7 @@ std::vector<GemmTestParams> CreateTests(
             .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).k(k_block * 12)
             .b_zero_point(8)
         , test_func, isa_check)
-        .loop_k(k_block, k_block * 12, k_block)
+        .loop_k(k_block, k_block * 12, k_block, LoopStepType::Linear)
         .loop_bl(2 * kr * sr, k_block * 12, 2 * kr * sr));
 
   return gemm_tests;


### PR DESCRIPTION
This PR updates test generation for blockwise (qb4w) kernels in preparation for ISA-specific kernels with kr > 2. Blockwise kernels currently enforce several constraints:

1) Kc is divisible by block size (no partial blocks in a column).
2) Block size is divisible by 2\*kr\*sr (inner loop is 2x unrolled for 2 planes, no partial epilogue).

The majority of the existing gemm tests cover edge cases that are incompatible with the above constraints, so this PR conditionally disables the irrelevant tests for blockwise kernels. Blockwise kernels still have tests for strides, M subtiles, N subtiles, and varying block/k sizes.

Blockwise tests also benefit from linear stepping of nc and kc. Existing test logic always calls NextPrime after incrementing nc and kc values. To allow for linear stepping in certain blockwise tests while also maintaining the existing behavior, I've tentatively added a step_type parameter to LoopParams, allowing for either linear or prime steps. The default value for step_type is set in GemmTestParams to maintain the existing behavior of prime steps for nc and kc.

Additionally, benchmark logic for blockwise kernels now rounds kc up to a multiple of 2\*kr\*sr.

All tests were regenerated via scripts/generate-tests.sh.