### PR TITLE
QB4W Neondot F16/F32 GEMM Kernels

### DIFF
--- a/bench/qd8-f16-qb4w-gemm.cc
+++ b/bench/qd8-f16-qb4w-gemm.cc
@@ -7,17 +7,15 @@
 //   Specification: test/qd8-f16-qb4w-gemm-minmax.yaml
 //   Generator: tools/generate-gemm-test.py
 
+#include <benchmark/benchmark.h>
+#include "bench/gemm-benchmark.h"
+#include "bench/utils.h"
 #include "xnnpack/common.h"
-#include "xnnpack/isa-checks.h"
 #include "xnnpack/gemm.h"
 #include "xnnpack/isa-checks.h"
 #include "xnnpack/microfnptr.h"
 #include "xnnpack/microparams-init.h"
 #include "xnnpack/pack.h"
-
-#include <benchmark/benchmark.h>
-#include "bench/gemm-benchmark.h"
-#include "bench/utils.h"
 
 
 static void qd8_f16_qb4w_gemm_minmax_ukernel_1x2__scalar(benchmark::State& state, const char* net) {
@@ -96,6 +94,141 @@ static void qd8_f16_qb4w_gemm_minmax_ukernel_4x4__scalar(benchmark::State& state
 }
 
 BENCHMARK_GEMM_BL(qd8_f16_qb4w_gemm_minmax_ukernel_4x4__scalar)
+
+#if XNN_ENABLE_ARM_DOTPROD && XNN_ENABLE_ARM_FP16_VECTOR && (XNN_ARCH_ARM || XNN_ARCH_ARM64)
+  static void qd8_f16_qb4w_gemm_minmax_ukernel_1x8c4__neondotfp16arith(benchmark::State& state, const char* net) {
+    GEMMBenchmark(state,
+      xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x8c4__neondotfp16arith,
+      xnn_init_f16_qb4w_minmax_scalar_params,
+      xnn_pack_qs8_qb4w_gemm_goi_w,
+      /*mr=*/1, /*nr=*/8, /*kr=*/4, /*sr=*/1,
+      benchmark::utils::CheckNEONDOT);
+  }
+
+  BENCHMARK_GEMM_BL(qd8_f16_qb4w_gemm_minmax_ukernel_1x8c4__neondotfp16arith)
+
+  static void qd8_f16_qb4w_gemm_minmax_ukernel_1x16c4__neondotfp16arith(benchmark::State& state, const char* net) {
+    GEMMBenchmark(state,
+      xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x16c4__neondotfp16arith,
+      xnn_init_f16_qb4w_minmax_scalar_params,
+      xnn_pack_qs8_qb4w_gemm_goi_w,
+      /*mr=*/1, /*nr=*/16, /*kr=*/4, /*sr=*/1,
+      benchmark::utils::CheckNEONDOT);
+  }
+
+  BENCHMARK_GEMM_BL(qd8_f16_qb4w_gemm_minmax_ukernel_1x16c4__neondotfp16arith)
+
+  static void qd8_f16_qb4w_gemm_minmax_ukernel_2x8c4__neondotfp16arith(benchmark::State& state, const char* net) {
+    GEMMBenchmark(state,
+      xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x8c4__neondotfp16arith,
+      xnn_init_f16_qb4w_minmax_scalar_params,
+      xnn_pack_qs8_qb4w_gemm_goi_w,
+      /*mr=*/2, /*nr=*/8, /*kr=*/4, /*sr=*/1,
+      benchmark::utils::CheckNEONDOT);
+  }
+
+  BENCHMARK_GEMM_BL(qd8_f16_qb4w_gemm_minmax_ukernel_2x8c4__neondotfp16arith)
+
+  static void qd8_f16_qb4w_gemm_minmax_ukernel_2x16c4__neondotfp16arith(benchmark::State& state, const char* net) {
+    GEMMBenchmark(state,
+      xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x16c4__neondotfp16arith,
+      xnn_init_f16_qb4w_minmax_scalar_params,
+      xnn_pack_qs8_qb4w_gemm_goi_w,
+      /*mr=*/2, /*nr=*/16, /*kr=*/4, /*sr=*/1,
+      benchmark::utils::CheckNEONDOT);
+  }
+
+  BENCHMARK_GEMM_BL(qd8_f16_qb4w_gemm_minmax_ukernel_2x16c4__neondotfp16arith)
+
+  static void qd8_f16_qb4w_gemm_minmax_ukernel_3x8c4__neondotfp16arith(benchmark::State& state, const char* net) {
+    GEMMBenchmark(state,
+      xnn_qd8_f16_qb4w_gemm_minmax_ukernel_3x8c4__neondotfp16arith,
+      xnn_init_f16_qb4w_minmax_scalar_params,
+      xnn_pack_qs8_qb4w_gemm_goi_w,
+      /*mr=*/3, /*nr=*/8, /*kr=*/4, /*sr=*/1,
+      benchmark::utils::CheckNEONDOT);
+  }
+
+  BENCHMARK_GEMM_BL(qd8_f16_qb4w_gemm_minmax_ukernel_3x8c4__neondotfp16arith)
+
+  static void qd8_f16_qb4w_gemm_minmax_ukernel_3x16c4__neondotfp16arith(benchmark::State& state, const char* net) {
+    GEMMBenchmark(state,
+      xnn_qd8_f16_qb4w_gemm_minmax_ukernel_3x16c4__neondotfp16arith,
+      xnn_init_f16_qb4w_minmax_scalar_params,
+      xnn_pack_qs8_qb4w_gemm_goi_w,
+      /*mr=*/3, /*nr=*/16, /*kr=*/4, /*sr=*/1,
+      benchmark::utils::CheckNEONDOT);
+  }
+
+  BENCHMARK_GEMM_BL(qd8_f16_qb4w_gemm_minmax_ukernel_3x16c4__neondotfp16arith)
+
+  static void qd8_f16_qb4w_gemm_minmax_ukernel_4x8c4__neondotfp16arith(benchmark::State& state, const char* net) {
+    GEMMBenchmark(state,
+      xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x8c4__neondotfp16arith,
+      xnn_init_f16_qb4w_minmax_scalar_params,
+      xnn_pack_qs8_qb4w_gemm_goi_w,
+      /*mr=*/4, /*nr=*/8, /*kr=*/4, /*sr=*/1,
+      benchmark::utils::CheckNEONDOT);
+  }
+
+  BENCHMARK_GEMM_BL(qd8_f16_qb4w_gemm_minmax_ukernel_4x8c4__neondotfp16arith)
+
+  static void qd8_f16_qb4w_gemm_minmax_ukernel_4x16c4__neondotfp16arith(benchmark::State& state, const char* net) {
+    GEMMBenchmark(state,
+      xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x16c4__neondotfp16arith,
+      xnn_init_f16_qb4w_minmax_scalar_params,
+      xnn_pack_qs8_qb4w_gemm_goi_w,
+      /*mr=*/4, /*nr=*/16, /*kr=*/4, /*sr=*/1,
+      benchmark::utils::CheckNEONDOT);
+  }
+
+  BENCHMARK_GEMM_BL(qd8_f16_qb4w_gemm_minmax_ukernel_4x16c4__neondotfp16arith)
+
+  static void qd8_f16_qb4w_gemm_minmax_ukernel_5x8c4__neondotfp16arith(benchmark::State& state, const char* net) {
+    GEMMBenchmark(state,
+      xnn_qd8_f16_qb4w_gemm_minmax_ukernel_5x8c4__neondotfp16arith,
+      xnn_init_f16_qb4w_minmax_scalar_params,
+      xnn_pack_qs8_qb4w_gemm_goi_w,
+      /*mr=*/5, /*nr=*/8, /*kr=*/4, /*sr=*/1,
+      benchmark::utils::CheckNEONDOT);
+  }
+
+  BENCHMARK_GEMM_BL(qd8_f16_qb4w_gemm_minmax_ukernel_5x8c4__neondotfp16arith)
+
+  static void qd8_f16_qb4w_gemm_minmax_ukernel_5x16c4__neondotfp16arith(benchmark::State& state, const char* net) {
+    GEMMBenchmark(state,
+      xnn_qd8_f16_qb4w_gemm_minmax_ukernel_5x16c4__neondotfp16arith,
+      xnn_init_f16_qb4w_minmax_scalar_params,
+      xnn_pack_qs8_qb4w_gemm_goi_w,
+      /*mr=*/5, /*nr=*/16, /*kr=*/4, /*sr=*/1,
+      benchmark::utils::CheckNEONDOT);
+  }
+
+  BENCHMARK_GEMM_BL(qd8_f16_qb4w_gemm_minmax_ukernel_5x16c4__neondotfp16arith)
+
+  static void qd8_f16_qb4w_gemm_minmax_ukernel_6x8c4__neondotfp16arith(benchmark::State& state, const char* net) {
+    GEMMBenchmark(state,
+      xnn_qd8_f16_qb4w_gemm_minmax_ukernel_6x8c4__neondotfp16arith,
+      xnn_init_f16_qb4w_minmax_scalar_params,
+      xnn_pack_qs8_qb4w_gemm_goi_w,
+      /*mr=*/6, /*nr=*/8, /*kr=*/4, /*sr=*/1,
+      benchmark::utils::CheckNEONDOT);
+  }
+
+  BENCHMARK_GEMM_BL(qd8_f16_qb4w_gemm_minmax_ukernel_6x8c4__neondotfp16arith)
+
+  static void qd8_f16_qb4w_gemm_minmax_ukernel_6x16c4__neondotfp16arith(benchmark::State& state, const char* net) {
+    GEMMBenchmark(state,
+      xnn_qd8_f16_qb4w_gemm_minmax_ukernel_6x16c4__neondotfp16arith,
+      xnn_init_f16_qb4w_minmax_scalar_params,
+      xnn_pack_qs8_qb4w_gemm_goi_w,
+      /*mr=*/6, /*nr=*/16, /*kr=*/4, /*sr=*/1,
+      benchmark::utils::CheckNEONDOT);
+  }
+
+  BENCHMARK_GEMM_BL(qd8_f16_qb4w_gemm_minmax_ukernel_6x16c4__neondotfp16arith)
+#endif  // XNN_ENABLE_ARM_DOTPROD && XNN_ENABLE_ARM_FP16_VECTOR && (XNN_ARCH_ARM || XNN_ARCH_ARM64)
+
 
 #ifndef XNNPACK_BENCHMARK_NO_MAIN
 BENCHMARK_MAIN();

--- a/bench/qd8-f16-qb4w-gemm.cc
+++ b/bench/qd8-f16-qb4w-gemm.cc
@@ -10,6 +10,7 @@
 #include "xnnpack/common.h"
 #include "xnnpack/isa-checks.h"
 #include "xnnpack/gemm.h"
+#include "xnnpack/isa-checks.h"
 #include "xnnpack/microfnptr.h"
 #include "xnnpack/microparams-init.h"
 #include "xnnpack/pack.h"

--- a/bench/qd8-f32-qb4w-gemm.cc
+++ b/bench/qd8-f32-qb4w-gemm.cc
@@ -18,6 +18,141 @@
 #include "xnnpack/pack.h"
 
 
+#if XNN_ENABLE_ARM_DOTPROD && (XNN_ARCH_ARM || XNN_ARCH_ARM64)
+  static void qd8_f32_qb4w_gemm_minmax_ukernel_1x8c4__neondot(benchmark::State& state, const char* net) {
+    GEMMBenchmark(state,
+      xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x8c4__neondot,
+      xnn_init_f32_qb4w_minmax_scalar_params,
+      xnn_pack_qs8_qb4w_gemm_goi_w,
+      /*mr=*/1, /*nr=*/8, /*kr=*/4, /*sr=*/1,
+      benchmark::utils::CheckNEONDOT);
+  }
+
+  BENCHMARK_GEMM_BL(qd8_f32_qb4w_gemm_minmax_ukernel_1x8c4__neondot)
+
+  static void qd8_f32_qb4w_gemm_minmax_ukernel_1x16c4__neondot(benchmark::State& state, const char* net) {
+    GEMMBenchmark(state,
+      xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x16c4__neondot,
+      xnn_init_f32_qb4w_minmax_scalar_params,
+      xnn_pack_qs8_qb4w_gemm_goi_w,
+      /*mr=*/1, /*nr=*/16, /*kr=*/4, /*sr=*/1,
+      benchmark::utils::CheckNEONDOT);
+  }
+
+  BENCHMARK_GEMM_BL(qd8_f32_qb4w_gemm_minmax_ukernel_1x16c4__neondot)
+
+  static void qd8_f32_qb4w_gemm_minmax_ukernel_2x8c4__neondot(benchmark::State& state, const char* net) {
+    GEMMBenchmark(state,
+      xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x8c4__neondot,
+      xnn_init_f32_qb4w_minmax_scalar_params,
+      xnn_pack_qs8_qb4w_gemm_goi_w,
+      /*mr=*/2, /*nr=*/8, /*kr=*/4, /*sr=*/1,
+      benchmark::utils::CheckNEONDOT);
+  }
+
+  BENCHMARK_GEMM_BL(qd8_f32_qb4w_gemm_minmax_ukernel_2x8c4__neondot)
+
+  static void qd8_f32_qb4w_gemm_minmax_ukernel_2x16c4__neondot(benchmark::State& state, const char* net) {
+    GEMMBenchmark(state,
+      xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x16c4__neondot,
+      xnn_init_f32_qb4w_minmax_scalar_params,
+      xnn_pack_qs8_qb4w_gemm_goi_w,
+      /*mr=*/2, /*nr=*/16, /*kr=*/4, /*sr=*/1,
+      benchmark::utils::CheckNEONDOT);
+  }
+
+  BENCHMARK_GEMM_BL(qd8_f32_qb4w_gemm_minmax_ukernel_2x16c4__neondot)
+
+  static void qd8_f32_qb4w_gemm_minmax_ukernel_3x8c4__neondot(benchmark::State& state, const char* net) {
+    GEMMBenchmark(state,
+      xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x8c4__neondot,
+      xnn_init_f32_qb4w_minmax_scalar_params,
+      xnn_pack_qs8_qb4w_gemm_goi_w,
+      /*mr=*/3, /*nr=*/8, /*kr=*/4, /*sr=*/1,
+      benchmark::utils::CheckNEONDOT);
+  }
+
+  BENCHMARK_GEMM_BL(qd8_f32_qb4w_gemm_minmax_ukernel_3x8c4__neondot)
+
+  static void qd8_f32_qb4w_gemm_minmax_ukernel_3x16c4__neondot(benchmark::State& state, const char* net) {
+    GEMMBenchmark(state,
+      xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x16c4__neondot,
+      xnn_init_f32_qb4w_minmax_scalar_params,
+      xnn_pack_qs8_qb4w_gemm_goi_w,
+      /*mr=*/3, /*nr=*/16, /*kr=*/4, /*sr=*/1,
+      benchmark::utils::CheckNEONDOT);
+  }
+
+  BENCHMARK_GEMM_BL(qd8_f32_qb4w_gemm_minmax_ukernel_3x16c4__neondot)
+
+  static void qd8_f32_qb4w_gemm_minmax_ukernel_4x8c4__neondot(benchmark::State& state, const char* net) {
+    GEMMBenchmark(state,
+      xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x8c4__neondot,
+      xnn_init_f32_qb4w_minmax_scalar_params,
+      xnn_pack_qs8_qb4w_gemm_goi_w,
+      /*mr=*/4, /*nr=*/8, /*kr=*/4, /*sr=*/1,
+      benchmark::utils::CheckNEONDOT);
+  }
+
+  BENCHMARK_GEMM_BL(qd8_f32_qb4w_gemm_minmax_ukernel_4x8c4__neondot)
+
+  static void qd8_f32_qb4w_gemm_minmax_ukernel_4x16c4__neondot(benchmark::State& state, const char* net) {
+    GEMMBenchmark(state,
+      xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x16c4__neondot,
+      xnn_init_f32_qb4w_minmax_scalar_params,
+      xnn_pack_qs8_qb4w_gemm_goi_w,
+      /*mr=*/4, /*nr=*/16, /*kr=*/4, /*sr=*/1,
+      benchmark::utils::CheckNEONDOT);
+  }
+
+  BENCHMARK_GEMM_BL(qd8_f32_qb4w_gemm_minmax_ukernel_4x16c4__neondot)
+
+  static void qd8_f32_qb4w_gemm_minmax_ukernel_5x8c4__neondot(benchmark::State& state, const char* net) {
+    GEMMBenchmark(state,
+      xnn_qd8_f32_qb4w_gemm_minmax_ukernel_5x8c4__neondot,
+      xnn_init_f32_qb4w_minmax_scalar_params,
+      xnn_pack_qs8_qb4w_gemm_goi_w,
+      /*mr=*/5, /*nr=*/8, /*kr=*/4, /*sr=*/1,
+      benchmark::utils::CheckNEONDOT);
+  }
+
+  BENCHMARK_GEMM_BL(qd8_f32_qb4w_gemm_minmax_ukernel_5x8c4__neondot)
+
+  static void qd8_f32_qb4w_gemm_minmax_ukernel_5x16c4__neondot(benchmark::State& state, const char* net) {
+    GEMMBenchmark(state,
+      xnn_qd8_f32_qb4w_gemm_minmax_ukernel_5x16c4__neondot,
+      xnn_init_f32_qb4w_minmax_scalar_params,
+      xnn_pack_qs8_qb4w_gemm_goi_w,
+      /*mr=*/5, /*nr=*/16, /*kr=*/4, /*sr=*/1,
+      benchmark::utils::CheckNEONDOT);
+  }
+
+  BENCHMARK_GEMM_BL(qd8_f32_qb4w_gemm_minmax_ukernel_5x16c4__neondot)
+
+  static void qd8_f32_qb4w_gemm_minmax_ukernel_6x8c4__neondot(benchmark::State& state, const char* net) {
+    GEMMBenchmark(state,
+      xnn_qd8_f32_qb4w_gemm_minmax_ukernel_6x8c4__neondot,
+      xnn_init_f32_qb4w_minmax_scalar_params,
+      xnn_pack_qs8_qb4w_gemm_goi_w,
+      /*mr=*/6, /*nr=*/8, /*kr=*/4, /*sr=*/1,
+      benchmark::utils::CheckNEONDOT);
+  }
+
+  BENCHMARK_GEMM_BL(qd8_f32_qb4w_gemm_minmax_ukernel_6x8c4__neondot)
+
+  static void qd8_f32_qb4w_gemm_minmax_ukernel_6x16c4__neondot(benchmark::State& state, const char* net) {
+    GEMMBenchmark(state,
+      xnn_qd8_f32_qb4w_gemm_minmax_ukernel_6x16c4__neondot,
+      xnn_init_f32_qb4w_minmax_scalar_params,
+      xnn_pack_qs8_qb4w_gemm_goi_w,
+      /*mr=*/6, /*nr=*/16, /*kr=*/4, /*sr=*/1,
+      benchmark::utils::CheckNEONDOT);
+  }
+
+  BENCHMARK_GEMM_BL(qd8_f32_qb4w_gemm_minmax_ukernel_6x16c4__neondot)
+#endif  // XNN_ENABLE_ARM_DOTPROD && (XNN_ARCH_ARM || XNN_ARCH_ARM64)
+
+
 #if XNN_ARCH_X86 || XNN_ARCH_X86_64
   static void qd8_f32_qb4w_gemm_minmax_ukernel_1x4c8__avx_ld128(benchmark::State& state, const char* net) {
     GEMMBenchmark(state,

--- a/cmake/gen/neondot_microkernels.cmake
+++ b/cmake/gen/neondot_microkernels.cmake
@@ -10,6 +10,18 @@
 
 
 SET(ALL_NEONDOT_MICROKERNEL_SRCS
+  src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x8c4-minmax-neondot.c
+  src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x16c4-minmax-neondot.c
+  src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x8c4-minmax-neondot.c
+  src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x16c4-minmax-neondot.c
+  src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x8c4-minmax-neondot.c
+  src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x16c4-minmax-neondot.c
+  src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x8c4-minmax-neondot.c
+  src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x16c4-minmax-neondot.c
+  src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-5x8c4-minmax-neondot.c
+  src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-5x16c4-minmax-neondot.c
+  src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-6x8c4-minmax-neondot.c
+  src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-6x16c4-minmax-neondot.c
   src/qd8-f32-qc4w-gemm/gen/qd8-f32-qc4w-gemm-1x8c4-minmax-neondot.c
   src/qd8-f32-qc4w-gemm/gen/qd8-f32-qc4w-gemm-1x16c4-minmax-neondot.c
   src/qd8-f32-qc4w-gemm/gen/qd8-f32-qc4w-gemm-2x8c4-minmax-neondot.c

--- a/cmake/gen/neondotfp16arith_microkernels.cmake
+++ b/cmake/gen/neondotfp16arith_microkernels.cmake
@@ -10,6 +10,18 @@
 
 
 SET(ALL_NEONDOTFP16ARITH_MICROKERNEL_SRCS
+  src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x8c4-minmax-neondotfp16arith.c
+  src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x16c4-minmax-neondotfp16arith.c
+  src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x8c4-minmax-neondotfp16arith.c
+  src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x16c4-minmax-neondotfp16arith.c
+  src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x8c4-minmax-neondotfp16arith.c
+  src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x16c4-minmax-neondotfp16arith.c
+  src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x8c4-minmax-neondotfp16arith.c
+  src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x16c4-minmax-neondotfp16arith.c
+  src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-5x8c4-minmax-neondotfp16arith.c
+  src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-5x16c4-minmax-neondotfp16arith.c
+  src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-6x8c4-minmax-neondotfp16arith.c
+  src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-6x16c4-minmax-neondotfp16arith.c
   src/qd8-f16-qc4w-gemm/gen/qd8-f16-qc4w-gemm-1x8c4-minmax-neondotfp16arith.c
   src/qd8-f16-qc4w-gemm/gen/qd8-f16-qc4w-gemm-1x16c4-minmax-neondotfp16arith.c
   src/qd8-f16-qc4w-gemm/gen/qd8-f16-qc4w-gemm-2x8c4-minmax-neondotfp16arith.c

--- a/gen/neondot_microkernels.bzl
+++ b/gen/neondot_microkernels.bzl
@@ -6,6 +6,18 @@ Auto-generated file. Do not edit!
 """
 
 ALL_NEONDOT_MICROKERNEL_SRCS = [
+    "src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x8c4-minmax-neondot.c",
+    "src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x16c4-minmax-neondot.c",
+    "src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x8c4-minmax-neondot.c",
+    "src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x16c4-minmax-neondot.c",
+    "src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x8c4-minmax-neondot.c",
+    "src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x16c4-minmax-neondot.c",
+    "src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x8c4-minmax-neondot.c",
+    "src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x16c4-minmax-neondot.c",
+    "src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-5x8c4-minmax-neondot.c",
+    "src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-5x16c4-minmax-neondot.c",
+    "src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-6x8c4-minmax-neondot.c",
+    "src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-6x16c4-minmax-neondot.c",
     "src/qd8-f32-qc4w-gemm/gen/qd8-f32-qc4w-gemm-1x8c4-minmax-neondot.c",
     "src/qd8-f32-qc4w-gemm/gen/qd8-f32-qc4w-gemm-1x16c4-minmax-neondot.c",
     "src/qd8-f32-qc4w-gemm/gen/qd8-f32-qc4w-gemm-2x8c4-minmax-neondot.c",

--- a/gen/neondotfp16arith_microkernels.bzl
+++ b/gen/neondotfp16arith_microkernels.bzl
@@ -6,6 +6,18 @@ Auto-generated file. Do not edit!
 """
 
 ALL_NEONDOTFP16ARITH_MICROKERNEL_SRCS = [
+    "src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x8c4-minmax-neondotfp16arith.c",
+    "src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x16c4-minmax-neondotfp16arith.c",
+    "src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x8c4-minmax-neondotfp16arith.c",
+    "src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x16c4-minmax-neondotfp16arith.c",
+    "src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x8c4-minmax-neondotfp16arith.c",
+    "src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x16c4-minmax-neondotfp16arith.c",
+    "src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x8c4-minmax-neondotfp16arith.c",
+    "src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x16c4-minmax-neondotfp16arith.c",
+    "src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-5x8c4-minmax-neondotfp16arith.c",
+    "src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-5x16c4-minmax-neondotfp16arith.c",
+    "src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-6x8c4-minmax-neondotfp16arith.c",
+    "src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-6x16c4-minmax-neondotfp16arith.c",
     "src/qd8-f16-qc4w-gemm/gen/qd8-f16-qc4w-gemm-1x8c4-minmax-neondotfp16arith.c",
     "src/qd8-f16-qc4w-gemm/gen/qd8-f16-qc4w-gemm-1x16c4-minmax-neondotfp16arith.c",
     "src/qd8-f16-qc4w-gemm/gen/qd8-f16-qc4w-gemm-2x8c4-minmax-neondotfp16arith.c",

--- a/scripts/generate-qs8-gemm.sh
+++ b/scripts/generate-qs8-gemm.sh
@@ -495,6 +495,20 @@ tools/xngen src/qs8-gemm/c4-neondot.c.in -D MR=3 -D NR=16 -D REQUANTIZATION= -D 
 tools/xngen src/qs8-gemm/c4-neondot.c.in -D MR=4 -D NR=16 -D REQUANTIZATION= -D DATATYPE=QC4_F32 -o src/qd8-f32-qc4w-gemm/gen/qd8-f32-qc4w-gemm-4x16c4-minmax-neondot.c &
 tools/xngen src/qs8-gemm/c4-neondot.c.in -D MR=6 -D NR=16 -D REQUANTIZATION= -D DATATYPE=QC4_F32 -o src/qd8-f32-qc4w-gemm/gen/qd8-f32-qc4w-gemm-6x16c4-minmax-neondot.c &
 
+tools/xngen src/qs8-gemm/c4-neondot.c.in -D MR=1 -D NR=8  -D REQUANTIZATION= -D DATATYPE=QB4_F32 -o src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x8c4-minmax-neondot.c &
+tools/xngen src/qs8-gemm/c4-neondot.c.in -D MR=2 -D NR=8  -D REQUANTIZATION= -D DATATYPE=QB4_F32 -o src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x8c4-minmax-neondot.c &
+tools/xngen src/qs8-gemm/c4-neondot.c.in -D MR=3 -D NR=8  -D REQUANTIZATION= -D DATATYPE=QB4_F32 -o src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x8c4-minmax-neondot.c &
+tools/xngen src/qs8-gemm/c4-neondot.c.in -D MR=4 -D NR=8  -D REQUANTIZATION= -D DATATYPE=QB4_F32 -o src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x8c4-minmax-neondot.c &
+tools/xngen src/qs8-gemm/c4-neondot.c.in -D MR=5 -D NR=8  -D REQUANTIZATION= -D DATATYPE=QB4_F32 -o src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-5x8c4-minmax-neondot.c &
+tools/xngen src/qs8-gemm/c4-neondot.c.in -D MR=6 -D NR=8  -D REQUANTIZATION= -D DATATYPE=QB4_F32 -o src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-6x8c4-minmax-neondot.c &
+
+tools/xngen src/qs8-gemm/c4-neondot.c.in -D MR=1 -D NR=16 -D REQUANTIZATION= -D DATATYPE=QB4_F32 -o src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x16c4-minmax-neondot.c &
+tools/xngen src/qs8-gemm/c4-neondot.c.in -D MR=2 -D NR=16 -D REQUANTIZATION= -D DATATYPE=QB4_F32 -o src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x16c4-minmax-neondot.c &
+tools/xngen src/qs8-gemm/c4-neondot.c.in -D MR=3 -D NR=16 -D REQUANTIZATION= -D DATATYPE=QB4_F32 -o src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x16c4-minmax-neondot.c &
+tools/xngen src/qs8-gemm/c4-neondot.c.in -D MR=4 -D NR=16 -D REQUANTIZATION= -D DATATYPE=QB4_F32 -o src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x16c4-minmax-neondot.c &
+tools/xngen src/qs8-gemm/c4-neondot.c.in -D MR=5 -D NR=16 -D REQUANTIZATION= -D DATATYPE=QB4_F32 -o src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-5x16c4-minmax-neondot.c &
+tools/xngen src/qs8-gemm/c4-neondot.c.in -D MR=6 -D NR=16 -D REQUANTIZATION= -D DATATYPE=QB4_F32 -o src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-6x16c4-minmax-neondot.c &
+
 tools/xngen src/qs8-gemm/c4-neondot.c.in -D MR=1 -D NR=8  -D REQUANTIZATION= -D DATATYPE=QC4_F16 -o src/qd8-f16-qc4w-gemm/gen/qd8-f16-qc4w-gemm-1x8c4-minmax-neondotfp16arith.c &
 tools/xngen src/qs8-gemm/c4-neondot.c.in -D MR=2 -D NR=8  -D REQUANTIZATION= -D DATATYPE=QC4_F16 -o src/qd8-f16-qc4w-gemm/gen/qd8-f16-qc4w-gemm-2x8c4-minmax-neondotfp16arith.c &
 tools/xngen src/qs8-gemm/c4-neondot.c.in -D MR=3 -D NR=8  -D REQUANTIZATION= -D DATATYPE=QC4_F16 -o src/qd8-f16-qc4w-gemm/gen/qd8-f16-qc4w-gemm-3x8c4-minmax-neondotfp16arith.c &
@@ -508,6 +522,21 @@ tools/xngen src/qs8-gemm/c4-neondot.c.in -D MR=3 -D NR=16 -D REQUANTIZATION= -D 
 tools/xngen src/qs8-gemm/c4-neondot.c.in -D MR=4 -D NR=16 -D REQUANTIZATION= -D DATATYPE=QC4_F16 -o src/qd8-f16-qc4w-gemm/gen/qd8-f16-qc4w-gemm-4x16c4-minmax-neondotfp16arith.c &
 tools/xngen src/qs8-gemm/c4-neondot.c.in -D MR=5 -D NR=16 -D REQUANTIZATION= -D DATATYPE=QC4_F16 -o src/qd8-f16-qc4w-gemm/gen/qd8-f16-qc4w-gemm-5x16c4-minmax-neondotfp16arith.c &
 tools/xngen src/qs8-gemm/c4-neondot.c.in -D MR=6 -D NR=16 -D REQUANTIZATION= -D DATATYPE=QC4_F16 -o src/qd8-f16-qc4w-gemm/gen/qd8-f16-qc4w-gemm-6x16c4-minmax-neondotfp16arith.c &
+
+tools/xngen src/qs8-gemm/c4-neondot.c.in -D MR=1 -D NR=8  -D REQUANTIZATION= -D DATATYPE=QB4_F16 -o src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x8c4-minmax-neondotfp16arith.c &
+tools/xngen src/qs8-gemm/c4-neondot.c.in -D MR=2 -D NR=8  -D REQUANTIZATION= -D DATATYPE=QB4_F16 -o src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x8c4-minmax-neondotfp16arith.c &
+tools/xngen src/qs8-gemm/c4-neondot.c.in -D MR=3 -D NR=8  -D REQUANTIZATION= -D DATATYPE=QB4_F16 -o src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x8c4-minmax-neondotfp16arith.c &
+tools/xngen src/qs8-gemm/c4-neondot.c.in -D MR=4 -D NR=8  -D REQUANTIZATION= -D DATATYPE=QB4_F16 -o src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x8c4-minmax-neondotfp16arith.c &
+tools/xngen src/qs8-gemm/c4-neondot.c.in -D MR=5 -D NR=8  -D REQUANTIZATION= -D DATATYPE=QB4_F16 -o src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-5x8c4-minmax-neondotfp16arith.c &
+tools/xngen src/qs8-gemm/c4-neondot.c.in -D MR=6 -D NR=8  -D REQUANTIZATION= -D DATATYPE=QB4_F16 -o src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-6x8c4-minmax-neondotfp16arith.c &
+
+tools/xngen src/qs8-gemm/c4-neondot.c.in -D MR=1 -D NR=16 -D REQUANTIZATION= -D DATATYPE=QB4_F16 -o src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x16c4-minmax-neondotfp16arith.c &
+tools/xngen src/qs8-gemm/c4-neondot.c.in -D MR=2 -D NR=16 -D REQUANTIZATION= -D DATATYPE=QB4_F16 -o src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x16c4-minmax-neondotfp16arith.c &
+tools/xngen src/qs8-gemm/c4-neondot.c.in -D MR=3 -D NR=16 -D REQUANTIZATION= -D DATATYPE=QB4_F16 -o src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x16c4-minmax-neondotfp16arith.c &
+tools/xngen src/qs8-gemm/c4-neondot.c.in -D MR=4 -D NR=16 -D REQUANTIZATION= -D DATATYPE=QB4_F16 -o src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x16c4-minmax-neondotfp16arith.c &
+tools/xngen src/qs8-gemm/c4-neondot.c.in -D MR=5 -D NR=16 -D REQUANTIZATION= -D DATATYPE=QB4_F16 -o src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-5x16c4-minmax-neondotfp16arith.c &
+tools/xngen src/qs8-gemm/c4-neondot.c.in -D MR=6 -D NR=16 -D REQUANTIZATION= -D DATATYPE=QB4_F16 -o src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-6x16c4-minmax-neondotfp16arith.c &
+
 
 tools/xngen src/qs8-gemm/c4-neondot.c.in -D MR=1  -D NR=8  -D REQUANTIZATION=FP32  -D DATATYPE=QC8 -o src/qs8-qc8w-gemm/gen/qs8-qc8w-gemm-1x8c4-minmax-fp32-neondot.c &
 tools/xngen src/qs8-gemm/c4-neondot.c.in -D MR=4  -D NR=8  -D REQUANTIZATION=FP32  -D DATATYPE=QC8 -o src/qs8-qc8w-gemm/gen/qs8-qc8w-gemm-4x8c4-minmax-fp32-neondot.c &

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x16c4-minmax-neondotfp16arith.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x16c4-minmax-neondotfp16arith.c
@@ -1,0 +1,192 @@
+// Auto-generated file. Do not edit!
+//   Template: src/qs8-gemm/c4-neondot.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2020 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+
+#include <arm_neon.h>
+
+#include "xnnpack/gemm.h"
+#include "xnnpack/math.h"
+
+
+void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x16c4__neondotfp16arith(
+    size_t mr,
+    size_t nc,
+    size_t kc,
+    const int8_t* restrict a,
+    size_t a_stride,
+    const void* restrict w,
+    uint16_t* restrict c,
+    size_t cm_stride,
+    size_t cn_stride,
+    const union xnn_f16_qb4w_minmax_params params[restrict XNN_MIN_ELEMENTS(1)],
+    const struct xnn_qd8_quantization_params quantization_params[restrict XNN_MIN_ELEMENTS(1)]) XNN_OOB_READS
+{
+  assert(mr != 0);
+  assert(mr <= 1);
+  assert(nc != 0);
+  assert(kc != 0);
+  assert(kc % sizeof(int8_t) == 0);
+  assert(a != NULL);
+  assert(w != NULL);
+  assert(c != NULL);
+
+  kc = round_up_po2(kc, 4 * sizeof(int8_t));
+  const int8_t* a0 = a;
+  uint16_t* c0 = (uint16_t*) c;
+
+  size_t bl = params->fp16arith.blocksize;
+  assert(bl <= kc);
+  assert(bl != 0);
+  size_t n_blocks = kc / bl;
+  const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
+  // Loop over groups of 16 columns.
+  do {
+    // Initialize accumulators with bias. 16 bias values are loaded from the
+    // weight matrix, at the start of the group of 16 columns.
+    const float32x4_t vinput_zero_point0 = vcvtq_f32_s32(vld1q_dup_s32(&quantization_params[0].zero_point));
+    const float32x4_t vksum0123 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x0123 = vmulq_f32(vksum0123, vinput_zero_point0);
+    const float32x4_t vksum4567 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x4567 = vmulq_f32(vksum4567, vinput_zero_point0);
+    const float32x4_t vksum89AB = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x89AB = vmulq_f32(vksum89AB, vinput_zero_point0);
+    const float32x4_t vksumCDEF = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0xCDEF = vmulq_f32(vksumCDEF, vinput_zero_point0);
+
+    for (size_t nb=0; nb < n_blocks; ++nb) {
+      int32x4_t vacc0x0123 = vdupq_n_s32(0);
+      int32x4_t vacc0x4567 = vdupq_n_s32(0);
+      int32x4_t vacc0x89AB = vdupq_n_s32(0);
+      int32x4_t vacc0xCDEF = vdupq_n_s32(0);
+    // Inner accumulation loop along the 16 columns.
+    size_t k = bl;
+    // 2x partial unrolled loop to load 8 bytes at a time.
+    while (k >= 8 * sizeof(int8_t)) {
+      // Load a 1x8 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 8;
+
+      // Load a 8x16 block of weights.
+      const int8x16_t vb01234567x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567x89AB = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567xCDEF = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x0123 = vshlq_n_s8(vb01234567x0123, 4);
+      const int8x16_t vb0123x4567 = vshlq_n_s8(vb01234567x4567, 4);
+      const int8x16_t vb0123x89AB = vshlq_n_s8(vb01234567x89AB, 4);
+      const int8x16_t vb0123xCDEF = vshlq_n_s8(vb01234567xCDEF, 4);
+      const int8x16_t vb4567x0123 = vandq_s8(vb01234567x0123, vmask);
+      const int8x16_t vb4567x4567 = vandq_s8(vb01234567x4567, vmask);
+      const int8x16_t vb4567x89AB = vandq_s8(vb01234567x89AB, vmask);
+      const int8x16_t vb4567xCDEF = vandq_s8(vb01234567xCDEF, vmask);
+
+      // Multiply-accumulate: 1x8 * 8x16 --> 1x16.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc0x89AB = vdotq_lane_s32(vacc0x89AB, vb0123x89AB, va0x01234567, 0);
+      vacc0xCDEF = vdotq_lane_s32(vacc0xCDEF, vb0123xCDEF, va0x01234567, 0);
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb4567x0123, va0x01234567, 1);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb4567x4567, va0x01234567, 1);
+      vacc0x89AB = vdotq_lane_s32(vacc0x89AB, vb4567x89AB, va0x01234567, 1);
+      vacc0xCDEF = vdotq_lane_s32(vacc0xCDEF, vb4567xCDEF, va0x01234567, 1);
+
+      k -= 8 * sizeof(int8_t);
+    }
+    // Handle up to 4 final positions of `k`
+    if XNN_UNLIKELY(k != 0) {
+      // Load a 1x4 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 4;
+
+      // Load a 4x16 block of weights.
+      const int8x16_t vb0123x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x89AB = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123xCDEF = vld1q_s8(w); w = (const int8_t*) w + 16;
+
+      // Multiply-accumulate: 1x4 * 4x16 --> 1x16.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc0x89AB = vdotq_lane_s32(vacc0x89AB, vb0123x89AB, va0x01234567, 0);
+      vacc0xCDEF = vdotq_lane_s32(vacc0xCDEF, vb0123xCDEF, va0x01234567, 0);
+    }
+    const float32x4_t vfilter_output_scale0123 = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scale4567 = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scale89AB = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scaleCDEF = vld1q_f32(w); w = (const float*) w + 4;
+
+    float32x4_t vf0x0123 = vcvtq_f32_s32(vacc0x0123);
+    vout0x0123 = vfmaq_f32(vout0x0123, vf0x0123, vfilter_output_scale0123);
+    float32x4_t vf0x4567 = vcvtq_f32_s32(vacc0x4567);
+    vout0x4567 = vfmaq_f32(vout0x4567, vf0x4567, vfilter_output_scale4567);
+    float32x4_t vf0x89AB = vcvtq_f32_s32(vacc0x89AB);
+    vout0x89AB = vfmaq_f32(vout0x89AB, vf0x89AB, vfilter_output_scale89AB);
+    float32x4_t vf0xCDEF = vcvtq_f32_s32(vacc0xCDEF);
+    vout0xCDEF = vfmaq_f32(vout0xCDEF, vf0xCDEF, vfilter_output_scaleCDEF);
+    }
+
+    const float32x4_t one_sixteenth = vdupq_n_f32(1/16.0);
+    vout0x0123 = vmulq_f32(vout0x0123, one_sixteenth);
+    vout0x4567 = vmulq_f32(vout0x4567, one_sixteenth);
+    vout0x89AB = vmulq_f32(vout0x89AB, one_sixteenth);
+    vout0xCDEF = vmulq_f32(vout0xCDEF, one_sixteenth);
+    const float32x4_t vinput_scale0 = vld1q_dup_f32(&quantization_params[0].inv_scale);
+    vout0x0123 = vmulq_f32(vout0x0123, vinput_scale0);
+    vout0x4567 = vmulq_f32(vout0x4567, vinput_scale0);
+    vout0x89AB = vmulq_f32(vout0x89AB, vinput_scale0);
+    vout0xCDEF = vmulq_f32(vout0xCDEF, vinput_scale0);
+
+
+    const float32x4_t vbias0123 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x0123 = vaddq_f32(vbias0123, vout0x0123);
+    const float32x4_t vbias4567 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x4567 = vaddq_f32(vbias4567, vout0x4567);
+    const float32x4_t vbias89AB = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x89AB = vaddq_f32(vbias89AB, vout0x89AB);
+    const float32x4_t vbiasCDEF = vld1q_f32(w); w = (const float*) w + 4;
+    vout0xCDEF = vaddq_f32(vbiasCDEF, vout0xCDEF);
+
+    float16x8_t vfp16out0x01234567 = vcombine_f16(vcvt_f16_f32(vout0x0123), vcvt_f16_f32(vout0x4567));
+    float16x8_t vfp16out0x89ABCDEF = vcombine_f16(vcvt_f16_f32(vout0x89AB), vcvt_f16_f32(vout0xCDEF));
+
+    const float16x8_t voutput_min = vreinterpretq_f16_u16(vld1q_dup_u16(&params->fp16arith.min));
+    vfp16out0x01234567 = vmaxq_f16(vfp16out0x01234567, voutput_min);
+    vfp16out0x89ABCDEF = vmaxq_f16(vfp16out0x89ABCDEF, voutput_min);
+    const float16x8_t voutput_max = vreinterpretq_f16_u16(vld1q_dup_u16(&params->fp16arith.max));
+    vfp16out0x01234567 = vminq_f16(vfp16out0x01234567, voutput_max);
+    vfp16out0x89ABCDEF = vminq_f16(vfp16out0x89ABCDEF, voutput_max);
+    if XNN_LIKELY(nc >= 16) {
+      vst1q_u16(c0, vreinterpretq_u16_f16(vfp16out0x01234567));
+      vst1q_u16(c0 + 8, vreinterpretq_u16_f16(vfp16out0x89ABCDEF));
+
+      a0 = (const int8_t*) ((uintptr_t) a0 - kc);
+
+      c0 = (uint16_t*) ((uintptr_t) c0 + cn_stride);
+
+      nc -= 16;
+    } else {
+     if (nc & 8) {
+       vst1q_u16(c0, vreinterpretq_u16_f16(vfp16out0x01234567)); c0 += 8;
+       vfp16out0x01234567 = vfp16out0x89ABCDEF;
+     }
+     float16x4_t vfp16out0x0123 = vget_low_f16(vfp16out0x01234567);
+     if (nc & 4) {
+       vst1_u16(c0, vreinterpret_u16_f16(vfp16out0x0123)); c0 += 4;
+       vfp16out0x0123 = vget_high_f16(vfp16out0x01234567);
+     }
+     if (nc & 2) {
+       vst1_lane_u32((void*) c0, vreinterpret_u32_f16(vfp16out0x0123), 0); c0 += 2;
+       vfp16out0x0123 = vext_f16(vfp16out0x0123, vfp16out0x0123, 2);
+     }
+     if (nc & 1) {
+       vst1_lane_u16(c0, vreinterpret_u16_f16(vfp16out0x0123), 0);
+     }
+      nc = 0;
+    }
+  } while (nc != 0);
+}

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x8c4-minmax-neondotfp16arith.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x8c4-minmax-neondotfp16arith.c
@@ -1,0 +1,150 @@
+// Auto-generated file. Do not edit!
+//   Template: src/qs8-gemm/c4-neondot.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2020 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+
+#include <arm_neon.h>
+
+#include "xnnpack/gemm.h"
+#include "xnnpack/math.h"
+
+
+void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x8c4__neondotfp16arith(
+    size_t mr,
+    size_t nc,
+    size_t kc,
+    const int8_t* restrict a,
+    size_t a_stride,
+    const void* restrict w,
+    uint16_t* restrict c,
+    size_t cm_stride,
+    size_t cn_stride,
+    const union xnn_f16_qb4w_minmax_params params[restrict XNN_MIN_ELEMENTS(1)],
+    const struct xnn_qd8_quantization_params quantization_params[restrict XNN_MIN_ELEMENTS(1)]) XNN_OOB_READS
+{
+  assert(mr != 0);
+  assert(mr <= 1);
+  assert(nc != 0);
+  assert(kc != 0);
+  assert(kc % sizeof(int8_t) == 0);
+  assert(a != NULL);
+  assert(w != NULL);
+  assert(c != NULL);
+
+  kc = round_up_po2(kc, 4 * sizeof(int8_t));
+  const int8_t* a0 = a;
+  uint16_t* c0 = (uint16_t*) c;
+
+  size_t bl = params->fp16arith.blocksize;
+  assert(bl <= kc);
+  assert(bl != 0);
+  size_t n_blocks = kc / bl;
+  const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
+  // Loop over groups of 8 columns.
+  do {
+    // Initialize accumulators with bias. 8 bias values are loaded from the
+    // weight matrix, at the start of the group of 8 columns.
+    const float32x4_t vinput_zero_point0 = vcvtq_f32_s32(vld1q_dup_s32(&quantization_params[0].zero_point));
+    const float32x4_t vksum0123 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x0123 = vmulq_f32(vksum0123, vinput_zero_point0);
+    const float32x4_t vksum4567 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x4567 = vmulq_f32(vksum4567, vinput_zero_point0);
+
+    for (size_t nb=0; nb < n_blocks; ++nb) {
+      int32x4_t vacc0x0123 = vdupq_n_s32(0);
+      int32x4_t vacc0x4567 = vdupq_n_s32(0);
+    // Inner accumulation loop along the 8 columns.
+    size_t k = bl;
+    // 2x partial unrolled loop to load 8 bytes at a time.
+    while (k >= 8 * sizeof(int8_t)) {
+      // Load a 1x8 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 8;
+
+      // Load a 8x8 block of weights.
+      const int8x16_t vb01234567x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x0123 = vshlq_n_s8(vb01234567x0123, 4);
+      const int8x16_t vb0123x4567 = vshlq_n_s8(vb01234567x4567, 4);
+      const int8x16_t vb4567x0123 = vandq_s8(vb01234567x0123, vmask);
+      const int8x16_t vb4567x4567 = vandq_s8(vb01234567x4567, vmask);
+
+      // Multiply-accumulate: 1x8 * 8x8 --> 1x8.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb4567x0123, va0x01234567, 1);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb4567x4567, va0x01234567, 1);
+
+      k -= 8 * sizeof(int8_t);
+    }
+    // Handle up to 4 final positions of `k`
+    if XNN_UNLIKELY(k != 0) {
+      // Load a 1x4 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 4;
+
+      // Load a 4x8 block of weights.
+      const int8x16_t vb0123x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+
+      // Multiply-accumulate: 1x4 * 4x8 --> 1x8.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+    }
+    const float32x4_t vfilter_output_scale0123 = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scale4567 = vld1q_f32(w); w = (const float*) w + 4;
+
+    float32x4_t vf0x0123 = vcvtq_f32_s32(vacc0x0123);
+    vout0x0123 = vfmaq_f32(vout0x0123, vf0x0123, vfilter_output_scale0123);
+    float32x4_t vf0x4567 = vcvtq_f32_s32(vacc0x4567);
+    vout0x4567 = vfmaq_f32(vout0x4567, vf0x4567, vfilter_output_scale4567);
+    }
+
+    const float32x4_t one_sixteenth = vdupq_n_f32(1/16.0);
+    vout0x0123 = vmulq_f32(vout0x0123, one_sixteenth);
+    vout0x4567 = vmulq_f32(vout0x4567, one_sixteenth);
+    const float32x4_t vinput_scale0 = vld1q_dup_f32(&quantization_params[0].inv_scale);
+    vout0x0123 = vmulq_f32(vout0x0123, vinput_scale0);
+    vout0x4567 = vmulq_f32(vout0x4567, vinput_scale0);
+
+
+    const float32x4_t vbias0123 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x0123 = vaddq_f32(vbias0123, vout0x0123);
+    const float32x4_t vbias4567 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x4567 = vaddq_f32(vbias4567, vout0x4567);
+
+    float16x8_t vfp16out0x01234567 = vcombine_f16(vcvt_f16_f32(vout0x0123), vcvt_f16_f32(vout0x4567));
+
+    const float16x8_t voutput_min = vreinterpretq_f16_u16(vld1q_dup_u16(&params->fp16arith.min));
+    vfp16out0x01234567 = vmaxq_f16(vfp16out0x01234567, voutput_min);
+    const float16x8_t voutput_max = vreinterpretq_f16_u16(vld1q_dup_u16(&params->fp16arith.max));
+    vfp16out0x01234567 = vminq_f16(vfp16out0x01234567, voutput_max);
+    if XNN_LIKELY(nc >= 8) {
+      vst1q_u16(c0, vreinterpretq_u16_f16(vfp16out0x01234567));
+
+      a0 = (const int8_t*) ((uintptr_t) a0 - kc);
+
+      c0 = (uint16_t*) ((uintptr_t) c0 + cn_stride);
+
+      nc -= 8;
+    } else {
+     float16x4_t vfp16out0x0123 = vget_low_f16(vfp16out0x01234567);
+     if (nc & 4) {
+       vst1_u16(c0, vreinterpret_u16_f16(vfp16out0x0123)); c0 += 4;
+       vfp16out0x0123 = vget_high_f16(vfp16out0x01234567);
+     }
+     if (nc & 2) {
+       vst1_lane_u32((void*) c0, vreinterpret_u32_f16(vfp16out0x0123), 0); c0 += 2;
+       vfp16out0x0123 = vext_f16(vfp16out0x0123, vfp16out0x0123, 2);
+     }
+     if (nc & 1) {
+       vst1_lane_u16(c0, vreinterpret_u16_f16(vfp16out0x0123), 0);
+     }
+      nc = 0;
+    }
+  } while (nc != 0);
+}

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x16c4-minmax-neondotfp16arith.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x16c4-minmax-neondotfp16arith.c
@@ -1,0 +1,258 @@
+// Auto-generated file. Do not edit!
+//   Template: src/qs8-gemm/c4-neondot.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2020 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+
+#include <arm_neon.h>
+
+#include "xnnpack/gemm.h"
+#include "xnnpack/math.h"
+
+
+void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x16c4__neondotfp16arith(
+    size_t mr,
+    size_t nc,
+    size_t kc,
+    const int8_t* restrict a,
+    size_t a_stride,
+    const void* restrict w,
+    uint16_t* restrict c,
+    size_t cm_stride,
+    size_t cn_stride,
+    const union xnn_f16_qb4w_minmax_params params[restrict XNN_MIN_ELEMENTS(1)],
+    const struct xnn_qd8_quantization_params quantization_params[restrict XNN_MIN_ELEMENTS(1)]) XNN_OOB_READS
+{
+  assert(mr != 0);
+  assert(mr <= 2);
+  assert(nc != 0);
+  assert(kc != 0);
+  assert(kc % sizeof(int8_t) == 0);
+  assert(a != NULL);
+  assert(w != NULL);
+  assert(c != NULL);
+
+  kc = round_up_po2(kc, 4 * sizeof(int8_t));
+  const int8_t* a0 = a;
+  uint16_t* c0 = (uint16_t*) c;
+  const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
+  uint16_t* c1 = (uint16_t*) ((uintptr_t) c0 + cm_stride);
+  if XNN_UNPREDICTABLE(mr != 2) {
+    a1 = a0;
+    c1 = c0;
+  }
+
+  size_t bl = params->fp16arith.blocksize;
+  assert(bl <= kc);
+  assert(bl != 0);
+  size_t n_blocks = kc / bl;
+  const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
+  // Loop over groups of 16 columns.
+  do {
+    // Initialize accumulators with bias. 16 bias values are loaded from the
+    // weight matrix, at the start of the group of 16 columns.
+    const float32x4_t vinput_zero_point01 = vcvtq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    const float32x4_t vksum0123 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x0123 = vmulq_lane_f32(vksum0123, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x0123 = vmulq_lane_f32(vksum0123, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksum4567 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksum89AB = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x89AB = vmulq_lane_f32(vksum89AB, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x89AB = vmulq_lane_f32(vksum89AB, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksumCDEF = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0xCDEF = vmulq_lane_f32(vksumCDEF, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vinput_zero_point01), 0);
+
+    for (size_t nb=0; nb < n_blocks; ++nb) {
+      int32x4_t vacc0x0123 = vdupq_n_s32(0);
+      int32x4_t vacc1x0123 = vdupq_n_s32(0);
+      int32x4_t vacc0x4567 = vdupq_n_s32(0);
+      int32x4_t vacc1x4567 = vdupq_n_s32(0);
+      int32x4_t vacc0x89AB = vdupq_n_s32(0);
+      int32x4_t vacc1x89AB = vdupq_n_s32(0);
+      int32x4_t vacc0xCDEF = vdupq_n_s32(0);
+      int32x4_t vacc1xCDEF = vdupq_n_s32(0);
+    // Inner accumulation loop along the 16 columns.
+    size_t k = bl;
+    // 2x partial unrolled loop to load 8 bytes at a time.
+    while (k >= 8 * sizeof(int8_t)) {
+      // Load a 2x8 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 8;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 8;
+
+      // Load a 8x16 block of weights.
+      const int8x16_t vb01234567x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567x89AB = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567xCDEF = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x0123 = vshlq_n_s8(vb01234567x0123, 4);
+      const int8x16_t vb0123x4567 = vshlq_n_s8(vb01234567x4567, 4);
+      const int8x16_t vb0123x89AB = vshlq_n_s8(vb01234567x89AB, 4);
+      const int8x16_t vb0123xCDEF = vshlq_n_s8(vb01234567xCDEF, 4);
+      const int8x16_t vb4567x0123 = vandq_s8(vb01234567x0123, vmask);
+      const int8x16_t vb4567x4567 = vandq_s8(vb01234567x4567, vmask);
+      const int8x16_t vb4567x89AB = vandq_s8(vb01234567x89AB, vmask);
+      const int8x16_t vb4567xCDEF = vandq_s8(vb01234567xCDEF, vmask);
+
+      // Multiply-accumulate: 2x8 * 8x16 --> 2x16.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc0x89AB = vdotq_lane_s32(vacc0x89AB, vb0123x89AB, va0x01234567, 0);
+      vacc0xCDEF = vdotq_lane_s32(vacc0xCDEF, vb0123xCDEF, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+      vacc1x89AB = vdotq_lane_s32(vacc1x89AB, vb0123x89AB, va1x01234567, 0);
+      vacc1xCDEF = vdotq_lane_s32(vacc1xCDEF, vb0123xCDEF, va1x01234567, 0);
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb4567x0123, va0x01234567, 1);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb4567x4567, va0x01234567, 1);
+      vacc0x89AB = vdotq_lane_s32(vacc0x89AB, vb4567x89AB, va0x01234567, 1);
+      vacc0xCDEF = vdotq_lane_s32(vacc0xCDEF, vb4567xCDEF, va0x01234567, 1);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb4567x0123, va1x01234567, 1);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb4567x4567, va1x01234567, 1);
+      vacc1x89AB = vdotq_lane_s32(vacc1x89AB, vb4567x89AB, va1x01234567, 1);
+      vacc1xCDEF = vdotq_lane_s32(vacc1xCDEF, vb4567xCDEF, va1x01234567, 1);
+
+      k -= 8 * sizeof(int8_t);
+    }
+    // Handle up to 4 final positions of `k`
+    if XNN_UNLIKELY(k != 0) {
+      // Load a 2x4 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 4;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 4;
+
+      // Load a 4x16 block of weights.
+      const int8x16_t vb0123x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x89AB = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123xCDEF = vld1q_s8(w); w = (const int8_t*) w + 16;
+
+      // Multiply-accumulate: 2x4 * 4x16 --> 2x16.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc0x89AB = vdotq_lane_s32(vacc0x89AB, vb0123x89AB, va0x01234567, 0);
+      vacc0xCDEF = vdotq_lane_s32(vacc0xCDEF, vb0123xCDEF, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+      vacc1x89AB = vdotq_lane_s32(vacc1x89AB, vb0123x89AB, va1x01234567, 0);
+      vacc1xCDEF = vdotq_lane_s32(vacc1xCDEF, vb0123xCDEF, va1x01234567, 0);
+    }
+    const float32x4_t vfilter_output_scale0123 = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scale4567 = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scale89AB = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scaleCDEF = vld1q_f32(w); w = (const float*) w + 4;
+
+    float32x4_t vf0x0123 = vcvtq_f32_s32(vacc0x0123);
+    float32x4_t vf1x0123 = vcvtq_f32_s32(vacc1x0123);
+    vout0x0123 = vfmaq_f32(vout0x0123, vf0x0123, vfilter_output_scale0123);
+    vout1x0123 = vfmaq_f32(vout1x0123, vf1x0123, vfilter_output_scale0123);
+    float32x4_t vf0x4567 = vcvtq_f32_s32(vacc0x4567);
+    float32x4_t vf1x4567 = vcvtq_f32_s32(vacc1x4567);
+    vout0x4567 = vfmaq_f32(vout0x4567, vf0x4567, vfilter_output_scale4567);
+    vout1x4567 = vfmaq_f32(vout1x4567, vf1x4567, vfilter_output_scale4567);
+    float32x4_t vf0x89AB = vcvtq_f32_s32(vacc0x89AB);
+    float32x4_t vf1x89AB = vcvtq_f32_s32(vacc1x89AB);
+    vout0x89AB = vfmaq_f32(vout0x89AB, vf0x89AB, vfilter_output_scale89AB);
+    vout1x89AB = vfmaq_f32(vout1x89AB, vf1x89AB, vfilter_output_scale89AB);
+    float32x4_t vf0xCDEF = vcvtq_f32_s32(vacc0xCDEF);
+    float32x4_t vf1xCDEF = vcvtq_f32_s32(vacc1xCDEF);
+    vout0xCDEF = vfmaq_f32(vout0xCDEF, vf0xCDEF, vfilter_output_scaleCDEF);
+    vout1xCDEF = vfmaq_f32(vout1xCDEF, vf1xCDEF, vfilter_output_scaleCDEF);
+    }
+
+    const float32x4_t one_sixteenth = vdupq_n_f32(1/16.0);
+    vout0x0123 = vmulq_f32(vout0x0123, one_sixteenth);
+    vout0x4567 = vmulq_f32(vout0x4567, one_sixteenth);
+    vout0x89AB = vmulq_f32(vout0x89AB, one_sixteenth);
+    vout0xCDEF = vmulq_f32(vout0xCDEF, one_sixteenth);
+    vout1x0123 = vmulq_f32(vout1x0123, one_sixteenth);
+    vout1x4567 = vmulq_f32(vout1x4567, one_sixteenth);
+    vout1x89AB = vmulq_f32(vout1x89AB, one_sixteenth);
+    vout1xCDEF = vmulq_f32(vout1xCDEF, one_sixteenth);
+    const float32x4_t vinput_scale01 = vreinterpretq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    vout0x0123 = vmulq_lane_f32(vout0x0123, vget_low_f32(vinput_scale01), 1);
+    vout1x0123 = vmulq_lane_f32(vout1x0123, vget_high_f32(vinput_scale01), 1);
+    vout0x4567 = vmulq_lane_f32(vout0x4567, vget_low_f32(vinput_scale01), 1);
+    vout1x4567 = vmulq_lane_f32(vout1x4567, vget_high_f32(vinput_scale01), 1);
+    vout0x89AB = vmulq_lane_f32(vout0x89AB, vget_low_f32(vinput_scale01), 1);
+    vout1x89AB = vmulq_lane_f32(vout1x89AB, vget_high_f32(vinput_scale01), 1);
+    vout0xCDEF = vmulq_lane_f32(vout0xCDEF, vget_low_f32(vinput_scale01), 1);
+    vout1xCDEF = vmulq_lane_f32(vout1xCDEF, vget_high_f32(vinput_scale01), 1);
+
+
+    const float32x4_t vbias0123 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x0123 = vaddq_f32(vbias0123, vout0x0123);
+    vout1x0123 = vaddq_f32(vbias0123, vout1x0123);
+    const float32x4_t vbias4567 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x4567 = vaddq_f32(vbias4567, vout0x4567);
+    vout1x4567 = vaddq_f32(vbias4567, vout1x4567);
+    const float32x4_t vbias89AB = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x89AB = vaddq_f32(vbias89AB, vout0x89AB);
+    vout1x89AB = vaddq_f32(vbias89AB, vout1x89AB);
+    const float32x4_t vbiasCDEF = vld1q_f32(w); w = (const float*) w + 4;
+    vout0xCDEF = vaddq_f32(vbiasCDEF, vout0xCDEF);
+    vout1xCDEF = vaddq_f32(vbiasCDEF, vout1xCDEF);
+
+    float16x8_t vfp16out0x01234567 = vcombine_f16(vcvt_f16_f32(vout0x0123), vcvt_f16_f32(vout0x4567));
+    float16x8_t vfp16out0x89ABCDEF = vcombine_f16(vcvt_f16_f32(vout0x89AB), vcvt_f16_f32(vout0xCDEF));
+    float16x8_t vfp16out1x01234567 = vcombine_f16(vcvt_f16_f32(vout1x0123), vcvt_f16_f32(vout1x4567));
+    float16x8_t vfp16out1x89ABCDEF = vcombine_f16(vcvt_f16_f32(vout1x89AB), vcvt_f16_f32(vout1xCDEF));
+
+    const float16x8_t voutput_min = vreinterpretq_f16_u16(vld1q_dup_u16(&params->fp16arith.min));
+    vfp16out0x01234567 = vmaxq_f16(vfp16out0x01234567, voutput_min);
+    vfp16out0x89ABCDEF = vmaxq_f16(vfp16out0x89ABCDEF, voutput_min);
+    vfp16out1x01234567 = vmaxq_f16(vfp16out1x01234567, voutput_min);
+    vfp16out1x89ABCDEF = vmaxq_f16(vfp16out1x89ABCDEF, voutput_min);
+    const float16x8_t voutput_max = vreinterpretq_f16_u16(vld1q_dup_u16(&params->fp16arith.max));
+    vfp16out0x01234567 = vminq_f16(vfp16out0x01234567, voutput_max);
+    vfp16out0x89ABCDEF = vminq_f16(vfp16out0x89ABCDEF, voutput_max);
+    vfp16out1x01234567 = vminq_f16(vfp16out1x01234567, voutput_max);
+    vfp16out1x89ABCDEF = vminq_f16(vfp16out1x89ABCDEF, voutput_max);
+    if XNN_LIKELY(nc >= 16) {
+      vst1q_u16(c0, vreinterpretq_u16_f16(vfp16out0x01234567));
+      vst1q_u16(c0 + 8, vreinterpretq_u16_f16(vfp16out0x89ABCDEF));
+      vst1q_u16(c1, vreinterpretq_u16_f16(vfp16out1x01234567));
+      vst1q_u16(c1 + 8, vreinterpretq_u16_f16(vfp16out1x89ABCDEF));
+
+      a0 = (const int8_t*) ((uintptr_t) a0 - kc);
+      a1 = (const int8_t*) ((uintptr_t) a1 - kc);
+
+      c0 = (uint16_t*) ((uintptr_t) c0 + cn_stride);
+      c1 = (uint16_t*) ((uintptr_t) c1 + cn_stride);
+
+      nc -= 16;
+    } else {
+     if (nc & 8) {
+       vst1q_u16(c0, vreinterpretq_u16_f16(vfp16out0x01234567)); c0 += 8;
+       vfp16out0x01234567 = vfp16out0x89ABCDEF;
+       vst1q_u16(c1, vreinterpretq_u16_f16(vfp16out1x01234567)); c1 += 8;
+       vfp16out1x01234567 = vfp16out1x89ABCDEF;
+     }
+     float16x4_t vfp16out0x0123 = vget_low_f16(vfp16out0x01234567);
+     float16x4_t vfp16out1x0123 = vget_low_f16(vfp16out1x01234567);
+     if (nc & 4) {
+       vst1_u16(c0, vreinterpret_u16_f16(vfp16out0x0123)); c0 += 4;
+       vst1_u16(c1, vreinterpret_u16_f16(vfp16out1x0123)); c1 += 4;
+       vfp16out0x0123 = vget_high_f16(vfp16out0x01234567);
+       vfp16out1x0123 = vget_high_f16(vfp16out1x01234567);
+     }
+     if (nc & 2) {
+       vst1_lane_u32((void*) c0, vreinterpret_u32_f16(vfp16out0x0123), 0); c0 += 2;
+       vst1_lane_u32((void*) c1, vreinterpret_u32_f16(vfp16out1x0123), 0); c1 += 2;
+       vfp16out0x0123 = vext_f16(vfp16out0x0123, vfp16out0x0123, 2);
+       vfp16out1x0123 = vext_f16(vfp16out1x0123, vfp16out1x0123, 2);
+     }
+     if (nc & 1) {
+       vst1_lane_u16(c0, vreinterpret_u16_f16(vfp16out0x0123), 0);
+       vst1_lane_u16(c1, vreinterpret_u16_f16(vfp16out1x0123), 0);
+     }
+      nc = 0;
+    }
+  } while (nc != 0);
+}

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x8c4-minmax-neondotfp16arith.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x8c4-minmax-neondotfp16arith.c
@@ -1,0 +1,190 @@
+// Auto-generated file. Do not edit!
+//   Template: src/qs8-gemm/c4-neondot.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2020 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+
+#include <arm_neon.h>
+
+#include "xnnpack/gemm.h"
+#include "xnnpack/math.h"
+
+
+void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x8c4__neondotfp16arith(
+    size_t mr,
+    size_t nc,
+    size_t kc,
+    const int8_t* restrict a,
+    size_t a_stride,
+    const void* restrict w,
+    uint16_t* restrict c,
+    size_t cm_stride,
+    size_t cn_stride,
+    const union xnn_f16_qb4w_minmax_params params[restrict XNN_MIN_ELEMENTS(1)],
+    const struct xnn_qd8_quantization_params quantization_params[restrict XNN_MIN_ELEMENTS(1)]) XNN_OOB_READS
+{
+  assert(mr != 0);
+  assert(mr <= 2);
+  assert(nc != 0);
+  assert(kc != 0);
+  assert(kc % sizeof(int8_t) == 0);
+  assert(a != NULL);
+  assert(w != NULL);
+  assert(c != NULL);
+
+  kc = round_up_po2(kc, 4 * sizeof(int8_t));
+  const int8_t* a0 = a;
+  uint16_t* c0 = (uint16_t*) c;
+  const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
+  uint16_t* c1 = (uint16_t*) ((uintptr_t) c0 + cm_stride);
+  if XNN_UNPREDICTABLE(mr != 2) {
+    a1 = a0;
+    c1 = c0;
+  }
+
+  size_t bl = params->fp16arith.blocksize;
+  assert(bl <= kc);
+  assert(bl != 0);
+  size_t n_blocks = kc / bl;
+  const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
+  // Loop over groups of 8 columns.
+  do {
+    // Initialize accumulators with bias. 8 bias values are loaded from the
+    // weight matrix, at the start of the group of 8 columns.
+    const float32x4_t vinput_zero_point01 = vcvtq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    const float32x4_t vksum0123 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x0123 = vmulq_lane_f32(vksum0123, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x0123 = vmulq_lane_f32(vksum0123, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksum4567 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point01), 0);
+
+    for (size_t nb=0; nb < n_blocks; ++nb) {
+      int32x4_t vacc0x0123 = vdupq_n_s32(0);
+      int32x4_t vacc1x0123 = vdupq_n_s32(0);
+      int32x4_t vacc0x4567 = vdupq_n_s32(0);
+      int32x4_t vacc1x4567 = vdupq_n_s32(0);
+    // Inner accumulation loop along the 8 columns.
+    size_t k = bl;
+    // 2x partial unrolled loop to load 8 bytes at a time.
+    while (k >= 8 * sizeof(int8_t)) {
+      // Load a 2x8 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 8;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 8;
+
+      // Load a 8x8 block of weights.
+      const int8x16_t vb01234567x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x0123 = vshlq_n_s8(vb01234567x0123, 4);
+      const int8x16_t vb0123x4567 = vshlq_n_s8(vb01234567x4567, 4);
+      const int8x16_t vb4567x0123 = vandq_s8(vb01234567x0123, vmask);
+      const int8x16_t vb4567x4567 = vandq_s8(vb01234567x4567, vmask);
+
+      // Multiply-accumulate: 2x8 * 8x8 --> 2x8.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb4567x0123, va0x01234567, 1);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb4567x4567, va0x01234567, 1);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb4567x0123, va1x01234567, 1);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb4567x4567, va1x01234567, 1);
+
+      k -= 8 * sizeof(int8_t);
+    }
+    // Handle up to 4 final positions of `k`
+    if XNN_UNLIKELY(k != 0) {
+      // Load a 2x4 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 4;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 4;
+
+      // Load a 4x8 block of weights.
+      const int8x16_t vb0123x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+
+      // Multiply-accumulate: 2x4 * 4x8 --> 2x8.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+    }
+    const float32x4_t vfilter_output_scale0123 = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scale4567 = vld1q_f32(w); w = (const float*) w + 4;
+
+    float32x4_t vf0x0123 = vcvtq_f32_s32(vacc0x0123);
+    float32x4_t vf1x0123 = vcvtq_f32_s32(vacc1x0123);
+    vout0x0123 = vfmaq_f32(vout0x0123, vf0x0123, vfilter_output_scale0123);
+    vout1x0123 = vfmaq_f32(vout1x0123, vf1x0123, vfilter_output_scale0123);
+    float32x4_t vf0x4567 = vcvtq_f32_s32(vacc0x4567);
+    float32x4_t vf1x4567 = vcvtq_f32_s32(vacc1x4567);
+    vout0x4567 = vfmaq_f32(vout0x4567, vf0x4567, vfilter_output_scale4567);
+    vout1x4567 = vfmaq_f32(vout1x4567, vf1x4567, vfilter_output_scale4567);
+    }
+
+    const float32x4_t one_sixteenth = vdupq_n_f32(1/16.0);
+    vout0x0123 = vmulq_f32(vout0x0123, one_sixteenth);
+    vout0x4567 = vmulq_f32(vout0x4567, one_sixteenth);
+    vout1x0123 = vmulq_f32(vout1x0123, one_sixteenth);
+    vout1x4567 = vmulq_f32(vout1x4567, one_sixteenth);
+    const float32x4_t vinput_scale01 = vreinterpretq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    vout0x0123 = vmulq_lane_f32(vout0x0123, vget_low_f32(vinput_scale01), 1);
+    vout1x0123 = vmulq_lane_f32(vout1x0123, vget_high_f32(vinput_scale01), 1);
+    vout0x4567 = vmulq_lane_f32(vout0x4567, vget_low_f32(vinput_scale01), 1);
+    vout1x4567 = vmulq_lane_f32(vout1x4567, vget_high_f32(vinput_scale01), 1);
+
+
+    const float32x4_t vbias0123 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x0123 = vaddq_f32(vbias0123, vout0x0123);
+    vout1x0123 = vaddq_f32(vbias0123, vout1x0123);
+    const float32x4_t vbias4567 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x4567 = vaddq_f32(vbias4567, vout0x4567);
+    vout1x4567 = vaddq_f32(vbias4567, vout1x4567);
+
+    float16x8_t vfp16out0x01234567 = vcombine_f16(vcvt_f16_f32(vout0x0123), vcvt_f16_f32(vout0x4567));
+    float16x8_t vfp16out1x01234567 = vcombine_f16(vcvt_f16_f32(vout1x0123), vcvt_f16_f32(vout1x4567));
+
+    const float16x8_t voutput_min = vreinterpretq_f16_u16(vld1q_dup_u16(&params->fp16arith.min));
+    vfp16out0x01234567 = vmaxq_f16(vfp16out0x01234567, voutput_min);
+    vfp16out1x01234567 = vmaxq_f16(vfp16out1x01234567, voutput_min);
+    const float16x8_t voutput_max = vreinterpretq_f16_u16(vld1q_dup_u16(&params->fp16arith.max));
+    vfp16out0x01234567 = vminq_f16(vfp16out0x01234567, voutput_max);
+    vfp16out1x01234567 = vminq_f16(vfp16out1x01234567, voutput_max);
+    if XNN_LIKELY(nc >= 8) {
+      vst1q_u16(c0, vreinterpretq_u16_f16(vfp16out0x01234567));
+      vst1q_u16(c1, vreinterpretq_u16_f16(vfp16out1x01234567));
+
+      a0 = (const int8_t*) ((uintptr_t) a0 - kc);
+      a1 = (const int8_t*) ((uintptr_t) a1 - kc);
+
+      c0 = (uint16_t*) ((uintptr_t) c0 + cn_stride);
+      c1 = (uint16_t*) ((uintptr_t) c1 + cn_stride);
+
+      nc -= 8;
+    } else {
+     float16x4_t vfp16out0x0123 = vget_low_f16(vfp16out0x01234567);
+     float16x4_t vfp16out1x0123 = vget_low_f16(vfp16out1x01234567);
+     if (nc & 4) {
+       vst1_u16(c0, vreinterpret_u16_f16(vfp16out0x0123)); c0 += 4;
+       vst1_u16(c1, vreinterpret_u16_f16(vfp16out1x0123)); c1 += 4;
+       vfp16out0x0123 = vget_high_f16(vfp16out0x01234567);
+       vfp16out1x0123 = vget_high_f16(vfp16out1x01234567);
+     }
+     if (nc & 2) {
+       vst1_lane_u32((void*) c0, vreinterpret_u32_f16(vfp16out0x0123), 0); c0 += 2;
+       vst1_lane_u32((void*) c1, vreinterpret_u32_f16(vfp16out1x0123), 0); c1 += 2;
+       vfp16out0x0123 = vext_f16(vfp16out0x0123, vfp16out0x0123, 2);
+       vfp16out1x0123 = vext_f16(vfp16out1x0123, vfp16out1x0123, 2);
+     }
+     if (nc & 1) {
+       vst1_lane_u16(c0, vreinterpret_u16_f16(vfp16out0x0123), 0);
+       vst1_lane_u16(c1, vreinterpret_u16_f16(vfp16out1x0123), 0);
+     }
+      nc = 0;
+    }
+  } while (nc != 0);
+}

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x16c4-minmax-neondotfp16arith.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x16c4-minmax-neondotfp16arith.c
@@ -1,0 +1,326 @@
+// Auto-generated file. Do not edit!
+//   Template: src/qs8-gemm/c4-neondot.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2020 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+
+#include <arm_neon.h>
+
+#include "xnnpack/gemm.h"
+#include "xnnpack/math.h"
+
+
+void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_3x16c4__neondotfp16arith(
+    size_t mr,
+    size_t nc,
+    size_t kc,
+    const int8_t* restrict a,
+    size_t a_stride,
+    const void* restrict w,
+    uint16_t* restrict c,
+    size_t cm_stride,
+    size_t cn_stride,
+    const union xnn_f16_qb4w_minmax_params params[restrict XNN_MIN_ELEMENTS(1)],
+    const struct xnn_qd8_quantization_params quantization_params[restrict XNN_MIN_ELEMENTS(1)]) XNN_OOB_READS
+{
+  assert(mr != 0);
+  assert(mr <= 3);
+  assert(nc != 0);
+  assert(kc != 0);
+  assert(kc % sizeof(int8_t) == 0);
+  assert(a != NULL);
+  assert(w != NULL);
+  assert(c != NULL);
+
+  kc = round_up_po2(kc, 4 * sizeof(int8_t));
+  const int8_t* a0 = a;
+  uint16_t* c0 = (uint16_t*) c;
+  const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
+  uint16_t* c1 = (uint16_t*) ((uintptr_t) c0 + cm_stride);
+  if XNN_UNPREDICTABLE(mr < 2) {
+    a1 = a0;
+    c1 = c0;
+  }
+  const int8_t* a2 = (const int8_t*) ((uintptr_t) a1 + a_stride);
+  uint16_t* c2 = (uint16_t*) ((uintptr_t) c1 + cm_stride);
+  if XNN_UNPREDICTABLE(mr <= 2) {
+    a2 = a1;
+    c2 = c1;
+  }
+
+  size_t bl = params->fp16arith.blocksize;
+  assert(bl <= kc);
+  assert(bl != 0);
+  size_t n_blocks = kc / bl;
+  const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
+  // Loop over groups of 16 columns.
+  do {
+    // Initialize accumulators with bias. 16 bias values are loaded from the
+    // weight matrix, at the start of the group of 16 columns.
+    const float32x4_t vinput_zero_point01 = vcvtq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    const float32x4_t vksum0123 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x0123 = vmulq_lane_f32(vksum0123, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x0123 = vmulq_lane_f32(vksum0123, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksum4567 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksum89AB = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x89AB = vmulq_lane_f32(vksum89AB, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x89AB = vmulq_lane_f32(vksum89AB, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksumCDEF = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0xCDEF = vmulq_lane_f32(vksumCDEF, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vinput_zero_point2 = vcvtq_f32_s32(vld1q_dup_s32(&quantization_params[2].zero_point));
+    float32x4_t vout2x0123 = vmulq_f32(vksum0123, vinput_zero_point2);
+    float32x4_t vout2x4567 = vmulq_f32(vksum4567, vinput_zero_point2);
+    float32x4_t vout2x89AB = vmulq_f32(vksum89AB, vinput_zero_point2);
+    float32x4_t vout2xCDEF = vmulq_f32(vksumCDEF, vinput_zero_point2);
+
+    for (size_t nb=0; nb < n_blocks; ++nb) {
+      int32x4_t vacc0x0123 = vdupq_n_s32(0);
+      int32x4_t vacc1x0123 = vdupq_n_s32(0);
+      int32x4_t vacc0x4567 = vdupq_n_s32(0);
+      int32x4_t vacc1x4567 = vdupq_n_s32(0);
+      int32x4_t vacc0x89AB = vdupq_n_s32(0);
+      int32x4_t vacc1x89AB = vdupq_n_s32(0);
+      int32x4_t vacc0xCDEF = vdupq_n_s32(0);
+      int32x4_t vacc1xCDEF = vdupq_n_s32(0);
+      int32x4_t vacc2x0123 = vdupq_n_s32(0);
+      int32x4_t vacc2x4567 = vdupq_n_s32(0);
+      int32x4_t vacc2x89AB = vdupq_n_s32(0);
+      int32x4_t vacc2xCDEF = vdupq_n_s32(0);
+    // Inner accumulation loop along the 16 columns.
+    size_t k = bl;
+    // 2x partial unrolled loop to load 8 bytes at a time.
+    while (k >= 8 * sizeof(int8_t)) {
+      // Load a 3x8 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 8;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 8;
+      const int8x8_t va2x01234567 = vld1_s8(a2); a2 += 8;
+
+      // Load a 8x16 block of weights.
+      const int8x16_t vb01234567x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567x89AB = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567xCDEF = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x0123 = vshlq_n_s8(vb01234567x0123, 4);
+      const int8x16_t vb0123x4567 = vshlq_n_s8(vb01234567x4567, 4);
+      const int8x16_t vb0123x89AB = vshlq_n_s8(vb01234567x89AB, 4);
+      const int8x16_t vb0123xCDEF = vshlq_n_s8(vb01234567xCDEF, 4);
+      const int8x16_t vb4567x0123 = vandq_s8(vb01234567x0123, vmask);
+      const int8x16_t vb4567x4567 = vandq_s8(vb01234567x4567, vmask);
+      const int8x16_t vb4567x89AB = vandq_s8(vb01234567x89AB, vmask);
+      const int8x16_t vb4567xCDEF = vandq_s8(vb01234567xCDEF, vmask);
+
+      // Multiply-accumulate: 3x8 * 8x16 --> 3x16.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc0x89AB = vdotq_lane_s32(vacc0x89AB, vb0123x89AB, va0x01234567, 0);
+      vacc0xCDEF = vdotq_lane_s32(vacc0xCDEF, vb0123xCDEF, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+      vacc1x89AB = vdotq_lane_s32(vacc1x89AB, vb0123x89AB, va1x01234567, 0);
+      vacc1xCDEF = vdotq_lane_s32(vacc1xCDEF, vb0123xCDEF, va1x01234567, 0);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb0123x0123, va2x01234567, 0);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb0123x4567, va2x01234567, 0);
+      vacc2x89AB = vdotq_lane_s32(vacc2x89AB, vb0123x89AB, va2x01234567, 0);
+      vacc2xCDEF = vdotq_lane_s32(vacc2xCDEF, vb0123xCDEF, va2x01234567, 0);
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb4567x0123, va0x01234567, 1);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb4567x4567, va0x01234567, 1);
+      vacc0x89AB = vdotq_lane_s32(vacc0x89AB, vb4567x89AB, va0x01234567, 1);
+      vacc0xCDEF = vdotq_lane_s32(vacc0xCDEF, vb4567xCDEF, va0x01234567, 1);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb4567x0123, va1x01234567, 1);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb4567x4567, va1x01234567, 1);
+      vacc1x89AB = vdotq_lane_s32(vacc1x89AB, vb4567x89AB, va1x01234567, 1);
+      vacc1xCDEF = vdotq_lane_s32(vacc1xCDEF, vb4567xCDEF, va1x01234567, 1);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb4567x0123, va2x01234567, 1);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb4567x4567, va2x01234567, 1);
+      vacc2x89AB = vdotq_lane_s32(vacc2x89AB, vb4567x89AB, va2x01234567, 1);
+      vacc2xCDEF = vdotq_lane_s32(vacc2xCDEF, vb4567xCDEF, va2x01234567, 1);
+
+      k -= 8 * sizeof(int8_t);
+    }
+    // Handle up to 4 final positions of `k`
+    if XNN_UNLIKELY(k != 0) {
+      // Load a 3x4 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 4;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 4;
+      const int8x8_t va2x01234567 = vld1_s8(a2); a2 += 4;
+
+      // Load a 4x16 block of weights.
+      const int8x16_t vb0123x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x89AB = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123xCDEF = vld1q_s8(w); w = (const int8_t*) w + 16;
+
+      // Multiply-accumulate: 3x4 * 4x16 --> 3x16.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc0x89AB = vdotq_lane_s32(vacc0x89AB, vb0123x89AB, va0x01234567, 0);
+      vacc0xCDEF = vdotq_lane_s32(vacc0xCDEF, vb0123xCDEF, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+      vacc1x89AB = vdotq_lane_s32(vacc1x89AB, vb0123x89AB, va1x01234567, 0);
+      vacc1xCDEF = vdotq_lane_s32(vacc1xCDEF, vb0123xCDEF, va1x01234567, 0);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb0123x0123, va2x01234567, 0);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb0123x4567, va2x01234567, 0);
+      vacc2x89AB = vdotq_lane_s32(vacc2x89AB, vb0123x89AB, va2x01234567, 0);
+      vacc2xCDEF = vdotq_lane_s32(vacc2xCDEF, vb0123xCDEF, va2x01234567, 0);
+    }
+    const float32x4_t vfilter_output_scale0123 = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scale4567 = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scale89AB = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scaleCDEF = vld1q_f32(w); w = (const float*) w + 4;
+
+    float32x4_t vf0x0123 = vcvtq_f32_s32(vacc0x0123);
+    float32x4_t vf1x0123 = vcvtq_f32_s32(vacc1x0123);
+    vout0x0123 = vfmaq_f32(vout0x0123, vf0x0123, vfilter_output_scale0123);
+    vout1x0123 = vfmaq_f32(vout1x0123, vf1x0123, vfilter_output_scale0123);
+    float32x4_t vf0x4567 = vcvtq_f32_s32(vacc0x4567);
+    float32x4_t vf1x4567 = vcvtq_f32_s32(vacc1x4567);
+    vout0x4567 = vfmaq_f32(vout0x4567, vf0x4567, vfilter_output_scale4567);
+    vout1x4567 = vfmaq_f32(vout1x4567, vf1x4567, vfilter_output_scale4567);
+    float32x4_t vf0x89AB = vcvtq_f32_s32(vacc0x89AB);
+    float32x4_t vf1x89AB = vcvtq_f32_s32(vacc1x89AB);
+    vout0x89AB = vfmaq_f32(vout0x89AB, vf0x89AB, vfilter_output_scale89AB);
+    vout1x89AB = vfmaq_f32(vout1x89AB, vf1x89AB, vfilter_output_scale89AB);
+    float32x4_t vf0xCDEF = vcvtq_f32_s32(vacc0xCDEF);
+    float32x4_t vf1xCDEF = vcvtq_f32_s32(vacc1xCDEF);
+    vout0xCDEF = vfmaq_f32(vout0xCDEF, vf0xCDEF, vfilter_output_scaleCDEF);
+    vout1xCDEF = vfmaq_f32(vout1xCDEF, vf1xCDEF, vfilter_output_scaleCDEF);
+    float32x4_t vf2x0123 = vcvtq_f32_s32(vacc2x0123);
+    vout2x0123 = vfmaq_f32(vout2x0123, vf2x0123, vfilter_output_scale0123);
+    float32x4_t vf2x4567 = vcvtq_f32_s32(vacc2x4567);
+    vout2x4567 = vfmaq_f32(vout2x4567, vf2x4567, vfilter_output_scale4567);
+    float32x4_t vf2x89AB = vcvtq_f32_s32(vacc2x89AB);
+    vout2x89AB = vfmaq_f32(vout2x89AB, vf2x89AB, vfilter_output_scale89AB);
+    float32x4_t vf2xCDEF = vcvtq_f32_s32(vacc2xCDEF);
+    vout2xCDEF = vfmaq_f32(vout2xCDEF, vf2xCDEF, vfilter_output_scaleCDEF);
+    }
+
+    const float32x4_t one_sixteenth = vdupq_n_f32(1/16.0);
+    vout0x0123 = vmulq_f32(vout0x0123, one_sixteenth);
+    vout0x4567 = vmulq_f32(vout0x4567, one_sixteenth);
+    vout0x89AB = vmulq_f32(vout0x89AB, one_sixteenth);
+    vout0xCDEF = vmulq_f32(vout0xCDEF, one_sixteenth);
+    vout1x0123 = vmulq_f32(vout1x0123, one_sixteenth);
+    vout1x4567 = vmulq_f32(vout1x4567, one_sixteenth);
+    vout1x89AB = vmulq_f32(vout1x89AB, one_sixteenth);
+    vout1xCDEF = vmulq_f32(vout1xCDEF, one_sixteenth);
+    vout2x0123 = vmulq_f32(vout2x0123, one_sixteenth);
+    vout2x4567 = vmulq_f32(vout2x4567, one_sixteenth);
+    vout2x89AB = vmulq_f32(vout2x89AB, one_sixteenth);
+    vout2xCDEF = vmulq_f32(vout2xCDEF, one_sixteenth);
+    const float32x4_t vinput_scale01 = vreinterpretq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    vout0x0123 = vmulq_lane_f32(vout0x0123, vget_low_f32(vinput_scale01), 1);
+    vout1x0123 = vmulq_lane_f32(vout1x0123, vget_high_f32(vinput_scale01), 1);
+    vout0x4567 = vmulq_lane_f32(vout0x4567, vget_low_f32(vinput_scale01), 1);
+    vout1x4567 = vmulq_lane_f32(vout1x4567, vget_high_f32(vinput_scale01), 1);
+    vout0x89AB = vmulq_lane_f32(vout0x89AB, vget_low_f32(vinput_scale01), 1);
+    vout1x89AB = vmulq_lane_f32(vout1x89AB, vget_high_f32(vinput_scale01), 1);
+    vout0xCDEF = vmulq_lane_f32(vout0xCDEF, vget_low_f32(vinput_scale01), 1);
+    vout1xCDEF = vmulq_lane_f32(vout1xCDEF, vget_high_f32(vinput_scale01), 1);
+    const float32x4_t vinput_scale2 = vld1q_dup_f32(&quantization_params[2].inv_scale);
+    vout2x0123 = vmulq_f32(vout2x0123, vinput_scale2);
+    vout2x4567 = vmulq_f32(vout2x4567, vinput_scale2);
+    vout2x89AB = vmulq_f32(vout2x89AB, vinput_scale2);
+    vout2xCDEF = vmulq_f32(vout2xCDEF, vinput_scale2);
+
+
+    const float32x4_t vbias0123 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x0123 = vaddq_f32(vbias0123, vout0x0123);
+    vout1x0123 = vaddq_f32(vbias0123, vout1x0123);
+    vout2x0123 = vaddq_f32(vbias0123, vout2x0123);
+    const float32x4_t vbias4567 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x4567 = vaddq_f32(vbias4567, vout0x4567);
+    vout1x4567 = vaddq_f32(vbias4567, vout1x4567);
+    vout2x4567 = vaddq_f32(vbias4567, vout2x4567);
+    const float32x4_t vbias89AB = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x89AB = vaddq_f32(vbias89AB, vout0x89AB);
+    vout1x89AB = vaddq_f32(vbias89AB, vout1x89AB);
+    vout2x89AB = vaddq_f32(vbias89AB, vout2x89AB);
+    const float32x4_t vbiasCDEF = vld1q_f32(w); w = (const float*) w + 4;
+    vout0xCDEF = vaddq_f32(vbiasCDEF, vout0xCDEF);
+    vout1xCDEF = vaddq_f32(vbiasCDEF, vout1xCDEF);
+    vout2xCDEF = vaddq_f32(vbiasCDEF, vout2xCDEF);
+
+    float16x8_t vfp16out0x01234567 = vcombine_f16(vcvt_f16_f32(vout0x0123), vcvt_f16_f32(vout0x4567));
+    float16x8_t vfp16out0x89ABCDEF = vcombine_f16(vcvt_f16_f32(vout0x89AB), vcvt_f16_f32(vout0xCDEF));
+    float16x8_t vfp16out1x01234567 = vcombine_f16(vcvt_f16_f32(vout1x0123), vcvt_f16_f32(vout1x4567));
+    float16x8_t vfp16out1x89ABCDEF = vcombine_f16(vcvt_f16_f32(vout1x89AB), vcvt_f16_f32(vout1xCDEF));
+    float16x8_t vfp16out2x01234567 = vcombine_f16(vcvt_f16_f32(vout2x0123), vcvt_f16_f32(vout2x4567));
+    float16x8_t vfp16out2x89ABCDEF = vcombine_f16(vcvt_f16_f32(vout2x89AB), vcvt_f16_f32(vout2xCDEF));
+
+    const float16x8_t voutput_min = vreinterpretq_f16_u16(vld1q_dup_u16(&params->fp16arith.min));
+    vfp16out0x01234567 = vmaxq_f16(vfp16out0x01234567, voutput_min);
+    vfp16out0x89ABCDEF = vmaxq_f16(vfp16out0x89ABCDEF, voutput_min);
+    vfp16out1x01234567 = vmaxq_f16(vfp16out1x01234567, voutput_min);
+    vfp16out1x89ABCDEF = vmaxq_f16(vfp16out1x89ABCDEF, voutput_min);
+    vfp16out2x01234567 = vmaxq_f16(vfp16out2x01234567, voutput_min);
+    vfp16out2x89ABCDEF = vmaxq_f16(vfp16out2x89ABCDEF, voutput_min);
+    const float16x8_t voutput_max = vreinterpretq_f16_u16(vld1q_dup_u16(&params->fp16arith.max));
+    vfp16out0x01234567 = vminq_f16(vfp16out0x01234567, voutput_max);
+    vfp16out0x89ABCDEF = vminq_f16(vfp16out0x89ABCDEF, voutput_max);
+    vfp16out1x01234567 = vminq_f16(vfp16out1x01234567, voutput_max);
+    vfp16out1x89ABCDEF = vminq_f16(vfp16out1x89ABCDEF, voutput_max);
+    vfp16out2x01234567 = vminq_f16(vfp16out2x01234567, voutput_max);
+    vfp16out2x89ABCDEF = vminq_f16(vfp16out2x89ABCDEF, voutput_max);
+    if XNN_LIKELY(nc >= 16) {
+      vst1q_u16(c0, vreinterpretq_u16_f16(vfp16out0x01234567));
+      vst1q_u16(c0 + 8, vreinterpretq_u16_f16(vfp16out0x89ABCDEF));
+      vst1q_u16(c1, vreinterpretq_u16_f16(vfp16out1x01234567));
+      vst1q_u16(c1 + 8, vreinterpretq_u16_f16(vfp16out1x89ABCDEF));
+      vst1q_u16(c2, vreinterpretq_u16_f16(vfp16out2x01234567));
+      vst1q_u16(c2 + 8, vreinterpretq_u16_f16(vfp16out2x89ABCDEF));
+
+      a0 = (const int8_t*) ((uintptr_t) a0 - kc);
+      a1 = (const int8_t*) ((uintptr_t) a1 - kc);
+      a2 = (const int8_t*) ((uintptr_t) a2 - kc);
+
+      c0 = (uint16_t*) ((uintptr_t) c0 + cn_stride);
+      c1 = (uint16_t*) ((uintptr_t) c1 + cn_stride);
+      c2 = (uint16_t*) ((uintptr_t) c2 + cn_stride);
+
+      nc -= 16;
+    } else {
+     if (nc & 8) {
+       vst1q_u16(c0, vreinterpretq_u16_f16(vfp16out0x01234567)); c0 += 8;
+       vfp16out0x01234567 = vfp16out0x89ABCDEF;
+       vst1q_u16(c1, vreinterpretq_u16_f16(vfp16out1x01234567)); c1 += 8;
+       vfp16out1x01234567 = vfp16out1x89ABCDEF;
+       vst1q_u16(c2, vreinterpretq_u16_f16(vfp16out2x01234567)); c2 += 8;
+       vfp16out2x01234567 = vfp16out2x89ABCDEF;
+     }
+     float16x4_t vfp16out0x0123 = vget_low_f16(vfp16out0x01234567);
+     float16x4_t vfp16out1x0123 = vget_low_f16(vfp16out1x01234567);
+     float16x4_t vfp16out2x0123 = vget_low_f16(vfp16out2x01234567);
+     if (nc & 4) {
+       vst1_u16(c0, vreinterpret_u16_f16(vfp16out0x0123)); c0 += 4;
+       vst1_u16(c1, vreinterpret_u16_f16(vfp16out1x0123)); c1 += 4;
+       vst1_u16(c2, vreinterpret_u16_f16(vfp16out2x0123)); c2 += 4;
+       vfp16out0x0123 = vget_high_f16(vfp16out0x01234567);
+       vfp16out1x0123 = vget_high_f16(vfp16out1x01234567);
+       vfp16out2x0123 = vget_high_f16(vfp16out2x01234567);
+     }
+     if (nc & 2) {
+       vst1_lane_u32((void*) c0, vreinterpret_u32_f16(vfp16out0x0123), 0); c0 += 2;
+       vst1_lane_u32((void*) c1, vreinterpret_u32_f16(vfp16out1x0123), 0); c1 += 2;
+       vst1_lane_u32((void*) c2, vreinterpret_u32_f16(vfp16out2x0123), 0); c2 += 2;
+       vfp16out0x0123 = vext_f16(vfp16out0x0123, vfp16out0x0123, 2);
+       vfp16out1x0123 = vext_f16(vfp16out1x0123, vfp16out1x0123, 2);
+       vfp16out2x0123 = vext_f16(vfp16out2x0123, vfp16out2x0123, 2);
+     }
+     if (nc & 1) {
+       vst1_lane_u16(c0, vreinterpret_u16_f16(vfp16out0x0123), 0);
+       vst1_lane_u16(c1, vreinterpret_u16_f16(vfp16out1x0123), 0);
+       vst1_lane_u16(c2, vreinterpret_u16_f16(vfp16out2x0123), 0);
+     }
+      nc = 0;
+    }
+  } while (nc != 0);
+}

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x8c4-minmax-neondotfp16arith.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x8c4-minmax-neondotfp16arith.c
@@ -1,0 +1,232 @@
+// Auto-generated file. Do not edit!
+//   Template: src/qs8-gemm/c4-neondot.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2020 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+
+#include <arm_neon.h>
+
+#include "xnnpack/gemm.h"
+#include "xnnpack/math.h"
+
+
+void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_3x8c4__neondotfp16arith(
+    size_t mr,
+    size_t nc,
+    size_t kc,
+    const int8_t* restrict a,
+    size_t a_stride,
+    const void* restrict w,
+    uint16_t* restrict c,
+    size_t cm_stride,
+    size_t cn_stride,
+    const union xnn_f16_qb4w_minmax_params params[restrict XNN_MIN_ELEMENTS(1)],
+    const struct xnn_qd8_quantization_params quantization_params[restrict XNN_MIN_ELEMENTS(1)]) XNN_OOB_READS
+{
+  assert(mr != 0);
+  assert(mr <= 3);
+  assert(nc != 0);
+  assert(kc != 0);
+  assert(kc % sizeof(int8_t) == 0);
+  assert(a != NULL);
+  assert(w != NULL);
+  assert(c != NULL);
+
+  kc = round_up_po2(kc, 4 * sizeof(int8_t));
+  const int8_t* a0 = a;
+  uint16_t* c0 = (uint16_t*) c;
+  const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
+  uint16_t* c1 = (uint16_t*) ((uintptr_t) c0 + cm_stride);
+  if XNN_UNPREDICTABLE(mr < 2) {
+    a1 = a0;
+    c1 = c0;
+  }
+  const int8_t* a2 = (const int8_t*) ((uintptr_t) a1 + a_stride);
+  uint16_t* c2 = (uint16_t*) ((uintptr_t) c1 + cm_stride);
+  if XNN_UNPREDICTABLE(mr <= 2) {
+    a2 = a1;
+    c2 = c1;
+  }
+
+  size_t bl = params->fp16arith.blocksize;
+  assert(bl <= kc);
+  assert(bl != 0);
+  size_t n_blocks = kc / bl;
+  const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
+  // Loop over groups of 8 columns.
+  do {
+    // Initialize accumulators with bias. 8 bias values are loaded from the
+    // weight matrix, at the start of the group of 8 columns.
+    const float32x4_t vinput_zero_point01 = vcvtq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    const float32x4_t vksum0123 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x0123 = vmulq_lane_f32(vksum0123, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x0123 = vmulq_lane_f32(vksum0123, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksum4567 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vinput_zero_point2 = vcvtq_f32_s32(vld1q_dup_s32(&quantization_params[2].zero_point));
+    float32x4_t vout2x0123 = vmulq_f32(vksum0123, vinput_zero_point2);
+    float32x4_t vout2x4567 = vmulq_f32(vksum4567, vinput_zero_point2);
+
+    for (size_t nb=0; nb < n_blocks; ++nb) {
+      int32x4_t vacc0x0123 = vdupq_n_s32(0);
+      int32x4_t vacc1x0123 = vdupq_n_s32(0);
+      int32x4_t vacc0x4567 = vdupq_n_s32(0);
+      int32x4_t vacc1x4567 = vdupq_n_s32(0);
+      int32x4_t vacc2x0123 = vdupq_n_s32(0);
+      int32x4_t vacc2x4567 = vdupq_n_s32(0);
+    // Inner accumulation loop along the 8 columns.
+    size_t k = bl;
+    // 2x partial unrolled loop to load 8 bytes at a time.
+    while (k >= 8 * sizeof(int8_t)) {
+      // Load a 3x8 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 8;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 8;
+      const int8x8_t va2x01234567 = vld1_s8(a2); a2 += 8;
+
+      // Load a 8x8 block of weights.
+      const int8x16_t vb01234567x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x0123 = vshlq_n_s8(vb01234567x0123, 4);
+      const int8x16_t vb0123x4567 = vshlq_n_s8(vb01234567x4567, 4);
+      const int8x16_t vb4567x0123 = vandq_s8(vb01234567x0123, vmask);
+      const int8x16_t vb4567x4567 = vandq_s8(vb01234567x4567, vmask);
+
+      // Multiply-accumulate: 3x8 * 8x8 --> 3x8.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb0123x0123, va2x01234567, 0);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb0123x4567, va2x01234567, 0);
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb4567x0123, va0x01234567, 1);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb4567x4567, va0x01234567, 1);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb4567x0123, va1x01234567, 1);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb4567x4567, va1x01234567, 1);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb4567x0123, va2x01234567, 1);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb4567x4567, va2x01234567, 1);
+
+      k -= 8 * sizeof(int8_t);
+    }
+    // Handle up to 4 final positions of `k`
+    if XNN_UNLIKELY(k != 0) {
+      // Load a 3x4 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 4;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 4;
+      const int8x8_t va2x01234567 = vld1_s8(a2); a2 += 4;
+
+      // Load a 4x8 block of weights.
+      const int8x16_t vb0123x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+
+      // Multiply-accumulate: 3x4 * 4x8 --> 3x8.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb0123x0123, va2x01234567, 0);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb0123x4567, va2x01234567, 0);
+    }
+    const float32x4_t vfilter_output_scale0123 = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scale4567 = vld1q_f32(w); w = (const float*) w + 4;
+
+    float32x4_t vf0x0123 = vcvtq_f32_s32(vacc0x0123);
+    float32x4_t vf1x0123 = vcvtq_f32_s32(vacc1x0123);
+    vout0x0123 = vfmaq_f32(vout0x0123, vf0x0123, vfilter_output_scale0123);
+    vout1x0123 = vfmaq_f32(vout1x0123, vf1x0123, vfilter_output_scale0123);
+    float32x4_t vf0x4567 = vcvtq_f32_s32(vacc0x4567);
+    float32x4_t vf1x4567 = vcvtq_f32_s32(vacc1x4567);
+    vout0x4567 = vfmaq_f32(vout0x4567, vf0x4567, vfilter_output_scale4567);
+    vout1x4567 = vfmaq_f32(vout1x4567, vf1x4567, vfilter_output_scale4567);
+    float32x4_t vf2x0123 = vcvtq_f32_s32(vacc2x0123);
+    vout2x0123 = vfmaq_f32(vout2x0123, vf2x0123, vfilter_output_scale0123);
+    float32x4_t vf2x4567 = vcvtq_f32_s32(vacc2x4567);
+    vout2x4567 = vfmaq_f32(vout2x4567, vf2x4567, vfilter_output_scale4567);
+    }
+
+    const float32x4_t one_sixteenth = vdupq_n_f32(1/16.0);
+    vout0x0123 = vmulq_f32(vout0x0123, one_sixteenth);
+    vout0x4567 = vmulq_f32(vout0x4567, one_sixteenth);
+    vout1x0123 = vmulq_f32(vout1x0123, one_sixteenth);
+    vout1x4567 = vmulq_f32(vout1x4567, one_sixteenth);
+    vout2x0123 = vmulq_f32(vout2x0123, one_sixteenth);
+    vout2x4567 = vmulq_f32(vout2x4567, one_sixteenth);
+    const float32x4_t vinput_scale01 = vreinterpretq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    vout0x0123 = vmulq_lane_f32(vout0x0123, vget_low_f32(vinput_scale01), 1);
+    vout1x0123 = vmulq_lane_f32(vout1x0123, vget_high_f32(vinput_scale01), 1);
+    vout0x4567 = vmulq_lane_f32(vout0x4567, vget_low_f32(vinput_scale01), 1);
+    vout1x4567 = vmulq_lane_f32(vout1x4567, vget_high_f32(vinput_scale01), 1);
+    const float32x4_t vinput_scale2 = vld1q_dup_f32(&quantization_params[2].inv_scale);
+    vout2x0123 = vmulq_f32(vout2x0123, vinput_scale2);
+    vout2x4567 = vmulq_f32(vout2x4567, vinput_scale2);
+
+
+    const float32x4_t vbias0123 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x0123 = vaddq_f32(vbias0123, vout0x0123);
+    vout1x0123 = vaddq_f32(vbias0123, vout1x0123);
+    vout2x0123 = vaddq_f32(vbias0123, vout2x0123);
+    const float32x4_t vbias4567 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x4567 = vaddq_f32(vbias4567, vout0x4567);
+    vout1x4567 = vaddq_f32(vbias4567, vout1x4567);
+    vout2x4567 = vaddq_f32(vbias4567, vout2x4567);
+
+    float16x8_t vfp16out0x01234567 = vcombine_f16(vcvt_f16_f32(vout0x0123), vcvt_f16_f32(vout0x4567));
+    float16x8_t vfp16out1x01234567 = vcombine_f16(vcvt_f16_f32(vout1x0123), vcvt_f16_f32(vout1x4567));
+    float16x8_t vfp16out2x01234567 = vcombine_f16(vcvt_f16_f32(vout2x0123), vcvt_f16_f32(vout2x4567));
+
+    const float16x8_t voutput_min = vreinterpretq_f16_u16(vld1q_dup_u16(&params->fp16arith.min));
+    vfp16out0x01234567 = vmaxq_f16(vfp16out0x01234567, voutput_min);
+    vfp16out1x01234567 = vmaxq_f16(vfp16out1x01234567, voutput_min);
+    vfp16out2x01234567 = vmaxq_f16(vfp16out2x01234567, voutput_min);
+    const float16x8_t voutput_max = vreinterpretq_f16_u16(vld1q_dup_u16(&params->fp16arith.max));
+    vfp16out0x01234567 = vminq_f16(vfp16out0x01234567, voutput_max);
+    vfp16out1x01234567 = vminq_f16(vfp16out1x01234567, voutput_max);
+    vfp16out2x01234567 = vminq_f16(vfp16out2x01234567, voutput_max);
+    if XNN_LIKELY(nc >= 8) {
+      vst1q_u16(c0, vreinterpretq_u16_f16(vfp16out0x01234567));
+      vst1q_u16(c1, vreinterpretq_u16_f16(vfp16out1x01234567));
+      vst1q_u16(c2, vreinterpretq_u16_f16(vfp16out2x01234567));
+
+      a0 = (const int8_t*) ((uintptr_t) a0 - kc);
+      a1 = (const int8_t*) ((uintptr_t) a1 - kc);
+      a2 = (const int8_t*) ((uintptr_t) a2 - kc);
+
+      c0 = (uint16_t*) ((uintptr_t) c0 + cn_stride);
+      c1 = (uint16_t*) ((uintptr_t) c1 + cn_stride);
+      c2 = (uint16_t*) ((uintptr_t) c2 + cn_stride);
+
+      nc -= 8;
+    } else {
+     float16x4_t vfp16out0x0123 = vget_low_f16(vfp16out0x01234567);
+     float16x4_t vfp16out1x0123 = vget_low_f16(vfp16out1x01234567);
+     float16x4_t vfp16out2x0123 = vget_low_f16(vfp16out2x01234567);
+     if (nc & 4) {
+       vst1_u16(c0, vreinterpret_u16_f16(vfp16out0x0123)); c0 += 4;
+       vst1_u16(c1, vreinterpret_u16_f16(vfp16out1x0123)); c1 += 4;
+       vst1_u16(c2, vreinterpret_u16_f16(vfp16out2x0123)); c2 += 4;
+       vfp16out0x0123 = vget_high_f16(vfp16out0x01234567);
+       vfp16out1x0123 = vget_high_f16(vfp16out1x01234567);
+       vfp16out2x0123 = vget_high_f16(vfp16out2x01234567);
+     }
+     if (nc & 2) {
+       vst1_lane_u32((void*) c0, vreinterpret_u32_f16(vfp16out0x0123), 0); c0 += 2;
+       vst1_lane_u32((void*) c1, vreinterpret_u32_f16(vfp16out1x0123), 0); c1 += 2;
+       vst1_lane_u32((void*) c2, vreinterpret_u32_f16(vfp16out2x0123), 0); c2 += 2;
+       vfp16out0x0123 = vext_f16(vfp16out0x0123, vfp16out0x0123, 2);
+       vfp16out1x0123 = vext_f16(vfp16out1x0123, vfp16out1x0123, 2);
+       vfp16out2x0123 = vext_f16(vfp16out2x0123, vfp16out2x0123, 2);
+     }
+     if (nc & 1) {
+       vst1_lane_u16(c0, vreinterpret_u16_f16(vfp16out0x0123), 0);
+       vst1_lane_u16(c1, vreinterpret_u16_f16(vfp16out1x0123), 0);
+       vst1_lane_u16(c2, vreinterpret_u16_f16(vfp16out2x0123), 0);
+     }
+      nc = 0;
+    }
+  } while (nc != 0);
+}

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x16c4-minmax-neondotfp16arith.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x16c4-minmax-neondotfp16arith.c
@@ -1,0 +1,392 @@
+// Auto-generated file. Do not edit!
+//   Template: src/qs8-gemm/c4-neondot.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2020 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+
+#include <arm_neon.h>
+
+#include "xnnpack/gemm.h"
+#include "xnnpack/math.h"
+
+
+void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x16c4__neondotfp16arith(
+    size_t mr,
+    size_t nc,
+    size_t kc,
+    const int8_t* restrict a,
+    size_t a_stride,
+    const void* restrict w,
+    uint16_t* restrict c,
+    size_t cm_stride,
+    size_t cn_stride,
+    const union xnn_f16_qb4w_minmax_params params[restrict XNN_MIN_ELEMENTS(1)],
+    const struct xnn_qd8_quantization_params quantization_params[restrict XNN_MIN_ELEMENTS(1)]) XNN_OOB_READS
+{
+  assert(mr != 0);
+  assert(mr <= 4);
+  assert(nc != 0);
+  assert(kc != 0);
+  assert(kc % sizeof(int8_t) == 0);
+  assert(a != NULL);
+  assert(w != NULL);
+  assert(c != NULL);
+
+  kc = round_up_po2(kc, 4 * sizeof(int8_t));
+  const int8_t* a0 = a;
+  uint16_t* c0 = (uint16_t*) c;
+  const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
+  uint16_t* c1 = (uint16_t*) ((uintptr_t) c0 + cm_stride);
+  if XNN_UNPREDICTABLE(mr < 2) {
+    a1 = a0;
+    c1 = c0;
+  }
+  const int8_t* a2 = (const int8_t*) ((uintptr_t) a1 + a_stride);
+  uint16_t* c2 = (uint16_t*) ((uintptr_t) c1 + cm_stride);
+  if XNN_UNPREDICTABLE(mr <= 2) {
+    a2 = a1;
+    c2 = c1;
+  }
+  const int8_t* a3 = (const int8_t*) ((uintptr_t) a2 + a_stride);
+  uint16_t* c3 = (uint16_t*) ((uintptr_t) c2 + cm_stride);
+  if XNN_UNPREDICTABLE(mr != 4) {
+    a3 = a2;
+    c3 = c2;
+  }
+
+  size_t bl = params->fp16arith.blocksize;
+  assert(bl <= kc);
+  assert(bl != 0);
+  size_t n_blocks = kc / bl;
+  const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
+  // Loop over groups of 16 columns.
+  do {
+    // Initialize accumulators with bias. 16 bias values are loaded from the
+    // weight matrix, at the start of the group of 16 columns.
+    const float32x4_t vinput_zero_point01 = vcvtq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    const float32x4_t vksum0123 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x0123 = vmulq_lane_f32(vksum0123, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x0123 = vmulq_lane_f32(vksum0123, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksum4567 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksum89AB = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x89AB = vmulq_lane_f32(vksum89AB, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x89AB = vmulq_lane_f32(vksum89AB, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksumCDEF = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0xCDEF = vmulq_lane_f32(vksumCDEF, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vinput_zero_point23 = vcvtq_f32_s32(vld1q_s32(&quantization_params[2].zero_point));
+    float32x4_t vout2x0123 = vmulq_lane_f32(vksum0123, vget_low_f32(vinput_zero_point23), 0);
+    float32x4_t vout3x0123 = vmulq_lane_f32(vksum0123, vget_high_f32(vinput_zero_point23), 0);
+    float32x4_t vout2x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point23), 0);
+    float32x4_t vout3x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point23), 0);
+    float32x4_t vout2x89AB = vmulq_lane_f32(vksum89AB, vget_low_f32(vinput_zero_point23), 0);
+    float32x4_t vout3x89AB = vmulq_lane_f32(vksum89AB, vget_high_f32(vinput_zero_point23), 0);
+    float32x4_t vout2xCDEF = vmulq_lane_f32(vksumCDEF, vget_low_f32(vinput_zero_point23), 0);
+    float32x4_t vout3xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vinput_zero_point23), 0);
+
+    for (size_t nb=0; nb < n_blocks; ++nb) {
+      int32x4_t vacc0x0123 = vdupq_n_s32(0);
+      int32x4_t vacc1x0123 = vdupq_n_s32(0);
+      int32x4_t vacc0x4567 = vdupq_n_s32(0);
+      int32x4_t vacc1x4567 = vdupq_n_s32(0);
+      int32x4_t vacc0x89AB = vdupq_n_s32(0);
+      int32x4_t vacc1x89AB = vdupq_n_s32(0);
+      int32x4_t vacc0xCDEF = vdupq_n_s32(0);
+      int32x4_t vacc1xCDEF = vdupq_n_s32(0);
+      int32x4_t vacc2x0123 = vdupq_n_s32(0);
+      int32x4_t vacc3x0123 = vdupq_n_s32(0);
+      int32x4_t vacc2x4567 = vdupq_n_s32(0);
+      int32x4_t vacc3x4567 = vdupq_n_s32(0);
+      int32x4_t vacc2x89AB = vdupq_n_s32(0);
+      int32x4_t vacc3x89AB = vdupq_n_s32(0);
+      int32x4_t vacc2xCDEF = vdupq_n_s32(0);
+      int32x4_t vacc3xCDEF = vdupq_n_s32(0);
+    // Inner accumulation loop along the 16 columns.
+    size_t k = bl;
+    // 2x partial unrolled loop to load 8 bytes at a time.
+    while (k >= 8 * sizeof(int8_t)) {
+      // Load a 4x8 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 8;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 8;
+      const int8x8_t va2x01234567 = vld1_s8(a2); a2 += 8;
+      const int8x8_t va3x01234567 = vld1_s8(a3); a3 += 8;
+
+      // Load a 8x16 block of weights.
+      const int8x16_t vb01234567x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567x89AB = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567xCDEF = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x0123 = vshlq_n_s8(vb01234567x0123, 4);
+      const int8x16_t vb0123x4567 = vshlq_n_s8(vb01234567x4567, 4);
+      const int8x16_t vb0123x89AB = vshlq_n_s8(vb01234567x89AB, 4);
+      const int8x16_t vb0123xCDEF = vshlq_n_s8(vb01234567xCDEF, 4);
+      const int8x16_t vb4567x0123 = vandq_s8(vb01234567x0123, vmask);
+      const int8x16_t vb4567x4567 = vandq_s8(vb01234567x4567, vmask);
+      const int8x16_t vb4567x89AB = vandq_s8(vb01234567x89AB, vmask);
+      const int8x16_t vb4567xCDEF = vandq_s8(vb01234567xCDEF, vmask);
+
+      // Multiply-accumulate: 4x8 * 8x16 --> 4x16.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc0x89AB = vdotq_lane_s32(vacc0x89AB, vb0123x89AB, va0x01234567, 0);
+      vacc0xCDEF = vdotq_lane_s32(vacc0xCDEF, vb0123xCDEF, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+      vacc1x89AB = vdotq_lane_s32(vacc1x89AB, vb0123x89AB, va1x01234567, 0);
+      vacc1xCDEF = vdotq_lane_s32(vacc1xCDEF, vb0123xCDEF, va1x01234567, 0);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb0123x0123, va2x01234567, 0);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb0123x4567, va2x01234567, 0);
+      vacc2x89AB = vdotq_lane_s32(vacc2x89AB, vb0123x89AB, va2x01234567, 0);
+      vacc2xCDEF = vdotq_lane_s32(vacc2xCDEF, vb0123xCDEF, va2x01234567, 0);
+      vacc3x0123 = vdotq_lane_s32(vacc3x0123, vb0123x0123, va3x01234567, 0);
+      vacc3x4567 = vdotq_lane_s32(vacc3x4567, vb0123x4567, va3x01234567, 0);
+      vacc3x89AB = vdotq_lane_s32(vacc3x89AB, vb0123x89AB, va3x01234567, 0);
+      vacc3xCDEF = vdotq_lane_s32(vacc3xCDEF, vb0123xCDEF, va3x01234567, 0);
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb4567x0123, va0x01234567, 1);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb4567x4567, va0x01234567, 1);
+      vacc0x89AB = vdotq_lane_s32(vacc0x89AB, vb4567x89AB, va0x01234567, 1);
+      vacc0xCDEF = vdotq_lane_s32(vacc0xCDEF, vb4567xCDEF, va0x01234567, 1);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb4567x0123, va1x01234567, 1);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb4567x4567, va1x01234567, 1);
+      vacc1x89AB = vdotq_lane_s32(vacc1x89AB, vb4567x89AB, va1x01234567, 1);
+      vacc1xCDEF = vdotq_lane_s32(vacc1xCDEF, vb4567xCDEF, va1x01234567, 1);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb4567x0123, va2x01234567, 1);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb4567x4567, va2x01234567, 1);
+      vacc2x89AB = vdotq_lane_s32(vacc2x89AB, vb4567x89AB, va2x01234567, 1);
+      vacc2xCDEF = vdotq_lane_s32(vacc2xCDEF, vb4567xCDEF, va2x01234567, 1);
+      vacc3x0123 = vdotq_lane_s32(vacc3x0123, vb4567x0123, va3x01234567, 1);
+      vacc3x4567 = vdotq_lane_s32(vacc3x4567, vb4567x4567, va3x01234567, 1);
+      vacc3x89AB = vdotq_lane_s32(vacc3x89AB, vb4567x89AB, va3x01234567, 1);
+      vacc3xCDEF = vdotq_lane_s32(vacc3xCDEF, vb4567xCDEF, va3x01234567, 1);
+
+      k -= 8 * sizeof(int8_t);
+    }
+    // Handle up to 4 final positions of `k`
+    if XNN_UNLIKELY(k != 0) {
+      // Load a 4x4 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 4;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 4;
+      const int8x8_t va2x01234567 = vld1_s8(a2); a2 += 4;
+      const int8x8_t va3x01234567 = vld1_s8(a3); a3 += 4;
+
+      // Load a 4x16 block of weights.
+      const int8x16_t vb0123x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x89AB = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123xCDEF = vld1q_s8(w); w = (const int8_t*) w + 16;
+
+      // Multiply-accumulate: 4x4 * 4x16 --> 4x16.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc0x89AB = vdotq_lane_s32(vacc0x89AB, vb0123x89AB, va0x01234567, 0);
+      vacc0xCDEF = vdotq_lane_s32(vacc0xCDEF, vb0123xCDEF, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+      vacc1x89AB = vdotq_lane_s32(vacc1x89AB, vb0123x89AB, va1x01234567, 0);
+      vacc1xCDEF = vdotq_lane_s32(vacc1xCDEF, vb0123xCDEF, va1x01234567, 0);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb0123x0123, va2x01234567, 0);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb0123x4567, va2x01234567, 0);
+      vacc2x89AB = vdotq_lane_s32(vacc2x89AB, vb0123x89AB, va2x01234567, 0);
+      vacc2xCDEF = vdotq_lane_s32(vacc2xCDEF, vb0123xCDEF, va2x01234567, 0);
+      vacc3x0123 = vdotq_lane_s32(vacc3x0123, vb0123x0123, va3x01234567, 0);
+      vacc3x4567 = vdotq_lane_s32(vacc3x4567, vb0123x4567, va3x01234567, 0);
+      vacc3x89AB = vdotq_lane_s32(vacc3x89AB, vb0123x89AB, va3x01234567, 0);
+      vacc3xCDEF = vdotq_lane_s32(vacc3xCDEF, vb0123xCDEF, va3x01234567, 0);
+    }
+    const float32x4_t vfilter_output_scale0123 = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scale4567 = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scale89AB = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scaleCDEF = vld1q_f32(w); w = (const float*) w + 4;
+
+    float32x4_t vf0x0123 = vcvtq_f32_s32(vacc0x0123);
+    float32x4_t vf1x0123 = vcvtq_f32_s32(vacc1x0123);
+    vout0x0123 = vfmaq_f32(vout0x0123, vf0x0123, vfilter_output_scale0123);
+    vout1x0123 = vfmaq_f32(vout1x0123, vf1x0123, vfilter_output_scale0123);
+    float32x4_t vf0x4567 = vcvtq_f32_s32(vacc0x4567);
+    float32x4_t vf1x4567 = vcvtq_f32_s32(vacc1x4567);
+    vout0x4567 = vfmaq_f32(vout0x4567, vf0x4567, vfilter_output_scale4567);
+    vout1x4567 = vfmaq_f32(vout1x4567, vf1x4567, vfilter_output_scale4567);
+    float32x4_t vf0x89AB = vcvtq_f32_s32(vacc0x89AB);
+    float32x4_t vf1x89AB = vcvtq_f32_s32(vacc1x89AB);
+    vout0x89AB = vfmaq_f32(vout0x89AB, vf0x89AB, vfilter_output_scale89AB);
+    vout1x89AB = vfmaq_f32(vout1x89AB, vf1x89AB, vfilter_output_scale89AB);
+    float32x4_t vf0xCDEF = vcvtq_f32_s32(vacc0xCDEF);
+    float32x4_t vf1xCDEF = vcvtq_f32_s32(vacc1xCDEF);
+    vout0xCDEF = vfmaq_f32(vout0xCDEF, vf0xCDEF, vfilter_output_scaleCDEF);
+    vout1xCDEF = vfmaq_f32(vout1xCDEF, vf1xCDEF, vfilter_output_scaleCDEF);
+    float32x4_t vf2x0123 = vcvtq_f32_s32(vacc2x0123);
+    float32x4_t vf3x0123 = vcvtq_f32_s32(vacc3x0123);
+    vout2x0123 = vfmaq_f32(vout2x0123, vf2x0123, vfilter_output_scale0123);
+    vout3x0123 = vfmaq_f32(vout3x0123, vf3x0123, vfilter_output_scale0123);
+    float32x4_t vf2x4567 = vcvtq_f32_s32(vacc2x4567);
+    float32x4_t vf3x4567 = vcvtq_f32_s32(vacc3x4567);
+    vout2x4567 = vfmaq_f32(vout2x4567, vf2x4567, vfilter_output_scale4567);
+    vout3x4567 = vfmaq_f32(vout3x4567, vf3x4567, vfilter_output_scale4567);
+    float32x4_t vf2x89AB = vcvtq_f32_s32(vacc2x89AB);
+    float32x4_t vf3x89AB = vcvtq_f32_s32(vacc3x89AB);
+    vout2x89AB = vfmaq_f32(vout2x89AB, vf2x89AB, vfilter_output_scale89AB);
+    vout3x89AB = vfmaq_f32(vout3x89AB, vf3x89AB, vfilter_output_scale89AB);
+    float32x4_t vf2xCDEF = vcvtq_f32_s32(vacc2xCDEF);
+    float32x4_t vf3xCDEF = vcvtq_f32_s32(vacc3xCDEF);
+    vout2xCDEF = vfmaq_f32(vout2xCDEF, vf2xCDEF, vfilter_output_scaleCDEF);
+    vout3xCDEF = vfmaq_f32(vout3xCDEF, vf3xCDEF, vfilter_output_scaleCDEF);
+    }
+
+    const float32x4_t one_sixteenth = vdupq_n_f32(1/16.0);
+    vout0x0123 = vmulq_f32(vout0x0123, one_sixteenth);
+    vout0x4567 = vmulq_f32(vout0x4567, one_sixteenth);
+    vout0x89AB = vmulq_f32(vout0x89AB, one_sixteenth);
+    vout0xCDEF = vmulq_f32(vout0xCDEF, one_sixteenth);
+    vout1x0123 = vmulq_f32(vout1x0123, one_sixteenth);
+    vout1x4567 = vmulq_f32(vout1x4567, one_sixteenth);
+    vout1x89AB = vmulq_f32(vout1x89AB, one_sixteenth);
+    vout1xCDEF = vmulq_f32(vout1xCDEF, one_sixteenth);
+    vout2x0123 = vmulq_f32(vout2x0123, one_sixteenth);
+    vout2x4567 = vmulq_f32(vout2x4567, one_sixteenth);
+    vout2x89AB = vmulq_f32(vout2x89AB, one_sixteenth);
+    vout2xCDEF = vmulq_f32(vout2xCDEF, one_sixteenth);
+    vout3x0123 = vmulq_f32(vout3x0123, one_sixteenth);
+    vout3x4567 = vmulq_f32(vout3x4567, one_sixteenth);
+    vout3x89AB = vmulq_f32(vout3x89AB, one_sixteenth);
+    vout3xCDEF = vmulq_f32(vout3xCDEF, one_sixteenth);
+    const float32x4_t vinput_scale01 = vreinterpretq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    vout0x0123 = vmulq_lane_f32(vout0x0123, vget_low_f32(vinput_scale01), 1);
+    vout1x0123 = vmulq_lane_f32(vout1x0123, vget_high_f32(vinput_scale01), 1);
+    vout0x4567 = vmulq_lane_f32(vout0x4567, vget_low_f32(vinput_scale01), 1);
+    vout1x4567 = vmulq_lane_f32(vout1x4567, vget_high_f32(vinput_scale01), 1);
+    vout0x89AB = vmulq_lane_f32(vout0x89AB, vget_low_f32(vinput_scale01), 1);
+    vout1x89AB = vmulq_lane_f32(vout1x89AB, vget_high_f32(vinput_scale01), 1);
+    vout0xCDEF = vmulq_lane_f32(vout0xCDEF, vget_low_f32(vinput_scale01), 1);
+    vout1xCDEF = vmulq_lane_f32(vout1xCDEF, vget_high_f32(vinput_scale01), 1);
+    const float32x4_t vinput_scale23 = vreinterpretq_f32_s32(vld1q_s32(&quantization_params[2].zero_point));
+    vout2x0123 = vmulq_lane_f32(vout2x0123, vget_low_f32(vinput_scale23), 1);
+    vout3x0123 = vmulq_lane_f32(vout3x0123, vget_high_f32(vinput_scale23), 1);
+    vout2x4567 = vmulq_lane_f32(vout2x4567, vget_low_f32(vinput_scale23), 1);
+    vout3x4567 = vmulq_lane_f32(vout3x4567, vget_high_f32(vinput_scale23), 1);
+    vout2x89AB = vmulq_lane_f32(vout2x89AB, vget_low_f32(vinput_scale23), 1);
+    vout3x89AB = vmulq_lane_f32(vout3x89AB, vget_high_f32(vinput_scale23), 1);
+    vout2xCDEF = vmulq_lane_f32(vout2xCDEF, vget_low_f32(vinput_scale23), 1);
+    vout3xCDEF = vmulq_lane_f32(vout3xCDEF, vget_high_f32(vinput_scale23), 1);
+
+
+    const float32x4_t vbias0123 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x0123 = vaddq_f32(vbias0123, vout0x0123);
+    vout1x0123 = vaddq_f32(vbias0123, vout1x0123);
+    vout2x0123 = vaddq_f32(vbias0123, vout2x0123);
+    vout3x0123 = vaddq_f32(vbias0123, vout3x0123);
+    const float32x4_t vbias4567 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x4567 = vaddq_f32(vbias4567, vout0x4567);
+    vout1x4567 = vaddq_f32(vbias4567, vout1x4567);
+    vout2x4567 = vaddq_f32(vbias4567, vout2x4567);
+    vout3x4567 = vaddq_f32(vbias4567, vout3x4567);
+    const float32x4_t vbias89AB = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x89AB = vaddq_f32(vbias89AB, vout0x89AB);
+    vout1x89AB = vaddq_f32(vbias89AB, vout1x89AB);
+    vout2x89AB = vaddq_f32(vbias89AB, vout2x89AB);
+    vout3x89AB = vaddq_f32(vbias89AB, vout3x89AB);
+    const float32x4_t vbiasCDEF = vld1q_f32(w); w = (const float*) w + 4;
+    vout0xCDEF = vaddq_f32(vbiasCDEF, vout0xCDEF);
+    vout1xCDEF = vaddq_f32(vbiasCDEF, vout1xCDEF);
+    vout2xCDEF = vaddq_f32(vbiasCDEF, vout2xCDEF);
+    vout3xCDEF = vaddq_f32(vbiasCDEF, vout3xCDEF);
+
+    float16x8_t vfp16out0x01234567 = vcombine_f16(vcvt_f16_f32(vout0x0123), vcvt_f16_f32(vout0x4567));
+    float16x8_t vfp16out0x89ABCDEF = vcombine_f16(vcvt_f16_f32(vout0x89AB), vcvt_f16_f32(vout0xCDEF));
+    float16x8_t vfp16out1x01234567 = vcombine_f16(vcvt_f16_f32(vout1x0123), vcvt_f16_f32(vout1x4567));
+    float16x8_t vfp16out1x89ABCDEF = vcombine_f16(vcvt_f16_f32(vout1x89AB), vcvt_f16_f32(vout1xCDEF));
+    float16x8_t vfp16out2x01234567 = vcombine_f16(vcvt_f16_f32(vout2x0123), vcvt_f16_f32(vout2x4567));
+    float16x8_t vfp16out2x89ABCDEF = vcombine_f16(vcvt_f16_f32(vout2x89AB), vcvt_f16_f32(vout2xCDEF));
+    float16x8_t vfp16out3x01234567 = vcombine_f16(vcvt_f16_f32(vout3x0123), vcvt_f16_f32(vout3x4567));
+    float16x8_t vfp16out3x89ABCDEF = vcombine_f16(vcvt_f16_f32(vout3x89AB), vcvt_f16_f32(vout3xCDEF));
+
+    const float16x8_t voutput_min = vreinterpretq_f16_u16(vld1q_dup_u16(&params->fp16arith.min));
+    vfp16out0x01234567 = vmaxq_f16(vfp16out0x01234567, voutput_min);
+    vfp16out0x89ABCDEF = vmaxq_f16(vfp16out0x89ABCDEF, voutput_min);
+    vfp16out1x01234567 = vmaxq_f16(vfp16out1x01234567, voutput_min);
+    vfp16out1x89ABCDEF = vmaxq_f16(vfp16out1x89ABCDEF, voutput_min);
+    vfp16out2x01234567 = vmaxq_f16(vfp16out2x01234567, voutput_min);
+    vfp16out2x89ABCDEF = vmaxq_f16(vfp16out2x89ABCDEF, voutput_min);
+    vfp16out3x01234567 = vmaxq_f16(vfp16out3x01234567, voutput_min);
+    vfp16out3x89ABCDEF = vmaxq_f16(vfp16out3x89ABCDEF, voutput_min);
+    const float16x8_t voutput_max = vreinterpretq_f16_u16(vld1q_dup_u16(&params->fp16arith.max));
+    vfp16out0x01234567 = vminq_f16(vfp16out0x01234567, voutput_max);
+    vfp16out0x89ABCDEF = vminq_f16(vfp16out0x89ABCDEF, voutput_max);
+    vfp16out1x01234567 = vminq_f16(vfp16out1x01234567, voutput_max);
+    vfp16out1x89ABCDEF = vminq_f16(vfp16out1x89ABCDEF, voutput_max);
+    vfp16out2x01234567 = vminq_f16(vfp16out2x01234567, voutput_max);
+    vfp16out2x89ABCDEF = vminq_f16(vfp16out2x89ABCDEF, voutput_max);
+    vfp16out3x01234567 = vminq_f16(vfp16out3x01234567, voutput_max);
+    vfp16out3x89ABCDEF = vminq_f16(vfp16out3x89ABCDEF, voutput_max);
+    if XNN_LIKELY(nc >= 16) {
+      vst1q_u16(c0, vreinterpretq_u16_f16(vfp16out0x01234567));
+      vst1q_u16(c0 + 8, vreinterpretq_u16_f16(vfp16out0x89ABCDEF));
+      vst1q_u16(c1, vreinterpretq_u16_f16(vfp16out1x01234567));
+      vst1q_u16(c1 + 8, vreinterpretq_u16_f16(vfp16out1x89ABCDEF));
+      vst1q_u16(c2, vreinterpretq_u16_f16(vfp16out2x01234567));
+      vst1q_u16(c2 + 8, vreinterpretq_u16_f16(vfp16out2x89ABCDEF));
+      vst1q_u16(c3, vreinterpretq_u16_f16(vfp16out3x01234567));
+      vst1q_u16(c3 + 8, vreinterpretq_u16_f16(vfp16out3x89ABCDEF));
+
+      a0 = (const int8_t*) ((uintptr_t) a0 - kc);
+      a1 = (const int8_t*) ((uintptr_t) a1 - kc);
+      a2 = (const int8_t*) ((uintptr_t) a2 - kc);
+      a3 = (const int8_t*) ((uintptr_t) a3 - kc);
+
+      c0 = (uint16_t*) ((uintptr_t) c0 + cn_stride);
+      c1 = (uint16_t*) ((uintptr_t) c1 + cn_stride);
+      c2 = (uint16_t*) ((uintptr_t) c2 + cn_stride);
+      c3 = (uint16_t*) ((uintptr_t) c3 + cn_stride);
+
+      nc -= 16;
+    } else {
+     if (nc & 8) {
+       vst1q_u16(c0, vreinterpretq_u16_f16(vfp16out0x01234567)); c0 += 8;
+       vfp16out0x01234567 = vfp16out0x89ABCDEF;
+       vst1q_u16(c1, vreinterpretq_u16_f16(vfp16out1x01234567)); c1 += 8;
+       vfp16out1x01234567 = vfp16out1x89ABCDEF;
+       vst1q_u16(c2, vreinterpretq_u16_f16(vfp16out2x01234567)); c2 += 8;
+       vfp16out2x01234567 = vfp16out2x89ABCDEF;
+       vst1q_u16(c3, vreinterpretq_u16_f16(vfp16out3x01234567)); c3 += 8;
+       vfp16out3x01234567 = vfp16out3x89ABCDEF;
+     }
+     float16x4_t vfp16out0x0123 = vget_low_f16(vfp16out0x01234567);
+     float16x4_t vfp16out1x0123 = vget_low_f16(vfp16out1x01234567);
+     float16x4_t vfp16out2x0123 = vget_low_f16(vfp16out2x01234567);
+     float16x4_t vfp16out3x0123 = vget_low_f16(vfp16out3x01234567);
+     if (nc & 4) {
+       vst1_u16(c0, vreinterpret_u16_f16(vfp16out0x0123)); c0 += 4;
+       vst1_u16(c1, vreinterpret_u16_f16(vfp16out1x0123)); c1 += 4;
+       vst1_u16(c2, vreinterpret_u16_f16(vfp16out2x0123)); c2 += 4;
+       vst1_u16(c3, vreinterpret_u16_f16(vfp16out3x0123)); c3 += 4;
+       vfp16out0x0123 = vget_high_f16(vfp16out0x01234567);
+       vfp16out1x0123 = vget_high_f16(vfp16out1x01234567);
+       vfp16out2x0123 = vget_high_f16(vfp16out2x01234567);
+       vfp16out3x0123 = vget_high_f16(vfp16out3x01234567);
+     }
+     if (nc & 2) {
+       vst1_lane_u32((void*) c0, vreinterpret_u32_f16(vfp16out0x0123), 0); c0 += 2;
+       vst1_lane_u32((void*) c1, vreinterpret_u32_f16(vfp16out1x0123), 0); c1 += 2;
+       vst1_lane_u32((void*) c2, vreinterpret_u32_f16(vfp16out2x0123), 0); c2 += 2;
+       vst1_lane_u32((void*) c3, vreinterpret_u32_f16(vfp16out3x0123), 0); c3 += 2;
+       vfp16out0x0123 = vext_f16(vfp16out0x0123, vfp16out0x0123, 2);
+       vfp16out1x0123 = vext_f16(vfp16out1x0123, vfp16out1x0123, 2);
+       vfp16out2x0123 = vext_f16(vfp16out2x0123, vfp16out2x0123, 2);
+       vfp16out3x0123 = vext_f16(vfp16out3x0123, vfp16out3x0123, 2);
+     }
+     if (nc & 1) {
+       vst1_lane_u16(c0, vreinterpret_u16_f16(vfp16out0x0123), 0);
+       vst1_lane_u16(c1, vreinterpret_u16_f16(vfp16out1x0123), 0);
+       vst1_lane_u16(c2, vreinterpret_u16_f16(vfp16out2x0123), 0);
+       vst1_lane_u16(c3, vreinterpret_u16_f16(vfp16out3x0123), 0);
+     }
+      nc = 0;
+    }
+  } while (nc != 0);
+}

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x8c4-minmax-neondotfp16arith.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x8c4-minmax-neondotfp16arith.c
@@ -1,0 +1,272 @@
+// Auto-generated file. Do not edit!
+//   Template: src/qs8-gemm/c4-neondot.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2020 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+
+#include <arm_neon.h>
+
+#include "xnnpack/gemm.h"
+#include "xnnpack/math.h"
+
+
+void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x8c4__neondotfp16arith(
+    size_t mr,
+    size_t nc,
+    size_t kc,
+    const int8_t* restrict a,
+    size_t a_stride,
+    const void* restrict w,
+    uint16_t* restrict c,
+    size_t cm_stride,
+    size_t cn_stride,
+    const union xnn_f16_qb4w_minmax_params params[restrict XNN_MIN_ELEMENTS(1)],
+    const struct xnn_qd8_quantization_params quantization_params[restrict XNN_MIN_ELEMENTS(1)]) XNN_OOB_READS
+{
+  assert(mr != 0);
+  assert(mr <= 4);
+  assert(nc != 0);
+  assert(kc != 0);
+  assert(kc % sizeof(int8_t) == 0);
+  assert(a != NULL);
+  assert(w != NULL);
+  assert(c != NULL);
+
+  kc = round_up_po2(kc, 4 * sizeof(int8_t));
+  const int8_t* a0 = a;
+  uint16_t* c0 = (uint16_t*) c;
+  const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
+  uint16_t* c1 = (uint16_t*) ((uintptr_t) c0 + cm_stride);
+  if XNN_UNPREDICTABLE(mr < 2) {
+    a1 = a0;
+    c1 = c0;
+  }
+  const int8_t* a2 = (const int8_t*) ((uintptr_t) a1 + a_stride);
+  uint16_t* c2 = (uint16_t*) ((uintptr_t) c1 + cm_stride);
+  if XNN_UNPREDICTABLE(mr <= 2) {
+    a2 = a1;
+    c2 = c1;
+  }
+  const int8_t* a3 = (const int8_t*) ((uintptr_t) a2 + a_stride);
+  uint16_t* c3 = (uint16_t*) ((uintptr_t) c2 + cm_stride);
+  if XNN_UNPREDICTABLE(mr != 4) {
+    a3 = a2;
+    c3 = c2;
+  }
+
+  size_t bl = params->fp16arith.blocksize;
+  assert(bl <= kc);
+  assert(bl != 0);
+  size_t n_blocks = kc / bl;
+  const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
+  // Loop over groups of 8 columns.
+  do {
+    // Initialize accumulators with bias. 8 bias values are loaded from the
+    // weight matrix, at the start of the group of 8 columns.
+    const float32x4_t vinput_zero_point01 = vcvtq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    const float32x4_t vksum0123 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x0123 = vmulq_lane_f32(vksum0123, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x0123 = vmulq_lane_f32(vksum0123, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksum4567 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vinput_zero_point23 = vcvtq_f32_s32(vld1q_s32(&quantization_params[2].zero_point));
+    float32x4_t vout2x0123 = vmulq_lane_f32(vksum0123, vget_low_f32(vinput_zero_point23), 0);
+    float32x4_t vout3x0123 = vmulq_lane_f32(vksum0123, vget_high_f32(vinput_zero_point23), 0);
+    float32x4_t vout2x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point23), 0);
+    float32x4_t vout3x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point23), 0);
+
+    for (size_t nb=0; nb < n_blocks; ++nb) {
+      int32x4_t vacc0x0123 = vdupq_n_s32(0);
+      int32x4_t vacc1x0123 = vdupq_n_s32(0);
+      int32x4_t vacc0x4567 = vdupq_n_s32(0);
+      int32x4_t vacc1x4567 = vdupq_n_s32(0);
+      int32x4_t vacc2x0123 = vdupq_n_s32(0);
+      int32x4_t vacc3x0123 = vdupq_n_s32(0);
+      int32x4_t vacc2x4567 = vdupq_n_s32(0);
+      int32x4_t vacc3x4567 = vdupq_n_s32(0);
+    // Inner accumulation loop along the 8 columns.
+    size_t k = bl;
+    // 2x partial unrolled loop to load 8 bytes at a time.
+    while (k >= 8 * sizeof(int8_t)) {
+      // Load a 4x8 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 8;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 8;
+      const int8x8_t va2x01234567 = vld1_s8(a2); a2 += 8;
+      const int8x8_t va3x01234567 = vld1_s8(a3); a3 += 8;
+
+      // Load a 8x8 block of weights.
+      const int8x16_t vb01234567x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x0123 = vshlq_n_s8(vb01234567x0123, 4);
+      const int8x16_t vb0123x4567 = vshlq_n_s8(vb01234567x4567, 4);
+      const int8x16_t vb4567x0123 = vandq_s8(vb01234567x0123, vmask);
+      const int8x16_t vb4567x4567 = vandq_s8(vb01234567x4567, vmask);
+
+      // Multiply-accumulate: 4x8 * 8x8 --> 4x8.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb0123x0123, va2x01234567, 0);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb0123x4567, va2x01234567, 0);
+      vacc3x0123 = vdotq_lane_s32(vacc3x0123, vb0123x0123, va3x01234567, 0);
+      vacc3x4567 = vdotq_lane_s32(vacc3x4567, vb0123x4567, va3x01234567, 0);
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb4567x0123, va0x01234567, 1);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb4567x4567, va0x01234567, 1);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb4567x0123, va1x01234567, 1);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb4567x4567, va1x01234567, 1);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb4567x0123, va2x01234567, 1);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb4567x4567, va2x01234567, 1);
+      vacc3x0123 = vdotq_lane_s32(vacc3x0123, vb4567x0123, va3x01234567, 1);
+      vacc3x4567 = vdotq_lane_s32(vacc3x4567, vb4567x4567, va3x01234567, 1);
+
+      k -= 8 * sizeof(int8_t);
+    }
+    // Handle up to 4 final positions of `k`
+    if XNN_UNLIKELY(k != 0) {
+      // Load a 4x4 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 4;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 4;
+      const int8x8_t va2x01234567 = vld1_s8(a2); a2 += 4;
+      const int8x8_t va3x01234567 = vld1_s8(a3); a3 += 4;
+
+      // Load a 4x8 block of weights.
+      const int8x16_t vb0123x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+
+      // Multiply-accumulate: 4x4 * 4x8 --> 4x8.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb0123x0123, va2x01234567, 0);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb0123x4567, va2x01234567, 0);
+      vacc3x0123 = vdotq_lane_s32(vacc3x0123, vb0123x0123, va3x01234567, 0);
+      vacc3x4567 = vdotq_lane_s32(vacc3x4567, vb0123x4567, va3x01234567, 0);
+    }
+    const float32x4_t vfilter_output_scale0123 = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scale4567 = vld1q_f32(w); w = (const float*) w + 4;
+
+    float32x4_t vf0x0123 = vcvtq_f32_s32(vacc0x0123);
+    float32x4_t vf1x0123 = vcvtq_f32_s32(vacc1x0123);
+    vout0x0123 = vfmaq_f32(vout0x0123, vf0x0123, vfilter_output_scale0123);
+    vout1x0123 = vfmaq_f32(vout1x0123, vf1x0123, vfilter_output_scale0123);
+    float32x4_t vf0x4567 = vcvtq_f32_s32(vacc0x4567);
+    float32x4_t vf1x4567 = vcvtq_f32_s32(vacc1x4567);
+    vout0x4567 = vfmaq_f32(vout0x4567, vf0x4567, vfilter_output_scale4567);
+    vout1x4567 = vfmaq_f32(vout1x4567, vf1x4567, vfilter_output_scale4567);
+    float32x4_t vf2x0123 = vcvtq_f32_s32(vacc2x0123);
+    float32x4_t vf3x0123 = vcvtq_f32_s32(vacc3x0123);
+    vout2x0123 = vfmaq_f32(vout2x0123, vf2x0123, vfilter_output_scale0123);
+    vout3x0123 = vfmaq_f32(vout3x0123, vf3x0123, vfilter_output_scale0123);
+    float32x4_t vf2x4567 = vcvtq_f32_s32(vacc2x4567);
+    float32x4_t vf3x4567 = vcvtq_f32_s32(vacc3x4567);
+    vout2x4567 = vfmaq_f32(vout2x4567, vf2x4567, vfilter_output_scale4567);
+    vout3x4567 = vfmaq_f32(vout3x4567, vf3x4567, vfilter_output_scale4567);
+    }
+
+    const float32x4_t one_sixteenth = vdupq_n_f32(1/16.0);
+    vout0x0123 = vmulq_f32(vout0x0123, one_sixteenth);
+    vout0x4567 = vmulq_f32(vout0x4567, one_sixteenth);
+    vout1x0123 = vmulq_f32(vout1x0123, one_sixteenth);
+    vout1x4567 = vmulq_f32(vout1x4567, one_sixteenth);
+    vout2x0123 = vmulq_f32(vout2x0123, one_sixteenth);
+    vout2x4567 = vmulq_f32(vout2x4567, one_sixteenth);
+    vout3x0123 = vmulq_f32(vout3x0123, one_sixteenth);
+    vout3x4567 = vmulq_f32(vout3x4567, one_sixteenth);
+    const float32x4_t vinput_scale01 = vreinterpretq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    vout0x0123 = vmulq_lane_f32(vout0x0123, vget_low_f32(vinput_scale01), 1);
+    vout1x0123 = vmulq_lane_f32(vout1x0123, vget_high_f32(vinput_scale01), 1);
+    vout0x4567 = vmulq_lane_f32(vout0x4567, vget_low_f32(vinput_scale01), 1);
+    vout1x4567 = vmulq_lane_f32(vout1x4567, vget_high_f32(vinput_scale01), 1);
+    const float32x4_t vinput_scale23 = vreinterpretq_f32_s32(vld1q_s32(&quantization_params[2].zero_point));
+    vout2x0123 = vmulq_lane_f32(vout2x0123, vget_low_f32(vinput_scale23), 1);
+    vout3x0123 = vmulq_lane_f32(vout3x0123, vget_high_f32(vinput_scale23), 1);
+    vout2x4567 = vmulq_lane_f32(vout2x4567, vget_low_f32(vinput_scale23), 1);
+    vout3x4567 = vmulq_lane_f32(vout3x4567, vget_high_f32(vinput_scale23), 1);
+
+
+    const float32x4_t vbias0123 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x0123 = vaddq_f32(vbias0123, vout0x0123);
+    vout1x0123 = vaddq_f32(vbias0123, vout1x0123);
+    vout2x0123 = vaddq_f32(vbias0123, vout2x0123);
+    vout3x0123 = vaddq_f32(vbias0123, vout3x0123);
+    const float32x4_t vbias4567 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x4567 = vaddq_f32(vbias4567, vout0x4567);
+    vout1x4567 = vaddq_f32(vbias4567, vout1x4567);
+    vout2x4567 = vaddq_f32(vbias4567, vout2x4567);
+    vout3x4567 = vaddq_f32(vbias4567, vout3x4567);
+
+    float16x8_t vfp16out0x01234567 = vcombine_f16(vcvt_f16_f32(vout0x0123), vcvt_f16_f32(vout0x4567));
+    float16x8_t vfp16out1x01234567 = vcombine_f16(vcvt_f16_f32(vout1x0123), vcvt_f16_f32(vout1x4567));
+    float16x8_t vfp16out2x01234567 = vcombine_f16(vcvt_f16_f32(vout2x0123), vcvt_f16_f32(vout2x4567));
+    float16x8_t vfp16out3x01234567 = vcombine_f16(vcvt_f16_f32(vout3x0123), vcvt_f16_f32(vout3x4567));
+
+    const float16x8_t voutput_min = vreinterpretq_f16_u16(vld1q_dup_u16(&params->fp16arith.min));
+    vfp16out0x01234567 = vmaxq_f16(vfp16out0x01234567, voutput_min);
+    vfp16out1x01234567 = vmaxq_f16(vfp16out1x01234567, voutput_min);
+    vfp16out2x01234567 = vmaxq_f16(vfp16out2x01234567, voutput_min);
+    vfp16out3x01234567 = vmaxq_f16(vfp16out3x01234567, voutput_min);
+    const float16x8_t voutput_max = vreinterpretq_f16_u16(vld1q_dup_u16(&params->fp16arith.max));
+    vfp16out0x01234567 = vminq_f16(vfp16out0x01234567, voutput_max);
+    vfp16out1x01234567 = vminq_f16(vfp16out1x01234567, voutput_max);
+    vfp16out2x01234567 = vminq_f16(vfp16out2x01234567, voutput_max);
+    vfp16out3x01234567 = vminq_f16(vfp16out3x01234567, voutput_max);
+    if XNN_LIKELY(nc >= 8) {
+      vst1q_u16(c0, vreinterpretq_u16_f16(vfp16out0x01234567));
+      vst1q_u16(c1, vreinterpretq_u16_f16(vfp16out1x01234567));
+      vst1q_u16(c2, vreinterpretq_u16_f16(vfp16out2x01234567));
+      vst1q_u16(c3, vreinterpretq_u16_f16(vfp16out3x01234567));
+
+      a0 = (const int8_t*) ((uintptr_t) a0 - kc);
+      a1 = (const int8_t*) ((uintptr_t) a1 - kc);
+      a2 = (const int8_t*) ((uintptr_t) a2 - kc);
+      a3 = (const int8_t*) ((uintptr_t) a3 - kc);
+
+      c0 = (uint16_t*) ((uintptr_t) c0 + cn_stride);
+      c1 = (uint16_t*) ((uintptr_t) c1 + cn_stride);
+      c2 = (uint16_t*) ((uintptr_t) c2 + cn_stride);
+      c3 = (uint16_t*) ((uintptr_t) c3 + cn_stride);
+
+      nc -= 8;
+    } else {
+     float16x4_t vfp16out0x0123 = vget_low_f16(vfp16out0x01234567);
+     float16x4_t vfp16out1x0123 = vget_low_f16(vfp16out1x01234567);
+     float16x4_t vfp16out2x0123 = vget_low_f16(vfp16out2x01234567);
+     float16x4_t vfp16out3x0123 = vget_low_f16(vfp16out3x01234567);
+     if (nc & 4) {
+       vst1_u16(c0, vreinterpret_u16_f16(vfp16out0x0123)); c0 += 4;
+       vst1_u16(c1, vreinterpret_u16_f16(vfp16out1x0123)); c1 += 4;
+       vst1_u16(c2, vreinterpret_u16_f16(vfp16out2x0123)); c2 += 4;
+       vst1_u16(c3, vreinterpret_u16_f16(vfp16out3x0123)); c3 += 4;
+       vfp16out0x0123 = vget_high_f16(vfp16out0x01234567);
+       vfp16out1x0123 = vget_high_f16(vfp16out1x01234567);
+       vfp16out2x0123 = vget_high_f16(vfp16out2x01234567);
+       vfp16out3x0123 = vget_high_f16(vfp16out3x01234567);
+     }
+     if (nc & 2) {
+       vst1_lane_u32((void*) c0, vreinterpret_u32_f16(vfp16out0x0123), 0); c0 += 2;
+       vst1_lane_u32((void*) c1, vreinterpret_u32_f16(vfp16out1x0123), 0); c1 += 2;
+       vst1_lane_u32((void*) c2, vreinterpret_u32_f16(vfp16out2x0123), 0); c2 += 2;
+       vst1_lane_u32((void*) c3, vreinterpret_u32_f16(vfp16out3x0123), 0); c3 += 2;
+       vfp16out0x0123 = vext_f16(vfp16out0x0123, vfp16out0x0123, 2);
+       vfp16out1x0123 = vext_f16(vfp16out1x0123, vfp16out1x0123, 2);
+       vfp16out2x0123 = vext_f16(vfp16out2x0123, vfp16out2x0123, 2);
+       vfp16out3x0123 = vext_f16(vfp16out3x0123, vfp16out3x0123, 2);
+     }
+     if (nc & 1) {
+       vst1_lane_u16(c0, vreinterpret_u16_f16(vfp16out0x0123), 0);
+       vst1_lane_u16(c1, vreinterpret_u16_f16(vfp16out1x0123), 0);
+       vst1_lane_u16(c2, vreinterpret_u16_f16(vfp16out2x0123), 0);
+       vst1_lane_u16(c3, vreinterpret_u16_f16(vfp16out3x0123), 0);
+     }
+      nc = 0;
+    }
+  } while (nc != 0);
+}

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-5x16c4-minmax-neondotfp16arith.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-5x16c4-minmax-neondotfp16arith.c
@@ -1,0 +1,460 @@
+// Auto-generated file. Do not edit!
+//   Template: src/qs8-gemm/c4-neondot.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2020 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+
+#include <arm_neon.h>
+
+#include "xnnpack/gemm.h"
+#include "xnnpack/math.h"
+
+
+void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_5x16c4__neondotfp16arith(
+    size_t mr,
+    size_t nc,
+    size_t kc,
+    const int8_t* restrict a,
+    size_t a_stride,
+    const void* restrict w,
+    uint16_t* restrict c,
+    size_t cm_stride,
+    size_t cn_stride,
+    const union xnn_f16_qb4w_minmax_params params[restrict XNN_MIN_ELEMENTS(1)],
+    const struct xnn_qd8_quantization_params quantization_params[restrict XNN_MIN_ELEMENTS(1)]) XNN_OOB_READS
+{
+  assert(mr != 0);
+  assert(mr <= 5);
+  assert(nc != 0);
+  assert(kc != 0);
+  assert(kc % sizeof(int8_t) == 0);
+  assert(a != NULL);
+  assert(w != NULL);
+  assert(c != NULL);
+
+  kc = round_up_po2(kc, 4 * sizeof(int8_t));
+  const int8_t* a0 = a;
+  uint16_t* c0 = (uint16_t*) c;
+  const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
+  uint16_t* c1 = (uint16_t*) ((uintptr_t) c0 + cm_stride);
+  if XNN_UNPREDICTABLE(mr < 2) {
+    a1 = a0;
+    c1 = c0;
+  }
+  const int8_t* a2 = (const int8_t*) ((uintptr_t) a1 + a_stride);
+  uint16_t* c2 = (uint16_t*) ((uintptr_t) c1 + cm_stride);
+  if XNN_UNPREDICTABLE(mr <= 2) {
+    a2 = a1;
+    c2 = c1;
+  }
+  const int8_t* a3 = (const int8_t*) ((uintptr_t) a2 + a_stride);
+  uint16_t* c3 = (uint16_t*) ((uintptr_t) c2 + cm_stride);
+  if XNN_UNPREDICTABLE(mr < 4) {
+    a3 = a2;
+    c3 = c2;
+  }
+  const int8_t* a4 = (const int8_t*) ((uintptr_t) a3 + a_stride);
+  uint16_t* c4 = (uint16_t*) ((uintptr_t) c3 + cm_stride);
+  if XNN_UNPREDICTABLE(mr <= 4) {
+    a4 = a3;
+    c4 = c3;
+  }
+
+  size_t bl = params->fp16arith.blocksize;
+  assert(bl <= kc);
+  assert(bl != 0);
+  size_t n_blocks = kc / bl;
+  const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
+  // Loop over groups of 16 columns.
+  do {
+    // Initialize accumulators with bias. 16 bias values are loaded from the
+    // weight matrix, at the start of the group of 16 columns.
+    const float32x4_t vinput_zero_point01 = vcvtq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    const float32x4_t vksum0123 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x0123 = vmulq_lane_f32(vksum0123, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x0123 = vmulq_lane_f32(vksum0123, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksum4567 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksum89AB = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x89AB = vmulq_lane_f32(vksum89AB, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x89AB = vmulq_lane_f32(vksum89AB, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksumCDEF = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0xCDEF = vmulq_lane_f32(vksumCDEF, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vinput_zero_point23 = vcvtq_f32_s32(vld1q_s32(&quantization_params[2].zero_point));
+    float32x4_t vout2x0123 = vmulq_lane_f32(vksum0123, vget_low_f32(vinput_zero_point23), 0);
+    float32x4_t vout3x0123 = vmulq_lane_f32(vksum0123, vget_high_f32(vinput_zero_point23), 0);
+    float32x4_t vout2x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point23), 0);
+    float32x4_t vout3x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point23), 0);
+    float32x4_t vout2x89AB = vmulq_lane_f32(vksum89AB, vget_low_f32(vinput_zero_point23), 0);
+    float32x4_t vout3x89AB = vmulq_lane_f32(vksum89AB, vget_high_f32(vinput_zero_point23), 0);
+    float32x4_t vout2xCDEF = vmulq_lane_f32(vksumCDEF, vget_low_f32(vinput_zero_point23), 0);
+    float32x4_t vout3xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vinput_zero_point23), 0);
+    const float32x4_t vinput_zero_point4 = vcvtq_f32_s32(vld1q_dup_s32(&quantization_params[4].zero_point));
+    float32x4_t vout4x0123 = vmulq_f32(vksum0123, vinput_zero_point4);
+    float32x4_t vout4x4567 = vmulq_f32(vksum4567, vinput_zero_point4);
+    float32x4_t vout4x89AB = vmulq_f32(vksum89AB, vinput_zero_point4);
+    float32x4_t vout4xCDEF = vmulq_f32(vksumCDEF, vinput_zero_point4);
+
+    for (size_t nb=0; nb < n_blocks; ++nb) {
+      int32x4_t vacc0x0123 = vdupq_n_s32(0);
+      int32x4_t vacc1x0123 = vdupq_n_s32(0);
+      int32x4_t vacc0x4567 = vdupq_n_s32(0);
+      int32x4_t vacc1x4567 = vdupq_n_s32(0);
+      int32x4_t vacc0x89AB = vdupq_n_s32(0);
+      int32x4_t vacc1x89AB = vdupq_n_s32(0);
+      int32x4_t vacc0xCDEF = vdupq_n_s32(0);
+      int32x4_t vacc1xCDEF = vdupq_n_s32(0);
+      int32x4_t vacc2x0123 = vdupq_n_s32(0);
+      int32x4_t vacc3x0123 = vdupq_n_s32(0);
+      int32x4_t vacc2x4567 = vdupq_n_s32(0);
+      int32x4_t vacc3x4567 = vdupq_n_s32(0);
+      int32x4_t vacc2x89AB = vdupq_n_s32(0);
+      int32x4_t vacc3x89AB = vdupq_n_s32(0);
+      int32x4_t vacc2xCDEF = vdupq_n_s32(0);
+      int32x4_t vacc3xCDEF = vdupq_n_s32(0);
+      int32x4_t vacc4x0123 = vdupq_n_s32(0);
+      int32x4_t vacc4x4567 = vdupq_n_s32(0);
+      int32x4_t vacc4x89AB = vdupq_n_s32(0);
+      int32x4_t vacc4xCDEF = vdupq_n_s32(0);
+    // Inner accumulation loop along the 16 columns.
+    size_t k = bl;
+    // 2x partial unrolled loop to load 8 bytes at a time.
+    while (k >= 8 * sizeof(int8_t)) {
+      // Load a 5x8 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 8;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 8;
+      const int8x8_t va2x01234567 = vld1_s8(a2); a2 += 8;
+      const int8x8_t va3x01234567 = vld1_s8(a3); a3 += 8;
+      const int8x8_t va4x01234567 = vld1_s8(a4); a4 += 8;
+
+      // Load a 8x16 block of weights.
+      const int8x16_t vb01234567x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567x89AB = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567xCDEF = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x0123 = vshlq_n_s8(vb01234567x0123, 4);
+      const int8x16_t vb0123x4567 = vshlq_n_s8(vb01234567x4567, 4);
+      const int8x16_t vb0123x89AB = vshlq_n_s8(vb01234567x89AB, 4);
+      const int8x16_t vb0123xCDEF = vshlq_n_s8(vb01234567xCDEF, 4);
+      const int8x16_t vb4567x0123 = vandq_s8(vb01234567x0123, vmask);
+      const int8x16_t vb4567x4567 = vandq_s8(vb01234567x4567, vmask);
+      const int8x16_t vb4567x89AB = vandq_s8(vb01234567x89AB, vmask);
+      const int8x16_t vb4567xCDEF = vandq_s8(vb01234567xCDEF, vmask);
+
+      // Multiply-accumulate: 5x8 * 8x16 --> 5x16.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc0x89AB = vdotq_lane_s32(vacc0x89AB, vb0123x89AB, va0x01234567, 0);
+      vacc0xCDEF = vdotq_lane_s32(vacc0xCDEF, vb0123xCDEF, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+      vacc1x89AB = vdotq_lane_s32(vacc1x89AB, vb0123x89AB, va1x01234567, 0);
+      vacc1xCDEF = vdotq_lane_s32(vacc1xCDEF, vb0123xCDEF, va1x01234567, 0);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb0123x0123, va2x01234567, 0);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb0123x4567, va2x01234567, 0);
+      vacc2x89AB = vdotq_lane_s32(vacc2x89AB, vb0123x89AB, va2x01234567, 0);
+      vacc2xCDEF = vdotq_lane_s32(vacc2xCDEF, vb0123xCDEF, va2x01234567, 0);
+      vacc3x0123 = vdotq_lane_s32(vacc3x0123, vb0123x0123, va3x01234567, 0);
+      vacc3x4567 = vdotq_lane_s32(vacc3x4567, vb0123x4567, va3x01234567, 0);
+      vacc3x89AB = vdotq_lane_s32(vacc3x89AB, vb0123x89AB, va3x01234567, 0);
+      vacc3xCDEF = vdotq_lane_s32(vacc3xCDEF, vb0123xCDEF, va3x01234567, 0);
+      vacc4x0123 = vdotq_lane_s32(vacc4x0123, vb0123x0123, va4x01234567, 0);
+      vacc4x4567 = vdotq_lane_s32(vacc4x4567, vb0123x4567, va4x01234567, 0);
+      vacc4x89AB = vdotq_lane_s32(vacc4x89AB, vb0123x89AB, va4x01234567, 0);
+      vacc4xCDEF = vdotq_lane_s32(vacc4xCDEF, vb0123xCDEF, va4x01234567, 0);
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb4567x0123, va0x01234567, 1);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb4567x4567, va0x01234567, 1);
+      vacc0x89AB = vdotq_lane_s32(vacc0x89AB, vb4567x89AB, va0x01234567, 1);
+      vacc0xCDEF = vdotq_lane_s32(vacc0xCDEF, vb4567xCDEF, va0x01234567, 1);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb4567x0123, va1x01234567, 1);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb4567x4567, va1x01234567, 1);
+      vacc1x89AB = vdotq_lane_s32(vacc1x89AB, vb4567x89AB, va1x01234567, 1);
+      vacc1xCDEF = vdotq_lane_s32(vacc1xCDEF, vb4567xCDEF, va1x01234567, 1);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb4567x0123, va2x01234567, 1);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb4567x4567, va2x01234567, 1);
+      vacc2x89AB = vdotq_lane_s32(vacc2x89AB, vb4567x89AB, va2x01234567, 1);
+      vacc2xCDEF = vdotq_lane_s32(vacc2xCDEF, vb4567xCDEF, va2x01234567, 1);
+      vacc3x0123 = vdotq_lane_s32(vacc3x0123, vb4567x0123, va3x01234567, 1);
+      vacc3x4567 = vdotq_lane_s32(vacc3x4567, vb4567x4567, va3x01234567, 1);
+      vacc3x89AB = vdotq_lane_s32(vacc3x89AB, vb4567x89AB, va3x01234567, 1);
+      vacc3xCDEF = vdotq_lane_s32(vacc3xCDEF, vb4567xCDEF, va3x01234567, 1);
+      vacc4x0123 = vdotq_lane_s32(vacc4x0123, vb4567x0123, va4x01234567, 1);
+      vacc4x4567 = vdotq_lane_s32(vacc4x4567, vb4567x4567, va4x01234567, 1);
+      vacc4x89AB = vdotq_lane_s32(vacc4x89AB, vb4567x89AB, va4x01234567, 1);
+      vacc4xCDEF = vdotq_lane_s32(vacc4xCDEF, vb4567xCDEF, va4x01234567, 1);
+
+      k -= 8 * sizeof(int8_t);
+    }
+    // Handle up to 4 final positions of `k`
+    if XNN_UNLIKELY(k != 0) {
+      // Load a 5x4 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 4;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 4;
+      const int8x8_t va2x01234567 = vld1_s8(a2); a2 += 4;
+      const int8x8_t va3x01234567 = vld1_s8(a3); a3 += 4;
+      const int8x8_t va4x01234567 = vld1_s8(a4); a4 += 4;
+
+      // Load a 4x16 block of weights.
+      const int8x16_t vb0123x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x89AB = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123xCDEF = vld1q_s8(w); w = (const int8_t*) w + 16;
+
+      // Multiply-accumulate: 5x4 * 4x16 --> 5x16.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc0x89AB = vdotq_lane_s32(vacc0x89AB, vb0123x89AB, va0x01234567, 0);
+      vacc0xCDEF = vdotq_lane_s32(vacc0xCDEF, vb0123xCDEF, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+      vacc1x89AB = vdotq_lane_s32(vacc1x89AB, vb0123x89AB, va1x01234567, 0);
+      vacc1xCDEF = vdotq_lane_s32(vacc1xCDEF, vb0123xCDEF, va1x01234567, 0);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb0123x0123, va2x01234567, 0);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb0123x4567, va2x01234567, 0);
+      vacc2x89AB = vdotq_lane_s32(vacc2x89AB, vb0123x89AB, va2x01234567, 0);
+      vacc2xCDEF = vdotq_lane_s32(vacc2xCDEF, vb0123xCDEF, va2x01234567, 0);
+      vacc3x0123 = vdotq_lane_s32(vacc3x0123, vb0123x0123, va3x01234567, 0);
+      vacc3x4567 = vdotq_lane_s32(vacc3x4567, vb0123x4567, va3x01234567, 0);
+      vacc3x89AB = vdotq_lane_s32(vacc3x89AB, vb0123x89AB, va3x01234567, 0);
+      vacc3xCDEF = vdotq_lane_s32(vacc3xCDEF, vb0123xCDEF, va3x01234567, 0);
+      vacc4x0123 = vdotq_lane_s32(vacc4x0123, vb0123x0123, va4x01234567, 0);
+      vacc4x4567 = vdotq_lane_s32(vacc4x4567, vb0123x4567, va4x01234567, 0);
+      vacc4x89AB = vdotq_lane_s32(vacc4x89AB, vb0123x89AB, va4x01234567, 0);
+      vacc4xCDEF = vdotq_lane_s32(vacc4xCDEF, vb0123xCDEF, va4x01234567, 0);
+    }
+    const float32x4_t vfilter_output_scale0123 = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scale4567 = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scale89AB = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scaleCDEF = vld1q_f32(w); w = (const float*) w + 4;
+
+    float32x4_t vf0x0123 = vcvtq_f32_s32(vacc0x0123);
+    float32x4_t vf1x0123 = vcvtq_f32_s32(vacc1x0123);
+    vout0x0123 = vfmaq_f32(vout0x0123, vf0x0123, vfilter_output_scale0123);
+    vout1x0123 = vfmaq_f32(vout1x0123, vf1x0123, vfilter_output_scale0123);
+    float32x4_t vf0x4567 = vcvtq_f32_s32(vacc0x4567);
+    float32x4_t vf1x4567 = vcvtq_f32_s32(vacc1x4567);
+    vout0x4567 = vfmaq_f32(vout0x4567, vf0x4567, vfilter_output_scale4567);
+    vout1x4567 = vfmaq_f32(vout1x4567, vf1x4567, vfilter_output_scale4567);
+    float32x4_t vf0x89AB = vcvtq_f32_s32(vacc0x89AB);
+    float32x4_t vf1x89AB = vcvtq_f32_s32(vacc1x89AB);
+    vout0x89AB = vfmaq_f32(vout0x89AB, vf0x89AB, vfilter_output_scale89AB);
+    vout1x89AB = vfmaq_f32(vout1x89AB, vf1x89AB, vfilter_output_scale89AB);
+    float32x4_t vf0xCDEF = vcvtq_f32_s32(vacc0xCDEF);
+    float32x4_t vf1xCDEF = vcvtq_f32_s32(vacc1xCDEF);
+    vout0xCDEF = vfmaq_f32(vout0xCDEF, vf0xCDEF, vfilter_output_scaleCDEF);
+    vout1xCDEF = vfmaq_f32(vout1xCDEF, vf1xCDEF, vfilter_output_scaleCDEF);
+    float32x4_t vf2x0123 = vcvtq_f32_s32(vacc2x0123);
+    float32x4_t vf3x0123 = vcvtq_f32_s32(vacc3x0123);
+    vout2x0123 = vfmaq_f32(vout2x0123, vf2x0123, vfilter_output_scale0123);
+    vout3x0123 = vfmaq_f32(vout3x0123, vf3x0123, vfilter_output_scale0123);
+    float32x4_t vf2x4567 = vcvtq_f32_s32(vacc2x4567);
+    float32x4_t vf3x4567 = vcvtq_f32_s32(vacc3x4567);
+    vout2x4567 = vfmaq_f32(vout2x4567, vf2x4567, vfilter_output_scale4567);
+    vout3x4567 = vfmaq_f32(vout3x4567, vf3x4567, vfilter_output_scale4567);
+    float32x4_t vf2x89AB = vcvtq_f32_s32(vacc2x89AB);
+    float32x4_t vf3x89AB = vcvtq_f32_s32(vacc3x89AB);
+    vout2x89AB = vfmaq_f32(vout2x89AB, vf2x89AB, vfilter_output_scale89AB);
+    vout3x89AB = vfmaq_f32(vout3x89AB, vf3x89AB, vfilter_output_scale89AB);
+    float32x4_t vf2xCDEF = vcvtq_f32_s32(vacc2xCDEF);
+    float32x4_t vf3xCDEF = vcvtq_f32_s32(vacc3xCDEF);
+    vout2xCDEF = vfmaq_f32(vout2xCDEF, vf2xCDEF, vfilter_output_scaleCDEF);
+    vout3xCDEF = vfmaq_f32(vout3xCDEF, vf3xCDEF, vfilter_output_scaleCDEF);
+    float32x4_t vf4x0123 = vcvtq_f32_s32(vacc4x0123);
+    vout4x0123 = vfmaq_f32(vout4x0123, vf4x0123, vfilter_output_scale0123);
+    float32x4_t vf4x4567 = vcvtq_f32_s32(vacc4x4567);
+    vout4x4567 = vfmaq_f32(vout4x4567, vf4x4567, vfilter_output_scale4567);
+    float32x4_t vf4x89AB = vcvtq_f32_s32(vacc4x89AB);
+    vout4x89AB = vfmaq_f32(vout4x89AB, vf4x89AB, vfilter_output_scale89AB);
+    float32x4_t vf4xCDEF = vcvtq_f32_s32(vacc4xCDEF);
+    vout4xCDEF = vfmaq_f32(vout4xCDEF, vf4xCDEF, vfilter_output_scaleCDEF);
+    }
+
+    const float32x4_t one_sixteenth = vdupq_n_f32(1/16.0);
+    vout0x0123 = vmulq_f32(vout0x0123, one_sixteenth);
+    vout0x4567 = vmulq_f32(vout0x4567, one_sixteenth);
+    vout0x89AB = vmulq_f32(vout0x89AB, one_sixteenth);
+    vout0xCDEF = vmulq_f32(vout0xCDEF, one_sixteenth);
+    vout1x0123 = vmulq_f32(vout1x0123, one_sixteenth);
+    vout1x4567 = vmulq_f32(vout1x4567, one_sixteenth);
+    vout1x89AB = vmulq_f32(vout1x89AB, one_sixteenth);
+    vout1xCDEF = vmulq_f32(vout1xCDEF, one_sixteenth);
+    vout2x0123 = vmulq_f32(vout2x0123, one_sixteenth);
+    vout2x4567 = vmulq_f32(vout2x4567, one_sixteenth);
+    vout2x89AB = vmulq_f32(vout2x89AB, one_sixteenth);
+    vout2xCDEF = vmulq_f32(vout2xCDEF, one_sixteenth);
+    vout3x0123 = vmulq_f32(vout3x0123, one_sixteenth);
+    vout3x4567 = vmulq_f32(vout3x4567, one_sixteenth);
+    vout3x89AB = vmulq_f32(vout3x89AB, one_sixteenth);
+    vout3xCDEF = vmulq_f32(vout3xCDEF, one_sixteenth);
+    vout4x0123 = vmulq_f32(vout4x0123, one_sixteenth);
+    vout4x4567 = vmulq_f32(vout4x4567, one_sixteenth);
+    vout4x89AB = vmulq_f32(vout4x89AB, one_sixteenth);
+    vout4xCDEF = vmulq_f32(vout4xCDEF, one_sixteenth);
+    const float32x4_t vinput_scale01 = vreinterpretq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    vout0x0123 = vmulq_lane_f32(vout0x0123, vget_low_f32(vinput_scale01), 1);
+    vout1x0123 = vmulq_lane_f32(vout1x0123, vget_high_f32(vinput_scale01), 1);
+    vout0x4567 = vmulq_lane_f32(vout0x4567, vget_low_f32(vinput_scale01), 1);
+    vout1x4567 = vmulq_lane_f32(vout1x4567, vget_high_f32(vinput_scale01), 1);
+    vout0x89AB = vmulq_lane_f32(vout0x89AB, vget_low_f32(vinput_scale01), 1);
+    vout1x89AB = vmulq_lane_f32(vout1x89AB, vget_high_f32(vinput_scale01), 1);
+    vout0xCDEF = vmulq_lane_f32(vout0xCDEF, vget_low_f32(vinput_scale01), 1);
+    vout1xCDEF = vmulq_lane_f32(vout1xCDEF, vget_high_f32(vinput_scale01), 1);
+    const float32x4_t vinput_scale23 = vreinterpretq_f32_s32(vld1q_s32(&quantization_params[2].zero_point));
+    vout2x0123 = vmulq_lane_f32(vout2x0123, vget_low_f32(vinput_scale23), 1);
+    vout3x0123 = vmulq_lane_f32(vout3x0123, vget_high_f32(vinput_scale23), 1);
+    vout2x4567 = vmulq_lane_f32(vout2x4567, vget_low_f32(vinput_scale23), 1);
+    vout3x4567 = vmulq_lane_f32(vout3x4567, vget_high_f32(vinput_scale23), 1);
+    vout2x89AB = vmulq_lane_f32(vout2x89AB, vget_low_f32(vinput_scale23), 1);
+    vout3x89AB = vmulq_lane_f32(vout3x89AB, vget_high_f32(vinput_scale23), 1);
+    vout2xCDEF = vmulq_lane_f32(vout2xCDEF, vget_low_f32(vinput_scale23), 1);
+    vout3xCDEF = vmulq_lane_f32(vout3xCDEF, vget_high_f32(vinput_scale23), 1);
+    const float32x4_t vinput_scale4 = vld1q_dup_f32(&quantization_params[4].inv_scale);
+    vout4x0123 = vmulq_f32(vout4x0123, vinput_scale4);
+    vout4x4567 = vmulq_f32(vout4x4567, vinput_scale4);
+    vout4x89AB = vmulq_f32(vout4x89AB, vinput_scale4);
+    vout4xCDEF = vmulq_f32(vout4xCDEF, vinput_scale4);
+
+
+    const float32x4_t vbias0123 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x0123 = vaddq_f32(vbias0123, vout0x0123);
+    vout1x0123 = vaddq_f32(vbias0123, vout1x0123);
+    vout2x0123 = vaddq_f32(vbias0123, vout2x0123);
+    vout3x0123 = vaddq_f32(vbias0123, vout3x0123);
+    vout4x0123 = vaddq_f32(vbias0123, vout4x0123);
+    const float32x4_t vbias4567 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x4567 = vaddq_f32(vbias4567, vout0x4567);
+    vout1x4567 = vaddq_f32(vbias4567, vout1x4567);
+    vout2x4567 = vaddq_f32(vbias4567, vout2x4567);
+    vout3x4567 = vaddq_f32(vbias4567, vout3x4567);
+    vout4x4567 = vaddq_f32(vbias4567, vout4x4567);
+    const float32x4_t vbias89AB = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x89AB = vaddq_f32(vbias89AB, vout0x89AB);
+    vout1x89AB = vaddq_f32(vbias89AB, vout1x89AB);
+    vout2x89AB = vaddq_f32(vbias89AB, vout2x89AB);
+    vout3x89AB = vaddq_f32(vbias89AB, vout3x89AB);
+    vout4x89AB = vaddq_f32(vbias89AB, vout4x89AB);
+    const float32x4_t vbiasCDEF = vld1q_f32(w); w = (const float*) w + 4;
+    vout0xCDEF = vaddq_f32(vbiasCDEF, vout0xCDEF);
+    vout1xCDEF = vaddq_f32(vbiasCDEF, vout1xCDEF);
+    vout2xCDEF = vaddq_f32(vbiasCDEF, vout2xCDEF);
+    vout3xCDEF = vaddq_f32(vbiasCDEF, vout3xCDEF);
+    vout4xCDEF = vaddq_f32(vbiasCDEF, vout4xCDEF);
+
+    float16x8_t vfp16out0x01234567 = vcombine_f16(vcvt_f16_f32(vout0x0123), vcvt_f16_f32(vout0x4567));
+    float16x8_t vfp16out0x89ABCDEF = vcombine_f16(vcvt_f16_f32(vout0x89AB), vcvt_f16_f32(vout0xCDEF));
+    float16x8_t vfp16out1x01234567 = vcombine_f16(vcvt_f16_f32(vout1x0123), vcvt_f16_f32(vout1x4567));
+    float16x8_t vfp16out1x89ABCDEF = vcombine_f16(vcvt_f16_f32(vout1x89AB), vcvt_f16_f32(vout1xCDEF));
+    float16x8_t vfp16out2x01234567 = vcombine_f16(vcvt_f16_f32(vout2x0123), vcvt_f16_f32(vout2x4567));
+    float16x8_t vfp16out2x89ABCDEF = vcombine_f16(vcvt_f16_f32(vout2x89AB), vcvt_f16_f32(vout2xCDEF));
+    float16x8_t vfp16out3x01234567 = vcombine_f16(vcvt_f16_f32(vout3x0123), vcvt_f16_f32(vout3x4567));
+    float16x8_t vfp16out3x89ABCDEF = vcombine_f16(vcvt_f16_f32(vout3x89AB), vcvt_f16_f32(vout3xCDEF));
+    float16x8_t vfp16out4x01234567 = vcombine_f16(vcvt_f16_f32(vout4x0123), vcvt_f16_f32(vout4x4567));
+    float16x8_t vfp16out4x89ABCDEF = vcombine_f16(vcvt_f16_f32(vout4x89AB), vcvt_f16_f32(vout4xCDEF));
+
+    const float16x8_t voutput_min = vreinterpretq_f16_u16(vld1q_dup_u16(&params->fp16arith.min));
+    vfp16out0x01234567 = vmaxq_f16(vfp16out0x01234567, voutput_min);
+    vfp16out0x89ABCDEF = vmaxq_f16(vfp16out0x89ABCDEF, voutput_min);
+    vfp16out1x01234567 = vmaxq_f16(vfp16out1x01234567, voutput_min);
+    vfp16out1x89ABCDEF = vmaxq_f16(vfp16out1x89ABCDEF, voutput_min);
+    vfp16out2x01234567 = vmaxq_f16(vfp16out2x01234567, voutput_min);
+    vfp16out2x89ABCDEF = vmaxq_f16(vfp16out2x89ABCDEF, voutput_min);
+    vfp16out3x01234567 = vmaxq_f16(vfp16out3x01234567, voutput_min);
+    vfp16out3x89ABCDEF = vmaxq_f16(vfp16out3x89ABCDEF, voutput_min);
+    vfp16out4x01234567 = vmaxq_f16(vfp16out4x01234567, voutput_min);
+    vfp16out4x89ABCDEF = vmaxq_f16(vfp16out4x89ABCDEF, voutput_min);
+    const float16x8_t voutput_max = vreinterpretq_f16_u16(vld1q_dup_u16(&params->fp16arith.max));
+    vfp16out0x01234567 = vminq_f16(vfp16out0x01234567, voutput_max);
+    vfp16out0x89ABCDEF = vminq_f16(vfp16out0x89ABCDEF, voutput_max);
+    vfp16out1x01234567 = vminq_f16(vfp16out1x01234567, voutput_max);
+    vfp16out1x89ABCDEF = vminq_f16(vfp16out1x89ABCDEF, voutput_max);
+    vfp16out2x01234567 = vminq_f16(vfp16out2x01234567, voutput_max);
+    vfp16out2x89ABCDEF = vminq_f16(vfp16out2x89ABCDEF, voutput_max);
+    vfp16out3x01234567 = vminq_f16(vfp16out3x01234567, voutput_max);
+    vfp16out3x89ABCDEF = vminq_f16(vfp16out3x89ABCDEF, voutput_max);
+    vfp16out4x01234567 = vminq_f16(vfp16out4x01234567, voutput_max);
+    vfp16out4x89ABCDEF = vminq_f16(vfp16out4x89ABCDEF, voutput_max);
+    if XNN_LIKELY(nc >= 16) {
+      vst1q_u16(c0, vreinterpretq_u16_f16(vfp16out0x01234567));
+      vst1q_u16(c0 + 8, vreinterpretq_u16_f16(vfp16out0x89ABCDEF));
+      vst1q_u16(c1, vreinterpretq_u16_f16(vfp16out1x01234567));
+      vst1q_u16(c1 + 8, vreinterpretq_u16_f16(vfp16out1x89ABCDEF));
+      vst1q_u16(c2, vreinterpretq_u16_f16(vfp16out2x01234567));
+      vst1q_u16(c2 + 8, vreinterpretq_u16_f16(vfp16out2x89ABCDEF));
+      vst1q_u16(c3, vreinterpretq_u16_f16(vfp16out3x01234567));
+      vst1q_u16(c3 + 8, vreinterpretq_u16_f16(vfp16out3x89ABCDEF));
+      vst1q_u16(c4, vreinterpretq_u16_f16(vfp16out4x01234567));
+      vst1q_u16(c4 + 8, vreinterpretq_u16_f16(vfp16out4x89ABCDEF));
+
+      a0 = (const int8_t*) ((uintptr_t) a0 - kc);
+      a1 = (const int8_t*) ((uintptr_t) a1 - kc);
+      a2 = (const int8_t*) ((uintptr_t) a2 - kc);
+      a3 = (const int8_t*) ((uintptr_t) a3 - kc);
+      a4 = (const int8_t*) ((uintptr_t) a4 - kc);
+
+      c0 = (uint16_t*) ((uintptr_t) c0 + cn_stride);
+      c1 = (uint16_t*) ((uintptr_t) c1 + cn_stride);
+      c2 = (uint16_t*) ((uintptr_t) c2 + cn_stride);
+      c3 = (uint16_t*) ((uintptr_t) c3 + cn_stride);
+      c4 = (uint16_t*) ((uintptr_t) c4 + cn_stride);
+
+      nc -= 16;
+    } else {
+     if (nc & 8) {
+       vst1q_u16(c0, vreinterpretq_u16_f16(vfp16out0x01234567)); c0 += 8;
+       vfp16out0x01234567 = vfp16out0x89ABCDEF;
+       vst1q_u16(c1, vreinterpretq_u16_f16(vfp16out1x01234567)); c1 += 8;
+       vfp16out1x01234567 = vfp16out1x89ABCDEF;
+       vst1q_u16(c2, vreinterpretq_u16_f16(vfp16out2x01234567)); c2 += 8;
+       vfp16out2x01234567 = vfp16out2x89ABCDEF;
+       vst1q_u16(c3, vreinterpretq_u16_f16(vfp16out3x01234567)); c3 += 8;
+       vfp16out3x01234567 = vfp16out3x89ABCDEF;
+       vst1q_u16(c4, vreinterpretq_u16_f16(vfp16out4x01234567)); c4 += 8;
+       vfp16out4x01234567 = vfp16out4x89ABCDEF;
+     }
+     float16x4_t vfp16out0x0123 = vget_low_f16(vfp16out0x01234567);
+     float16x4_t vfp16out1x0123 = vget_low_f16(vfp16out1x01234567);
+     float16x4_t vfp16out2x0123 = vget_low_f16(vfp16out2x01234567);
+     float16x4_t vfp16out3x0123 = vget_low_f16(vfp16out3x01234567);
+     float16x4_t vfp16out4x0123 = vget_low_f16(vfp16out4x01234567);
+     if (nc & 4) {
+       vst1_u16(c0, vreinterpret_u16_f16(vfp16out0x0123)); c0 += 4;
+       vst1_u16(c1, vreinterpret_u16_f16(vfp16out1x0123)); c1 += 4;
+       vst1_u16(c2, vreinterpret_u16_f16(vfp16out2x0123)); c2 += 4;
+       vst1_u16(c3, vreinterpret_u16_f16(vfp16out3x0123)); c3 += 4;
+       vst1_u16(c4, vreinterpret_u16_f16(vfp16out4x0123)); c4 += 4;
+       vfp16out0x0123 = vget_high_f16(vfp16out0x01234567);
+       vfp16out1x0123 = vget_high_f16(vfp16out1x01234567);
+       vfp16out2x0123 = vget_high_f16(vfp16out2x01234567);
+       vfp16out3x0123 = vget_high_f16(vfp16out3x01234567);
+       vfp16out4x0123 = vget_high_f16(vfp16out4x01234567);
+     }
+     if (nc & 2) {
+       vst1_lane_u32((void*) c0, vreinterpret_u32_f16(vfp16out0x0123), 0); c0 += 2;
+       vst1_lane_u32((void*) c1, vreinterpret_u32_f16(vfp16out1x0123), 0); c1 += 2;
+       vst1_lane_u32((void*) c2, vreinterpret_u32_f16(vfp16out2x0123), 0); c2 += 2;
+       vst1_lane_u32((void*) c3, vreinterpret_u32_f16(vfp16out3x0123), 0); c3 += 2;
+       vst1_lane_u32((void*) c4, vreinterpret_u32_f16(vfp16out4x0123), 0); c4 += 2;
+       vfp16out0x0123 = vext_f16(vfp16out0x0123, vfp16out0x0123, 2);
+       vfp16out1x0123 = vext_f16(vfp16out1x0123, vfp16out1x0123, 2);
+       vfp16out2x0123 = vext_f16(vfp16out2x0123, vfp16out2x0123, 2);
+       vfp16out3x0123 = vext_f16(vfp16out3x0123, vfp16out3x0123, 2);
+       vfp16out4x0123 = vext_f16(vfp16out4x0123, vfp16out4x0123, 2);
+     }
+     if (nc & 1) {
+       vst1_lane_u16(c0, vreinterpret_u16_f16(vfp16out0x0123), 0);
+       vst1_lane_u16(c1, vreinterpret_u16_f16(vfp16out1x0123), 0);
+       vst1_lane_u16(c2, vreinterpret_u16_f16(vfp16out2x0123), 0);
+       vst1_lane_u16(c3, vreinterpret_u16_f16(vfp16out3x0123), 0);
+       vst1_lane_u16(c4, vreinterpret_u16_f16(vfp16out4x0123), 0);
+     }
+      nc = 0;
+    }
+  } while (nc != 0);
+}

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-5x8c4-minmax-neondotfp16arith.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-5x8c4-minmax-neondotfp16arith.c
@@ -1,0 +1,314 @@
+// Auto-generated file. Do not edit!
+//   Template: src/qs8-gemm/c4-neondot.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2020 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+
+#include <arm_neon.h>
+
+#include "xnnpack/gemm.h"
+#include "xnnpack/math.h"
+
+
+void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_5x8c4__neondotfp16arith(
+    size_t mr,
+    size_t nc,
+    size_t kc,
+    const int8_t* restrict a,
+    size_t a_stride,
+    const void* restrict w,
+    uint16_t* restrict c,
+    size_t cm_stride,
+    size_t cn_stride,
+    const union xnn_f16_qb4w_minmax_params params[restrict XNN_MIN_ELEMENTS(1)],
+    const struct xnn_qd8_quantization_params quantization_params[restrict XNN_MIN_ELEMENTS(1)]) XNN_OOB_READS
+{
+  assert(mr != 0);
+  assert(mr <= 5);
+  assert(nc != 0);
+  assert(kc != 0);
+  assert(kc % sizeof(int8_t) == 0);
+  assert(a != NULL);
+  assert(w != NULL);
+  assert(c != NULL);
+
+  kc = round_up_po2(kc, 4 * sizeof(int8_t));
+  const int8_t* a0 = a;
+  uint16_t* c0 = (uint16_t*) c;
+  const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
+  uint16_t* c1 = (uint16_t*) ((uintptr_t) c0 + cm_stride);
+  if XNN_UNPREDICTABLE(mr < 2) {
+    a1 = a0;
+    c1 = c0;
+  }
+  const int8_t* a2 = (const int8_t*) ((uintptr_t) a1 + a_stride);
+  uint16_t* c2 = (uint16_t*) ((uintptr_t) c1 + cm_stride);
+  if XNN_UNPREDICTABLE(mr <= 2) {
+    a2 = a1;
+    c2 = c1;
+  }
+  const int8_t* a3 = (const int8_t*) ((uintptr_t) a2 + a_stride);
+  uint16_t* c3 = (uint16_t*) ((uintptr_t) c2 + cm_stride);
+  if XNN_UNPREDICTABLE(mr < 4) {
+    a3 = a2;
+    c3 = c2;
+  }
+  const int8_t* a4 = (const int8_t*) ((uintptr_t) a3 + a_stride);
+  uint16_t* c4 = (uint16_t*) ((uintptr_t) c3 + cm_stride);
+  if XNN_UNPREDICTABLE(mr <= 4) {
+    a4 = a3;
+    c4 = c3;
+  }
+
+  size_t bl = params->fp16arith.blocksize;
+  assert(bl <= kc);
+  assert(bl != 0);
+  size_t n_blocks = kc / bl;
+  const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
+  // Loop over groups of 8 columns.
+  do {
+    // Initialize accumulators with bias. 8 bias values are loaded from the
+    // weight matrix, at the start of the group of 8 columns.
+    const float32x4_t vinput_zero_point01 = vcvtq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    const float32x4_t vksum0123 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x0123 = vmulq_lane_f32(vksum0123, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x0123 = vmulq_lane_f32(vksum0123, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksum4567 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vinput_zero_point23 = vcvtq_f32_s32(vld1q_s32(&quantization_params[2].zero_point));
+    float32x4_t vout2x0123 = vmulq_lane_f32(vksum0123, vget_low_f32(vinput_zero_point23), 0);
+    float32x4_t vout3x0123 = vmulq_lane_f32(vksum0123, vget_high_f32(vinput_zero_point23), 0);
+    float32x4_t vout2x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point23), 0);
+    float32x4_t vout3x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point23), 0);
+    const float32x4_t vinput_zero_point4 = vcvtq_f32_s32(vld1q_dup_s32(&quantization_params[4].zero_point));
+    float32x4_t vout4x0123 = vmulq_f32(vksum0123, vinput_zero_point4);
+    float32x4_t vout4x4567 = vmulq_f32(vksum4567, vinput_zero_point4);
+
+    for (size_t nb=0; nb < n_blocks; ++nb) {
+      int32x4_t vacc0x0123 = vdupq_n_s32(0);
+      int32x4_t vacc1x0123 = vdupq_n_s32(0);
+      int32x4_t vacc0x4567 = vdupq_n_s32(0);
+      int32x4_t vacc1x4567 = vdupq_n_s32(0);
+      int32x4_t vacc2x0123 = vdupq_n_s32(0);
+      int32x4_t vacc3x0123 = vdupq_n_s32(0);
+      int32x4_t vacc2x4567 = vdupq_n_s32(0);
+      int32x4_t vacc3x4567 = vdupq_n_s32(0);
+      int32x4_t vacc4x0123 = vdupq_n_s32(0);
+      int32x4_t vacc4x4567 = vdupq_n_s32(0);
+    // Inner accumulation loop along the 8 columns.
+    size_t k = bl;
+    // 2x partial unrolled loop to load 8 bytes at a time.
+    while (k >= 8 * sizeof(int8_t)) {
+      // Load a 5x8 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 8;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 8;
+      const int8x8_t va2x01234567 = vld1_s8(a2); a2 += 8;
+      const int8x8_t va3x01234567 = vld1_s8(a3); a3 += 8;
+      const int8x8_t va4x01234567 = vld1_s8(a4); a4 += 8;
+
+      // Load a 8x8 block of weights.
+      const int8x16_t vb01234567x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x0123 = vshlq_n_s8(vb01234567x0123, 4);
+      const int8x16_t vb0123x4567 = vshlq_n_s8(vb01234567x4567, 4);
+      const int8x16_t vb4567x0123 = vandq_s8(vb01234567x0123, vmask);
+      const int8x16_t vb4567x4567 = vandq_s8(vb01234567x4567, vmask);
+
+      // Multiply-accumulate: 5x8 * 8x8 --> 5x8.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb0123x0123, va2x01234567, 0);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb0123x4567, va2x01234567, 0);
+      vacc3x0123 = vdotq_lane_s32(vacc3x0123, vb0123x0123, va3x01234567, 0);
+      vacc3x4567 = vdotq_lane_s32(vacc3x4567, vb0123x4567, va3x01234567, 0);
+      vacc4x0123 = vdotq_lane_s32(vacc4x0123, vb0123x0123, va4x01234567, 0);
+      vacc4x4567 = vdotq_lane_s32(vacc4x4567, vb0123x4567, va4x01234567, 0);
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb4567x0123, va0x01234567, 1);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb4567x4567, va0x01234567, 1);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb4567x0123, va1x01234567, 1);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb4567x4567, va1x01234567, 1);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb4567x0123, va2x01234567, 1);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb4567x4567, va2x01234567, 1);
+      vacc3x0123 = vdotq_lane_s32(vacc3x0123, vb4567x0123, va3x01234567, 1);
+      vacc3x4567 = vdotq_lane_s32(vacc3x4567, vb4567x4567, va3x01234567, 1);
+      vacc4x0123 = vdotq_lane_s32(vacc4x0123, vb4567x0123, va4x01234567, 1);
+      vacc4x4567 = vdotq_lane_s32(vacc4x4567, vb4567x4567, va4x01234567, 1);
+
+      k -= 8 * sizeof(int8_t);
+    }
+    // Handle up to 4 final positions of `k`
+    if XNN_UNLIKELY(k != 0) {
+      // Load a 5x4 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 4;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 4;
+      const int8x8_t va2x01234567 = vld1_s8(a2); a2 += 4;
+      const int8x8_t va3x01234567 = vld1_s8(a3); a3 += 4;
+      const int8x8_t va4x01234567 = vld1_s8(a4); a4 += 4;
+
+      // Load a 4x8 block of weights.
+      const int8x16_t vb0123x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+
+      // Multiply-accumulate: 5x4 * 4x8 --> 5x8.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb0123x0123, va2x01234567, 0);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb0123x4567, va2x01234567, 0);
+      vacc3x0123 = vdotq_lane_s32(vacc3x0123, vb0123x0123, va3x01234567, 0);
+      vacc3x4567 = vdotq_lane_s32(vacc3x4567, vb0123x4567, va3x01234567, 0);
+      vacc4x0123 = vdotq_lane_s32(vacc4x0123, vb0123x0123, va4x01234567, 0);
+      vacc4x4567 = vdotq_lane_s32(vacc4x4567, vb0123x4567, va4x01234567, 0);
+    }
+    const float32x4_t vfilter_output_scale0123 = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scale4567 = vld1q_f32(w); w = (const float*) w + 4;
+
+    float32x4_t vf0x0123 = vcvtq_f32_s32(vacc0x0123);
+    float32x4_t vf1x0123 = vcvtq_f32_s32(vacc1x0123);
+    vout0x0123 = vfmaq_f32(vout0x0123, vf0x0123, vfilter_output_scale0123);
+    vout1x0123 = vfmaq_f32(vout1x0123, vf1x0123, vfilter_output_scale0123);
+    float32x4_t vf0x4567 = vcvtq_f32_s32(vacc0x4567);
+    float32x4_t vf1x4567 = vcvtq_f32_s32(vacc1x4567);
+    vout0x4567 = vfmaq_f32(vout0x4567, vf0x4567, vfilter_output_scale4567);
+    vout1x4567 = vfmaq_f32(vout1x4567, vf1x4567, vfilter_output_scale4567);
+    float32x4_t vf2x0123 = vcvtq_f32_s32(vacc2x0123);
+    float32x4_t vf3x0123 = vcvtq_f32_s32(vacc3x0123);
+    vout2x0123 = vfmaq_f32(vout2x0123, vf2x0123, vfilter_output_scale0123);
+    vout3x0123 = vfmaq_f32(vout3x0123, vf3x0123, vfilter_output_scale0123);
+    float32x4_t vf2x4567 = vcvtq_f32_s32(vacc2x4567);
+    float32x4_t vf3x4567 = vcvtq_f32_s32(vacc3x4567);
+    vout2x4567 = vfmaq_f32(vout2x4567, vf2x4567, vfilter_output_scale4567);
+    vout3x4567 = vfmaq_f32(vout3x4567, vf3x4567, vfilter_output_scale4567);
+    float32x4_t vf4x0123 = vcvtq_f32_s32(vacc4x0123);
+    vout4x0123 = vfmaq_f32(vout4x0123, vf4x0123, vfilter_output_scale0123);
+    float32x4_t vf4x4567 = vcvtq_f32_s32(vacc4x4567);
+    vout4x4567 = vfmaq_f32(vout4x4567, vf4x4567, vfilter_output_scale4567);
+    }
+
+    const float32x4_t one_sixteenth = vdupq_n_f32(1/16.0);
+    vout0x0123 = vmulq_f32(vout0x0123, one_sixteenth);
+    vout0x4567 = vmulq_f32(vout0x4567, one_sixteenth);
+    vout1x0123 = vmulq_f32(vout1x0123, one_sixteenth);
+    vout1x4567 = vmulq_f32(vout1x4567, one_sixteenth);
+    vout2x0123 = vmulq_f32(vout2x0123, one_sixteenth);
+    vout2x4567 = vmulq_f32(vout2x4567, one_sixteenth);
+    vout3x0123 = vmulq_f32(vout3x0123, one_sixteenth);
+    vout3x4567 = vmulq_f32(vout3x4567, one_sixteenth);
+    vout4x0123 = vmulq_f32(vout4x0123, one_sixteenth);
+    vout4x4567 = vmulq_f32(vout4x4567, one_sixteenth);
+    const float32x4_t vinput_scale01 = vreinterpretq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    vout0x0123 = vmulq_lane_f32(vout0x0123, vget_low_f32(vinput_scale01), 1);
+    vout1x0123 = vmulq_lane_f32(vout1x0123, vget_high_f32(vinput_scale01), 1);
+    vout0x4567 = vmulq_lane_f32(vout0x4567, vget_low_f32(vinput_scale01), 1);
+    vout1x4567 = vmulq_lane_f32(vout1x4567, vget_high_f32(vinput_scale01), 1);
+    const float32x4_t vinput_scale23 = vreinterpretq_f32_s32(vld1q_s32(&quantization_params[2].zero_point));
+    vout2x0123 = vmulq_lane_f32(vout2x0123, vget_low_f32(vinput_scale23), 1);
+    vout3x0123 = vmulq_lane_f32(vout3x0123, vget_high_f32(vinput_scale23), 1);
+    vout2x4567 = vmulq_lane_f32(vout2x4567, vget_low_f32(vinput_scale23), 1);
+    vout3x4567 = vmulq_lane_f32(vout3x4567, vget_high_f32(vinput_scale23), 1);
+    const float32x4_t vinput_scale4 = vld1q_dup_f32(&quantization_params[4].inv_scale);
+    vout4x0123 = vmulq_f32(vout4x0123, vinput_scale4);
+    vout4x4567 = vmulq_f32(vout4x4567, vinput_scale4);
+
+
+    const float32x4_t vbias0123 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x0123 = vaddq_f32(vbias0123, vout0x0123);
+    vout1x0123 = vaddq_f32(vbias0123, vout1x0123);
+    vout2x0123 = vaddq_f32(vbias0123, vout2x0123);
+    vout3x0123 = vaddq_f32(vbias0123, vout3x0123);
+    vout4x0123 = vaddq_f32(vbias0123, vout4x0123);
+    const float32x4_t vbias4567 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x4567 = vaddq_f32(vbias4567, vout0x4567);
+    vout1x4567 = vaddq_f32(vbias4567, vout1x4567);
+    vout2x4567 = vaddq_f32(vbias4567, vout2x4567);
+    vout3x4567 = vaddq_f32(vbias4567, vout3x4567);
+    vout4x4567 = vaddq_f32(vbias4567, vout4x4567);
+
+    float16x8_t vfp16out0x01234567 = vcombine_f16(vcvt_f16_f32(vout0x0123), vcvt_f16_f32(vout0x4567));
+    float16x8_t vfp16out1x01234567 = vcombine_f16(vcvt_f16_f32(vout1x0123), vcvt_f16_f32(vout1x4567));
+    float16x8_t vfp16out2x01234567 = vcombine_f16(vcvt_f16_f32(vout2x0123), vcvt_f16_f32(vout2x4567));
+    float16x8_t vfp16out3x01234567 = vcombine_f16(vcvt_f16_f32(vout3x0123), vcvt_f16_f32(vout3x4567));
+    float16x8_t vfp16out4x01234567 = vcombine_f16(vcvt_f16_f32(vout4x0123), vcvt_f16_f32(vout4x4567));
+
+    const float16x8_t voutput_min = vreinterpretq_f16_u16(vld1q_dup_u16(&params->fp16arith.min));
+    vfp16out0x01234567 = vmaxq_f16(vfp16out0x01234567, voutput_min);
+    vfp16out1x01234567 = vmaxq_f16(vfp16out1x01234567, voutput_min);
+    vfp16out2x01234567 = vmaxq_f16(vfp16out2x01234567, voutput_min);
+    vfp16out3x01234567 = vmaxq_f16(vfp16out3x01234567, voutput_min);
+    vfp16out4x01234567 = vmaxq_f16(vfp16out4x01234567, voutput_min);
+    const float16x8_t voutput_max = vreinterpretq_f16_u16(vld1q_dup_u16(&params->fp16arith.max));
+    vfp16out0x01234567 = vminq_f16(vfp16out0x01234567, voutput_max);
+    vfp16out1x01234567 = vminq_f16(vfp16out1x01234567, voutput_max);
+    vfp16out2x01234567 = vminq_f16(vfp16out2x01234567, voutput_max);
+    vfp16out3x01234567 = vminq_f16(vfp16out3x01234567, voutput_max);
+    vfp16out4x01234567 = vminq_f16(vfp16out4x01234567, voutput_max);
+    if XNN_LIKELY(nc >= 8) {
+      vst1q_u16(c0, vreinterpretq_u16_f16(vfp16out0x01234567));
+      vst1q_u16(c1, vreinterpretq_u16_f16(vfp16out1x01234567));
+      vst1q_u16(c2, vreinterpretq_u16_f16(vfp16out2x01234567));
+      vst1q_u16(c3, vreinterpretq_u16_f16(vfp16out3x01234567));
+      vst1q_u16(c4, vreinterpretq_u16_f16(vfp16out4x01234567));
+
+      a0 = (const int8_t*) ((uintptr_t) a0 - kc);
+      a1 = (const int8_t*) ((uintptr_t) a1 - kc);
+      a2 = (const int8_t*) ((uintptr_t) a2 - kc);
+      a3 = (const int8_t*) ((uintptr_t) a3 - kc);
+      a4 = (const int8_t*) ((uintptr_t) a4 - kc);
+
+      c0 = (uint16_t*) ((uintptr_t) c0 + cn_stride);
+      c1 = (uint16_t*) ((uintptr_t) c1 + cn_stride);
+      c2 = (uint16_t*) ((uintptr_t) c2 + cn_stride);
+      c3 = (uint16_t*) ((uintptr_t) c3 + cn_stride);
+      c4 = (uint16_t*) ((uintptr_t) c4 + cn_stride);
+
+      nc -= 8;
+    } else {
+     float16x4_t vfp16out0x0123 = vget_low_f16(vfp16out0x01234567);
+     float16x4_t vfp16out1x0123 = vget_low_f16(vfp16out1x01234567);
+     float16x4_t vfp16out2x0123 = vget_low_f16(vfp16out2x01234567);
+     float16x4_t vfp16out3x0123 = vget_low_f16(vfp16out3x01234567);
+     float16x4_t vfp16out4x0123 = vget_low_f16(vfp16out4x01234567);
+     if (nc & 4) {
+       vst1_u16(c0, vreinterpret_u16_f16(vfp16out0x0123)); c0 += 4;
+       vst1_u16(c1, vreinterpret_u16_f16(vfp16out1x0123)); c1 += 4;
+       vst1_u16(c2, vreinterpret_u16_f16(vfp16out2x0123)); c2 += 4;
+       vst1_u16(c3, vreinterpret_u16_f16(vfp16out3x0123)); c3 += 4;
+       vst1_u16(c4, vreinterpret_u16_f16(vfp16out4x0123)); c4 += 4;
+       vfp16out0x0123 = vget_high_f16(vfp16out0x01234567);
+       vfp16out1x0123 = vget_high_f16(vfp16out1x01234567);
+       vfp16out2x0123 = vget_high_f16(vfp16out2x01234567);
+       vfp16out3x0123 = vget_high_f16(vfp16out3x01234567);
+       vfp16out4x0123 = vget_high_f16(vfp16out4x01234567);
+     }
+     if (nc & 2) {
+       vst1_lane_u32((void*) c0, vreinterpret_u32_f16(vfp16out0x0123), 0); c0 += 2;
+       vst1_lane_u32((void*) c1, vreinterpret_u32_f16(vfp16out1x0123), 0); c1 += 2;
+       vst1_lane_u32((void*) c2, vreinterpret_u32_f16(vfp16out2x0123), 0); c2 += 2;
+       vst1_lane_u32((void*) c3, vreinterpret_u32_f16(vfp16out3x0123), 0); c3 += 2;
+       vst1_lane_u32((void*) c4, vreinterpret_u32_f16(vfp16out4x0123), 0); c4 += 2;
+       vfp16out0x0123 = vext_f16(vfp16out0x0123, vfp16out0x0123, 2);
+       vfp16out1x0123 = vext_f16(vfp16out1x0123, vfp16out1x0123, 2);
+       vfp16out2x0123 = vext_f16(vfp16out2x0123, vfp16out2x0123, 2);
+       vfp16out3x0123 = vext_f16(vfp16out3x0123, vfp16out3x0123, 2);
+       vfp16out4x0123 = vext_f16(vfp16out4x0123, vfp16out4x0123, 2);
+     }
+     if (nc & 1) {
+       vst1_lane_u16(c0, vreinterpret_u16_f16(vfp16out0x0123), 0);
+       vst1_lane_u16(c1, vreinterpret_u16_f16(vfp16out1x0123), 0);
+       vst1_lane_u16(c2, vreinterpret_u16_f16(vfp16out2x0123), 0);
+       vst1_lane_u16(c3, vreinterpret_u16_f16(vfp16out3x0123), 0);
+       vst1_lane_u16(c4, vreinterpret_u16_f16(vfp16out4x0123), 0);
+     }
+      nc = 0;
+    }
+  } while (nc != 0);
+}

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-6x16c4-minmax-neondotfp16arith.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-6x16c4-minmax-neondotfp16arith.c
@@ -1,0 +1,526 @@
+// Auto-generated file. Do not edit!
+//   Template: src/qs8-gemm/c4-neondot.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2020 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+
+#include <arm_neon.h>
+
+#include "xnnpack/gemm.h"
+#include "xnnpack/math.h"
+
+
+void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_6x16c4__neondotfp16arith(
+    size_t mr,
+    size_t nc,
+    size_t kc,
+    const int8_t* restrict a,
+    size_t a_stride,
+    const void* restrict w,
+    uint16_t* restrict c,
+    size_t cm_stride,
+    size_t cn_stride,
+    const union xnn_f16_qb4w_minmax_params params[restrict XNN_MIN_ELEMENTS(1)],
+    const struct xnn_qd8_quantization_params quantization_params[restrict XNN_MIN_ELEMENTS(1)]) XNN_OOB_READS
+{
+  assert(mr != 0);
+  assert(mr <= 6);
+  assert(nc != 0);
+  assert(kc != 0);
+  assert(kc % sizeof(int8_t) == 0);
+  assert(a != NULL);
+  assert(w != NULL);
+  assert(c != NULL);
+
+  kc = round_up_po2(kc, 4 * sizeof(int8_t));
+  const int8_t* a0 = a;
+  uint16_t* c0 = (uint16_t*) c;
+  const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
+  uint16_t* c1 = (uint16_t*) ((uintptr_t) c0 + cm_stride);
+  if XNN_UNPREDICTABLE(mr < 2) {
+    a1 = a0;
+    c1 = c0;
+  }
+  const int8_t* a2 = (const int8_t*) ((uintptr_t) a1 + a_stride);
+  uint16_t* c2 = (uint16_t*) ((uintptr_t) c1 + cm_stride);
+  if XNN_UNPREDICTABLE(mr <= 2) {
+    a2 = a1;
+    c2 = c1;
+  }
+  const int8_t* a3 = (const int8_t*) ((uintptr_t) a2 + a_stride);
+  uint16_t* c3 = (uint16_t*) ((uintptr_t) c2 + cm_stride);
+  if XNN_UNPREDICTABLE(mr < 4) {
+    a3 = a2;
+    c3 = c2;
+  }
+  const int8_t* a4 = (const int8_t*) ((uintptr_t) a3 + a_stride);
+  uint16_t* c4 = (uint16_t*) ((uintptr_t) c3 + cm_stride);
+  if XNN_UNPREDICTABLE(mr <= 4) {
+    a4 = a3;
+    c4 = c3;
+  }
+  const int8_t* a5 = (const int8_t*) ((uintptr_t) a4 + a_stride);
+  uint16_t* c5 = (uint16_t*) ((uintptr_t) c4 + cm_stride);
+  if XNN_UNPREDICTABLE(mr != 6) {
+    a5 = a4;
+    c5 = c4;
+  }
+
+  size_t bl = params->fp16arith.blocksize;
+  assert(bl <= kc);
+  assert(bl != 0);
+  size_t n_blocks = kc / bl;
+  const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
+  // Loop over groups of 16 columns.
+  do {
+    // Initialize accumulators with bias. 16 bias values are loaded from the
+    // weight matrix, at the start of the group of 16 columns.
+    const float32x4_t vinput_zero_point01 = vcvtq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    const float32x4_t vksum0123 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x0123 = vmulq_lane_f32(vksum0123, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x0123 = vmulq_lane_f32(vksum0123, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksum4567 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksum89AB = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x89AB = vmulq_lane_f32(vksum89AB, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x89AB = vmulq_lane_f32(vksum89AB, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksumCDEF = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0xCDEF = vmulq_lane_f32(vksumCDEF, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vinput_zero_point23 = vcvtq_f32_s32(vld1q_s32(&quantization_params[2].zero_point));
+    float32x4_t vout2x0123 = vmulq_lane_f32(vksum0123, vget_low_f32(vinput_zero_point23), 0);
+    float32x4_t vout3x0123 = vmulq_lane_f32(vksum0123, vget_high_f32(vinput_zero_point23), 0);
+    float32x4_t vout2x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point23), 0);
+    float32x4_t vout3x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point23), 0);
+    float32x4_t vout2x89AB = vmulq_lane_f32(vksum89AB, vget_low_f32(vinput_zero_point23), 0);
+    float32x4_t vout3x89AB = vmulq_lane_f32(vksum89AB, vget_high_f32(vinput_zero_point23), 0);
+    float32x4_t vout2xCDEF = vmulq_lane_f32(vksumCDEF, vget_low_f32(vinput_zero_point23), 0);
+    float32x4_t vout3xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vinput_zero_point23), 0);
+    const float32x4_t vinput_zero_point45 = vcvtq_f32_s32(vld1q_s32(&quantization_params[4].zero_point));
+    float32x4_t vout4x0123 = vmulq_lane_f32(vksum0123, vget_low_f32(vinput_zero_point45), 0);
+    float32x4_t vout5x0123 = vmulq_lane_f32(vksum0123, vget_high_f32(vinput_zero_point45), 0);
+    float32x4_t vout4x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point45), 0);
+    float32x4_t vout5x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point45), 0);
+    float32x4_t vout4x89AB = vmulq_lane_f32(vksum89AB, vget_low_f32(vinput_zero_point45), 0);
+    float32x4_t vout5x89AB = vmulq_lane_f32(vksum89AB, vget_high_f32(vinput_zero_point45), 0);
+    float32x4_t vout4xCDEF = vmulq_lane_f32(vksumCDEF, vget_low_f32(vinput_zero_point45), 0);
+    float32x4_t vout5xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vinput_zero_point45), 0);
+
+    for (size_t nb=0; nb < n_blocks; ++nb) {
+      int32x4_t vacc0x0123 = vdupq_n_s32(0);
+      int32x4_t vacc1x0123 = vdupq_n_s32(0);
+      int32x4_t vacc0x4567 = vdupq_n_s32(0);
+      int32x4_t vacc1x4567 = vdupq_n_s32(0);
+      int32x4_t vacc0x89AB = vdupq_n_s32(0);
+      int32x4_t vacc1x89AB = vdupq_n_s32(0);
+      int32x4_t vacc0xCDEF = vdupq_n_s32(0);
+      int32x4_t vacc1xCDEF = vdupq_n_s32(0);
+      int32x4_t vacc2x0123 = vdupq_n_s32(0);
+      int32x4_t vacc3x0123 = vdupq_n_s32(0);
+      int32x4_t vacc2x4567 = vdupq_n_s32(0);
+      int32x4_t vacc3x4567 = vdupq_n_s32(0);
+      int32x4_t vacc2x89AB = vdupq_n_s32(0);
+      int32x4_t vacc3x89AB = vdupq_n_s32(0);
+      int32x4_t vacc2xCDEF = vdupq_n_s32(0);
+      int32x4_t vacc3xCDEF = vdupq_n_s32(0);
+      int32x4_t vacc4x0123 = vdupq_n_s32(0);
+      int32x4_t vacc5x0123 = vdupq_n_s32(0);
+      int32x4_t vacc4x4567 = vdupq_n_s32(0);
+      int32x4_t vacc5x4567 = vdupq_n_s32(0);
+      int32x4_t vacc4x89AB = vdupq_n_s32(0);
+      int32x4_t vacc5x89AB = vdupq_n_s32(0);
+      int32x4_t vacc4xCDEF = vdupq_n_s32(0);
+      int32x4_t vacc5xCDEF = vdupq_n_s32(0);
+    // Inner accumulation loop along the 16 columns.
+    size_t k = bl;
+    // 2x partial unrolled loop to load 8 bytes at a time.
+    while (k >= 8 * sizeof(int8_t)) {
+      // Load a 6x8 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 8;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 8;
+      const int8x8_t va2x01234567 = vld1_s8(a2); a2 += 8;
+      const int8x8_t va3x01234567 = vld1_s8(a3); a3 += 8;
+      const int8x8_t va4x01234567 = vld1_s8(a4); a4 += 8;
+      const int8x8_t va5x01234567 = vld1_s8(a5); a5 += 8;
+
+      // Load a 8x16 block of weights.
+      const int8x16_t vb01234567x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567x89AB = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567xCDEF = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x0123 = vshlq_n_s8(vb01234567x0123, 4);
+      const int8x16_t vb0123x4567 = vshlq_n_s8(vb01234567x4567, 4);
+      const int8x16_t vb0123x89AB = vshlq_n_s8(vb01234567x89AB, 4);
+      const int8x16_t vb0123xCDEF = vshlq_n_s8(vb01234567xCDEF, 4);
+      const int8x16_t vb4567x0123 = vandq_s8(vb01234567x0123, vmask);
+      const int8x16_t vb4567x4567 = vandq_s8(vb01234567x4567, vmask);
+      const int8x16_t vb4567x89AB = vandq_s8(vb01234567x89AB, vmask);
+      const int8x16_t vb4567xCDEF = vandq_s8(vb01234567xCDEF, vmask);
+
+      // Multiply-accumulate: 6x8 * 8x16 --> 6x16.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc0x89AB = vdotq_lane_s32(vacc0x89AB, vb0123x89AB, va0x01234567, 0);
+      vacc0xCDEF = vdotq_lane_s32(vacc0xCDEF, vb0123xCDEF, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+      vacc1x89AB = vdotq_lane_s32(vacc1x89AB, vb0123x89AB, va1x01234567, 0);
+      vacc1xCDEF = vdotq_lane_s32(vacc1xCDEF, vb0123xCDEF, va1x01234567, 0);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb0123x0123, va2x01234567, 0);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb0123x4567, va2x01234567, 0);
+      vacc2x89AB = vdotq_lane_s32(vacc2x89AB, vb0123x89AB, va2x01234567, 0);
+      vacc2xCDEF = vdotq_lane_s32(vacc2xCDEF, vb0123xCDEF, va2x01234567, 0);
+      vacc3x0123 = vdotq_lane_s32(vacc3x0123, vb0123x0123, va3x01234567, 0);
+      vacc3x4567 = vdotq_lane_s32(vacc3x4567, vb0123x4567, va3x01234567, 0);
+      vacc3x89AB = vdotq_lane_s32(vacc3x89AB, vb0123x89AB, va3x01234567, 0);
+      vacc3xCDEF = vdotq_lane_s32(vacc3xCDEF, vb0123xCDEF, va3x01234567, 0);
+      vacc4x0123 = vdotq_lane_s32(vacc4x0123, vb0123x0123, va4x01234567, 0);
+      vacc4x4567 = vdotq_lane_s32(vacc4x4567, vb0123x4567, va4x01234567, 0);
+      vacc4x89AB = vdotq_lane_s32(vacc4x89AB, vb0123x89AB, va4x01234567, 0);
+      vacc4xCDEF = vdotq_lane_s32(vacc4xCDEF, vb0123xCDEF, va4x01234567, 0);
+      vacc5x0123 = vdotq_lane_s32(vacc5x0123, vb0123x0123, va5x01234567, 0);
+      vacc5x4567 = vdotq_lane_s32(vacc5x4567, vb0123x4567, va5x01234567, 0);
+      vacc5x89AB = vdotq_lane_s32(vacc5x89AB, vb0123x89AB, va5x01234567, 0);
+      vacc5xCDEF = vdotq_lane_s32(vacc5xCDEF, vb0123xCDEF, va5x01234567, 0);
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb4567x0123, va0x01234567, 1);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb4567x4567, va0x01234567, 1);
+      vacc0x89AB = vdotq_lane_s32(vacc0x89AB, vb4567x89AB, va0x01234567, 1);
+      vacc0xCDEF = vdotq_lane_s32(vacc0xCDEF, vb4567xCDEF, va0x01234567, 1);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb4567x0123, va1x01234567, 1);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb4567x4567, va1x01234567, 1);
+      vacc1x89AB = vdotq_lane_s32(vacc1x89AB, vb4567x89AB, va1x01234567, 1);
+      vacc1xCDEF = vdotq_lane_s32(vacc1xCDEF, vb4567xCDEF, va1x01234567, 1);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb4567x0123, va2x01234567, 1);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb4567x4567, va2x01234567, 1);
+      vacc2x89AB = vdotq_lane_s32(vacc2x89AB, vb4567x89AB, va2x01234567, 1);
+      vacc2xCDEF = vdotq_lane_s32(vacc2xCDEF, vb4567xCDEF, va2x01234567, 1);
+      vacc3x0123 = vdotq_lane_s32(vacc3x0123, vb4567x0123, va3x01234567, 1);
+      vacc3x4567 = vdotq_lane_s32(vacc3x4567, vb4567x4567, va3x01234567, 1);
+      vacc3x89AB = vdotq_lane_s32(vacc3x89AB, vb4567x89AB, va3x01234567, 1);
+      vacc3xCDEF = vdotq_lane_s32(vacc3xCDEF, vb4567xCDEF, va3x01234567, 1);
+      vacc4x0123 = vdotq_lane_s32(vacc4x0123, vb4567x0123, va4x01234567, 1);
+      vacc4x4567 = vdotq_lane_s32(vacc4x4567, vb4567x4567, va4x01234567, 1);
+      vacc4x89AB = vdotq_lane_s32(vacc4x89AB, vb4567x89AB, va4x01234567, 1);
+      vacc4xCDEF = vdotq_lane_s32(vacc4xCDEF, vb4567xCDEF, va4x01234567, 1);
+      vacc5x0123 = vdotq_lane_s32(vacc5x0123, vb4567x0123, va5x01234567, 1);
+      vacc5x4567 = vdotq_lane_s32(vacc5x4567, vb4567x4567, va5x01234567, 1);
+      vacc5x89AB = vdotq_lane_s32(vacc5x89AB, vb4567x89AB, va5x01234567, 1);
+      vacc5xCDEF = vdotq_lane_s32(vacc5xCDEF, vb4567xCDEF, va5x01234567, 1);
+
+      k -= 8 * sizeof(int8_t);
+    }
+    // Handle up to 4 final positions of `k`
+    if XNN_UNLIKELY(k != 0) {
+      // Load a 6x4 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 4;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 4;
+      const int8x8_t va2x01234567 = vld1_s8(a2); a2 += 4;
+      const int8x8_t va3x01234567 = vld1_s8(a3); a3 += 4;
+      const int8x8_t va4x01234567 = vld1_s8(a4); a4 += 4;
+      const int8x8_t va5x01234567 = vld1_s8(a5); a5 += 4;
+
+      // Load a 4x16 block of weights.
+      const int8x16_t vb0123x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x89AB = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123xCDEF = vld1q_s8(w); w = (const int8_t*) w + 16;
+
+      // Multiply-accumulate: 6x4 * 4x16 --> 6x16.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc0x89AB = vdotq_lane_s32(vacc0x89AB, vb0123x89AB, va0x01234567, 0);
+      vacc0xCDEF = vdotq_lane_s32(vacc0xCDEF, vb0123xCDEF, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+      vacc1x89AB = vdotq_lane_s32(vacc1x89AB, vb0123x89AB, va1x01234567, 0);
+      vacc1xCDEF = vdotq_lane_s32(vacc1xCDEF, vb0123xCDEF, va1x01234567, 0);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb0123x0123, va2x01234567, 0);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb0123x4567, va2x01234567, 0);
+      vacc2x89AB = vdotq_lane_s32(vacc2x89AB, vb0123x89AB, va2x01234567, 0);
+      vacc2xCDEF = vdotq_lane_s32(vacc2xCDEF, vb0123xCDEF, va2x01234567, 0);
+      vacc3x0123 = vdotq_lane_s32(vacc3x0123, vb0123x0123, va3x01234567, 0);
+      vacc3x4567 = vdotq_lane_s32(vacc3x4567, vb0123x4567, va3x01234567, 0);
+      vacc3x89AB = vdotq_lane_s32(vacc3x89AB, vb0123x89AB, va3x01234567, 0);
+      vacc3xCDEF = vdotq_lane_s32(vacc3xCDEF, vb0123xCDEF, va3x01234567, 0);
+      vacc4x0123 = vdotq_lane_s32(vacc4x0123, vb0123x0123, va4x01234567, 0);
+      vacc4x4567 = vdotq_lane_s32(vacc4x4567, vb0123x4567, va4x01234567, 0);
+      vacc4x89AB = vdotq_lane_s32(vacc4x89AB, vb0123x89AB, va4x01234567, 0);
+      vacc4xCDEF = vdotq_lane_s32(vacc4xCDEF, vb0123xCDEF, va4x01234567, 0);
+      vacc5x0123 = vdotq_lane_s32(vacc5x0123, vb0123x0123, va5x01234567, 0);
+      vacc5x4567 = vdotq_lane_s32(vacc5x4567, vb0123x4567, va5x01234567, 0);
+      vacc5x89AB = vdotq_lane_s32(vacc5x89AB, vb0123x89AB, va5x01234567, 0);
+      vacc5xCDEF = vdotq_lane_s32(vacc5xCDEF, vb0123xCDEF, va5x01234567, 0);
+    }
+    const float32x4_t vfilter_output_scale0123 = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scale4567 = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scale89AB = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scaleCDEF = vld1q_f32(w); w = (const float*) w + 4;
+
+    float32x4_t vf0x0123 = vcvtq_f32_s32(vacc0x0123);
+    float32x4_t vf1x0123 = vcvtq_f32_s32(vacc1x0123);
+    vout0x0123 = vfmaq_f32(vout0x0123, vf0x0123, vfilter_output_scale0123);
+    vout1x0123 = vfmaq_f32(vout1x0123, vf1x0123, vfilter_output_scale0123);
+    float32x4_t vf0x4567 = vcvtq_f32_s32(vacc0x4567);
+    float32x4_t vf1x4567 = vcvtq_f32_s32(vacc1x4567);
+    vout0x4567 = vfmaq_f32(vout0x4567, vf0x4567, vfilter_output_scale4567);
+    vout1x4567 = vfmaq_f32(vout1x4567, vf1x4567, vfilter_output_scale4567);
+    float32x4_t vf0x89AB = vcvtq_f32_s32(vacc0x89AB);
+    float32x4_t vf1x89AB = vcvtq_f32_s32(vacc1x89AB);
+    vout0x89AB = vfmaq_f32(vout0x89AB, vf0x89AB, vfilter_output_scale89AB);
+    vout1x89AB = vfmaq_f32(vout1x89AB, vf1x89AB, vfilter_output_scale89AB);
+    float32x4_t vf0xCDEF = vcvtq_f32_s32(vacc0xCDEF);
+    float32x4_t vf1xCDEF = vcvtq_f32_s32(vacc1xCDEF);
+    vout0xCDEF = vfmaq_f32(vout0xCDEF, vf0xCDEF, vfilter_output_scaleCDEF);
+    vout1xCDEF = vfmaq_f32(vout1xCDEF, vf1xCDEF, vfilter_output_scaleCDEF);
+    float32x4_t vf2x0123 = vcvtq_f32_s32(vacc2x0123);
+    float32x4_t vf3x0123 = vcvtq_f32_s32(vacc3x0123);
+    vout2x0123 = vfmaq_f32(vout2x0123, vf2x0123, vfilter_output_scale0123);
+    vout3x0123 = vfmaq_f32(vout3x0123, vf3x0123, vfilter_output_scale0123);
+    float32x4_t vf2x4567 = vcvtq_f32_s32(vacc2x4567);
+    float32x4_t vf3x4567 = vcvtq_f32_s32(vacc3x4567);
+    vout2x4567 = vfmaq_f32(vout2x4567, vf2x4567, vfilter_output_scale4567);
+    vout3x4567 = vfmaq_f32(vout3x4567, vf3x4567, vfilter_output_scale4567);
+    float32x4_t vf2x89AB = vcvtq_f32_s32(vacc2x89AB);
+    float32x4_t vf3x89AB = vcvtq_f32_s32(vacc3x89AB);
+    vout2x89AB = vfmaq_f32(vout2x89AB, vf2x89AB, vfilter_output_scale89AB);
+    vout3x89AB = vfmaq_f32(vout3x89AB, vf3x89AB, vfilter_output_scale89AB);
+    float32x4_t vf2xCDEF = vcvtq_f32_s32(vacc2xCDEF);
+    float32x4_t vf3xCDEF = vcvtq_f32_s32(vacc3xCDEF);
+    vout2xCDEF = vfmaq_f32(vout2xCDEF, vf2xCDEF, vfilter_output_scaleCDEF);
+    vout3xCDEF = vfmaq_f32(vout3xCDEF, vf3xCDEF, vfilter_output_scaleCDEF);
+    float32x4_t vf4x0123 = vcvtq_f32_s32(vacc4x0123);
+    float32x4_t vf5x0123 = vcvtq_f32_s32(vacc5x0123);
+    vout4x0123 = vfmaq_f32(vout4x0123, vf4x0123, vfilter_output_scale0123);
+    vout5x0123 = vfmaq_f32(vout5x0123, vf5x0123, vfilter_output_scale0123);
+    float32x4_t vf4x4567 = vcvtq_f32_s32(vacc4x4567);
+    float32x4_t vf5x4567 = vcvtq_f32_s32(vacc5x4567);
+    vout4x4567 = vfmaq_f32(vout4x4567, vf4x4567, vfilter_output_scale4567);
+    vout5x4567 = vfmaq_f32(vout5x4567, vf5x4567, vfilter_output_scale4567);
+    float32x4_t vf4x89AB = vcvtq_f32_s32(vacc4x89AB);
+    float32x4_t vf5x89AB = vcvtq_f32_s32(vacc5x89AB);
+    vout4x89AB = vfmaq_f32(vout4x89AB, vf4x89AB, vfilter_output_scale89AB);
+    vout5x89AB = vfmaq_f32(vout5x89AB, vf5x89AB, vfilter_output_scale89AB);
+    float32x4_t vf4xCDEF = vcvtq_f32_s32(vacc4xCDEF);
+    float32x4_t vf5xCDEF = vcvtq_f32_s32(vacc5xCDEF);
+    vout4xCDEF = vfmaq_f32(vout4xCDEF, vf4xCDEF, vfilter_output_scaleCDEF);
+    vout5xCDEF = vfmaq_f32(vout5xCDEF, vf5xCDEF, vfilter_output_scaleCDEF);
+    }
+
+    const float32x4_t one_sixteenth = vdupq_n_f32(1/16.0);
+    vout0x0123 = vmulq_f32(vout0x0123, one_sixteenth);
+    vout0x4567 = vmulq_f32(vout0x4567, one_sixteenth);
+    vout0x89AB = vmulq_f32(vout0x89AB, one_sixteenth);
+    vout0xCDEF = vmulq_f32(vout0xCDEF, one_sixteenth);
+    vout1x0123 = vmulq_f32(vout1x0123, one_sixteenth);
+    vout1x4567 = vmulq_f32(vout1x4567, one_sixteenth);
+    vout1x89AB = vmulq_f32(vout1x89AB, one_sixteenth);
+    vout1xCDEF = vmulq_f32(vout1xCDEF, one_sixteenth);
+    vout2x0123 = vmulq_f32(vout2x0123, one_sixteenth);
+    vout2x4567 = vmulq_f32(vout2x4567, one_sixteenth);
+    vout2x89AB = vmulq_f32(vout2x89AB, one_sixteenth);
+    vout2xCDEF = vmulq_f32(vout2xCDEF, one_sixteenth);
+    vout3x0123 = vmulq_f32(vout3x0123, one_sixteenth);
+    vout3x4567 = vmulq_f32(vout3x4567, one_sixteenth);
+    vout3x89AB = vmulq_f32(vout3x89AB, one_sixteenth);
+    vout3xCDEF = vmulq_f32(vout3xCDEF, one_sixteenth);
+    vout4x0123 = vmulq_f32(vout4x0123, one_sixteenth);
+    vout4x4567 = vmulq_f32(vout4x4567, one_sixteenth);
+    vout4x89AB = vmulq_f32(vout4x89AB, one_sixteenth);
+    vout4xCDEF = vmulq_f32(vout4xCDEF, one_sixteenth);
+    vout5x0123 = vmulq_f32(vout5x0123, one_sixteenth);
+    vout5x4567 = vmulq_f32(vout5x4567, one_sixteenth);
+    vout5x89AB = vmulq_f32(vout5x89AB, one_sixteenth);
+    vout5xCDEF = vmulq_f32(vout5xCDEF, one_sixteenth);
+    const float32x4_t vinput_scale01 = vreinterpretq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    vout0x0123 = vmulq_lane_f32(vout0x0123, vget_low_f32(vinput_scale01), 1);
+    vout1x0123 = vmulq_lane_f32(vout1x0123, vget_high_f32(vinput_scale01), 1);
+    vout0x4567 = vmulq_lane_f32(vout0x4567, vget_low_f32(vinput_scale01), 1);
+    vout1x4567 = vmulq_lane_f32(vout1x4567, vget_high_f32(vinput_scale01), 1);
+    vout0x89AB = vmulq_lane_f32(vout0x89AB, vget_low_f32(vinput_scale01), 1);
+    vout1x89AB = vmulq_lane_f32(vout1x89AB, vget_high_f32(vinput_scale01), 1);
+    vout0xCDEF = vmulq_lane_f32(vout0xCDEF, vget_low_f32(vinput_scale01), 1);
+    vout1xCDEF = vmulq_lane_f32(vout1xCDEF, vget_high_f32(vinput_scale01), 1);
+    const float32x4_t vinput_scale23 = vreinterpretq_f32_s32(vld1q_s32(&quantization_params[2].zero_point));
+    vout2x0123 = vmulq_lane_f32(vout2x0123, vget_low_f32(vinput_scale23), 1);
+    vout3x0123 = vmulq_lane_f32(vout3x0123, vget_high_f32(vinput_scale23), 1);
+    vout2x4567 = vmulq_lane_f32(vout2x4567, vget_low_f32(vinput_scale23), 1);
+    vout3x4567 = vmulq_lane_f32(vout3x4567, vget_high_f32(vinput_scale23), 1);
+    vout2x89AB = vmulq_lane_f32(vout2x89AB, vget_low_f32(vinput_scale23), 1);
+    vout3x89AB = vmulq_lane_f32(vout3x89AB, vget_high_f32(vinput_scale23), 1);
+    vout2xCDEF = vmulq_lane_f32(vout2xCDEF, vget_low_f32(vinput_scale23), 1);
+    vout3xCDEF = vmulq_lane_f32(vout3xCDEF, vget_high_f32(vinput_scale23), 1);
+    const float32x4_t vinput_scale45 = vreinterpretq_f32_s32(vld1q_s32(&quantization_params[4].zero_point));
+    vout4x0123 = vmulq_lane_f32(vout4x0123, vget_low_f32(vinput_scale45), 1);
+    vout5x0123 = vmulq_lane_f32(vout5x0123, vget_high_f32(vinput_scale45), 1);
+    vout4x4567 = vmulq_lane_f32(vout4x4567, vget_low_f32(vinput_scale45), 1);
+    vout5x4567 = vmulq_lane_f32(vout5x4567, vget_high_f32(vinput_scale45), 1);
+    vout4x89AB = vmulq_lane_f32(vout4x89AB, vget_low_f32(vinput_scale45), 1);
+    vout5x89AB = vmulq_lane_f32(vout5x89AB, vget_high_f32(vinput_scale45), 1);
+    vout4xCDEF = vmulq_lane_f32(vout4xCDEF, vget_low_f32(vinput_scale45), 1);
+    vout5xCDEF = vmulq_lane_f32(vout5xCDEF, vget_high_f32(vinput_scale45), 1);
+
+
+    const float32x4_t vbias0123 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x0123 = vaddq_f32(vbias0123, vout0x0123);
+    vout1x0123 = vaddq_f32(vbias0123, vout1x0123);
+    vout2x0123 = vaddq_f32(vbias0123, vout2x0123);
+    vout3x0123 = vaddq_f32(vbias0123, vout3x0123);
+    vout4x0123 = vaddq_f32(vbias0123, vout4x0123);
+    vout5x0123 = vaddq_f32(vbias0123, vout5x0123);
+    const float32x4_t vbias4567 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x4567 = vaddq_f32(vbias4567, vout0x4567);
+    vout1x4567 = vaddq_f32(vbias4567, vout1x4567);
+    vout2x4567 = vaddq_f32(vbias4567, vout2x4567);
+    vout3x4567 = vaddq_f32(vbias4567, vout3x4567);
+    vout4x4567 = vaddq_f32(vbias4567, vout4x4567);
+    vout5x4567 = vaddq_f32(vbias4567, vout5x4567);
+    const float32x4_t vbias89AB = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x89AB = vaddq_f32(vbias89AB, vout0x89AB);
+    vout1x89AB = vaddq_f32(vbias89AB, vout1x89AB);
+    vout2x89AB = vaddq_f32(vbias89AB, vout2x89AB);
+    vout3x89AB = vaddq_f32(vbias89AB, vout3x89AB);
+    vout4x89AB = vaddq_f32(vbias89AB, vout4x89AB);
+    vout5x89AB = vaddq_f32(vbias89AB, vout5x89AB);
+    const float32x4_t vbiasCDEF = vld1q_f32(w); w = (const float*) w + 4;
+    vout0xCDEF = vaddq_f32(vbiasCDEF, vout0xCDEF);
+    vout1xCDEF = vaddq_f32(vbiasCDEF, vout1xCDEF);
+    vout2xCDEF = vaddq_f32(vbiasCDEF, vout2xCDEF);
+    vout3xCDEF = vaddq_f32(vbiasCDEF, vout3xCDEF);
+    vout4xCDEF = vaddq_f32(vbiasCDEF, vout4xCDEF);
+    vout5xCDEF = vaddq_f32(vbiasCDEF, vout5xCDEF);
+
+    float16x8_t vfp16out0x01234567 = vcombine_f16(vcvt_f16_f32(vout0x0123), vcvt_f16_f32(vout0x4567));
+    float16x8_t vfp16out0x89ABCDEF = vcombine_f16(vcvt_f16_f32(vout0x89AB), vcvt_f16_f32(vout0xCDEF));
+    float16x8_t vfp16out1x01234567 = vcombine_f16(vcvt_f16_f32(vout1x0123), vcvt_f16_f32(vout1x4567));
+    float16x8_t vfp16out1x89ABCDEF = vcombine_f16(vcvt_f16_f32(vout1x89AB), vcvt_f16_f32(vout1xCDEF));
+    float16x8_t vfp16out2x01234567 = vcombine_f16(vcvt_f16_f32(vout2x0123), vcvt_f16_f32(vout2x4567));
+    float16x8_t vfp16out2x89ABCDEF = vcombine_f16(vcvt_f16_f32(vout2x89AB), vcvt_f16_f32(vout2xCDEF));
+    float16x8_t vfp16out3x01234567 = vcombine_f16(vcvt_f16_f32(vout3x0123), vcvt_f16_f32(vout3x4567));
+    float16x8_t vfp16out3x89ABCDEF = vcombine_f16(vcvt_f16_f32(vout3x89AB), vcvt_f16_f32(vout3xCDEF));
+    float16x8_t vfp16out4x01234567 = vcombine_f16(vcvt_f16_f32(vout4x0123), vcvt_f16_f32(vout4x4567));
+    float16x8_t vfp16out4x89ABCDEF = vcombine_f16(vcvt_f16_f32(vout4x89AB), vcvt_f16_f32(vout4xCDEF));
+    float16x8_t vfp16out5x01234567 = vcombine_f16(vcvt_f16_f32(vout5x0123), vcvt_f16_f32(vout5x4567));
+    float16x8_t vfp16out5x89ABCDEF = vcombine_f16(vcvt_f16_f32(vout5x89AB), vcvt_f16_f32(vout5xCDEF));
+
+    const float16x8_t voutput_min = vreinterpretq_f16_u16(vld1q_dup_u16(&params->fp16arith.min));
+    vfp16out0x01234567 = vmaxq_f16(vfp16out0x01234567, voutput_min);
+    vfp16out0x89ABCDEF = vmaxq_f16(vfp16out0x89ABCDEF, voutput_min);
+    vfp16out1x01234567 = vmaxq_f16(vfp16out1x01234567, voutput_min);
+    vfp16out1x89ABCDEF = vmaxq_f16(vfp16out1x89ABCDEF, voutput_min);
+    vfp16out2x01234567 = vmaxq_f16(vfp16out2x01234567, voutput_min);
+    vfp16out2x89ABCDEF = vmaxq_f16(vfp16out2x89ABCDEF, voutput_min);
+    vfp16out3x01234567 = vmaxq_f16(vfp16out3x01234567, voutput_min);
+    vfp16out3x89ABCDEF = vmaxq_f16(vfp16out3x89ABCDEF, voutput_min);
+    vfp16out4x01234567 = vmaxq_f16(vfp16out4x01234567, voutput_min);
+    vfp16out4x89ABCDEF = vmaxq_f16(vfp16out4x89ABCDEF, voutput_min);
+    vfp16out5x01234567 = vmaxq_f16(vfp16out5x01234567, voutput_min);
+    vfp16out5x89ABCDEF = vmaxq_f16(vfp16out5x89ABCDEF, voutput_min);
+    const float16x8_t voutput_max = vreinterpretq_f16_u16(vld1q_dup_u16(&params->fp16arith.max));
+    vfp16out0x01234567 = vminq_f16(vfp16out0x01234567, voutput_max);
+    vfp16out0x89ABCDEF = vminq_f16(vfp16out0x89ABCDEF, voutput_max);
+    vfp16out1x01234567 = vminq_f16(vfp16out1x01234567, voutput_max);
+    vfp16out1x89ABCDEF = vminq_f16(vfp16out1x89ABCDEF, voutput_max);
+    vfp16out2x01234567 = vminq_f16(vfp16out2x01234567, voutput_max);
+    vfp16out2x89ABCDEF = vminq_f16(vfp16out2x89ABCDEF, voutput_max);
+    vfp16out3x01234567 = vminq_f16(vfp16out3x01234567, voutput_max);
+    vfp16out3x89ABCDEF = vminq_f16(vfp16out3x89ABCDEF, voutput_max);
+    vfp16out4x01234567 = vminq_f16(vfp16out4x01234567, voutput_max);
+    vfp16out4x89ABCDEF = vminq_f16(vfp16out4x89ABCDEF, voutput_max);
+    vfp16out5x01234567 = vminq_f16(vfp16out5x01234567, voutput_max);
+    vfp16out5x89ABCDEF = vminq_f16(vfp16out5x89ABCDEF, voutput_max);
+    if XNN_LIKELY(nc >= 16) {
+      vst1q_u16(c0, vreinterpretq_u16_f16(vfp16out0x01234567));
+      vst1q_u16(c0 + 8, vreinterpretq_u16_f16(vfp16out0x89ABCDEF));
+      vst1q_u16(c1, vreinterpretq_u16_f16(vfp16out1x01234567));
+      vst1q_u16(c1 + 8, vreinterpretq_u16_f16(vfp16out1x89ABCDEF));
+      vst1q_u16(c2, vreinterpretq_u16_f16(vfp16out2x01234567));
+      vst1q_u16(c2 + 8, vreinterpretq_u16_f16(vfp16out2x89ABCDEF));
+      vst1q_u16(c3, vreinterpretq_u16_f16(vfp16out3x01234567));
+      vst1q_u16(c3 + 8, vreinterpretq_u16_f16(vfp16out3x89ABCDEF));
+      vst1q_u16(c4, vreinterpretq_u16_f16(vfp16out4x01234567));
+      vst1q_u16(c4 + 8, vreinterpretq_u16_f16(vfp16out4x89ABCDEF));
+      vst1q_u16(c5, vreinterpretq_u16_f16(vfp16out5x01234567));
+      vst1q_u16(c5 + 8, vreinterpretq_u16_f16(vfp16out5x89ABCDEF));
+
+      a0 = (const int8_t*) ((uintptr_t) a0 - kc);
+      a1 = (const int8_t*) ((uintptr_t) a1 - kc);
+      a2 = (const int8_t*) ((uintptr_t) a2 - kc);
+      a3 = (const int8_t*) ((uintptr_t) a3 - kc);
+      a4 = (const int8_t*) ((uintptr_t) a4 - kc);
+      a5 = (const int8_t*) ((uintptr_t) a5 - kc);
+
+      c0 = (uint16_t*) ((uintptr_t) c0 + cn_stride);
+      c1 = (uint16_t*) ((uintptr_t) c1 + cn_stride);
+      c2 = (uint16_t*) ((uintptr_t) c2 + cn_stride);
+      c3 = (uint16_t*) ((uintptr_t) c3 + cn_stride);
+      c4 = (uint16_t*) ((uintptr_t) c4 + cn_stride);
+      c5 = (uint16_t*) ((uintptr_t) c5 + cn_stride);
+
+      nc -= 16;
+    } else {
+     if (nc & 8) {
+       vst1q_u16(c0, vreinterpretq_u16_f16(vfp16out0x01234567)); c0 += 8;
+       vfp16out0x01234567 = vfp16out0x89ABCDEF;
+       vst1q_u16(c1, vreinterpretq_u16_f16(vfp16out1x01234567)); c1 += 8;
+       vfp16out1x01234567 = vfp16out1x89ABCDEF;
+       vst1q_u16(c2, vreinterpretq_u16_f16(vfp16out2x01234567)); c2 += 8;
+       vfp16out2x01234567 = vfp16out2x89ABCDEF;
+       vst1q_u16(c3, vreinterpretq_u16_f16(vfp16out3x01234567)); c3 += 8;
+       vfp16out3x01234567 = vfp16out3x89ABCDEF;
+       vst1q_u16(c4, vreinterpretq_u16_f16(vfp16out4x01234567)); c4 += 8;
+       vfp16out4x01234567 = vfp16out4x89ABCDEF;
+       vst1q_u16(c5, vreinterpretq_u16_f16(vfp16out5x01234567)); c5 += 8;
+       vfp16out5x01234567 = vfp16out5x89ABCDEF;
+     }
+     float16x4_t vfp16out0x0123 = vget_low_f16(vfp16out0x01234567);
+     float16x4_t vfp16out1x0123 = vget_low_f16(vfp16out1x01234567);
+     float16x4_t vfp16out2x0123 = vget_low_f16(vfp16out2x01234567);
+     float16x4_t vfp16out3x0123 = vget_low_f16(vfp16out3x01234567);
+     float16x4_t vfp16out4x0123 = vget_low_f16(vfp16out4x01234567);
+     float16x4_t vfp16out5x0123 = vget_low_f16(vfp16out5x01234567);
+     if (nc & 4) {
+       vst1_u16(c0, vreinterpret_u16_f16(vfp16out0x0123)); c0 += 4;
+       vst1_u16(c1, vreinterpret_u16_f16(vfp16out1x0123)); c1 += 4;
+       vst1_u16(c2, vreinterpret_u16_f16(vfp16out2x0123)); c2 += 4;
+       vst1_u16(c3, vreinterpret_u16_f16(vfp16out3x0123)); c3 += 4;
+       vst1_u16(c4, vreinterpret_u16_f16(vfp16out4x0123)); c4 += 4;
+       vst1_u16(c5, vreinterpret_u16_f16(vfp16out5x0123)); c5 += 4;
+       vfp16out0x0123 = vget_high_f16(vfp16out0x01234567);
+       vfp16out1x0123 = vget_high_f16(vfp16out1x01234567);
+       vfp16out2x0123 = vget_high_f16(vfp16out2x01234567);
+       vfp16out3x0123 = vget_high_f16(vfp16out3x01234567);
+       vfp16out4x0123 = vget_high_f16(vfp16out4x01234567);
+       vfp16out5x0123 = vget_high_f16(vfp16out5x01234567);
+     }
+     if (nc & 2) {
+       vst1_lane_u32((void*) c0, vreinterpret_u32_f16(vfp16out0x0123), 0); c0 += 2;
+       vst1_lane_u32((void*) c1, vreinterpret_u32_f16(vfp16out1x0123), 0); c1 += 2;
+       vst1_lane_u32((void*) c2, vreinterpret_u32_f16(vfp16out2x0123), 0); c2 += 2;
+       vst1_lane_u32((void*) c3, vreinterpret_u32_f16(vfp16out3x0123), 0); c3 += 2;
+       vst1_lane_u32((void*) c4, vreinterpret_u32_f16(vfp16out4x0123), 0); c4 += 2;
+       vst1_lane_u32((void*) c5, vreinterpret_u32_f16(vfp16out5x0123), 0); c5 += 2;
+       vfp16out0x0123 = vext_f16(vfp16out0x0123, vfp16out0x0123, 2);
+       vfp16out1x0123 = vext_f16(vfp16out1x0123, vfp16out1x0123, 2);
+       vfp16out2x0123 = vext_f16(vfp16out2x0123, vfp16out2x0123, 2);
+       vfp16out3x0123 = vext_f16(vfp16out3x0123, vfp16out3x0123, 2);
+       vfp16out4x0123 = vext_f16(vfp16out4x0123, vfp16out4x0123, 2);
+       vfp16out5x0123 = vext_f16(vfp16out5x0123, vfp16out5x0123, 2);
+     }
+     if (nc & 1) {
+       vst1_lane_u16(c0, vreinterpret_u16_f16(vfp16out0x0123), 0);
+       vst1_lane_u16(c1, vreinterpret_u16_f16(vfp16out1x0123), 0);
+       vst1_lane_u16(c2, vreinterpret_u16_f16(vfp16out2x0123), 0);
+       vst1_lane_u16(c3, vreinterpret_u16_f16(vfp16out3x0123), 0);
+       vst1_lane_u16(c4, vreinterpret_u16_f16(vfp16out4x0123), 0);
+       vst1_lane_u16(c5, vreinterpret_u16_f16(vfp16out5x0123), 0);
+     }
+      nc = 0;
+    }
+  } while (nc != 0);
+}

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-6x8c4-minmax-neondotfp16arith.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-6x8c4-minmax-neondotfp16arith.c
@@ -1,0 +1,354 @@
+// Auto-generated file. Do not edit!
+//   Template: src/qs8-gemm/c4-neondot.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2020 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+
+#include <arm_neon.h>
+
+#include "xnnpack/gemm.h"
+#include "xnnpack/math.h"
+
+
+void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_6x8c4__neondotfp16arith(
+    size_t mr,
+    size_t nc,
+    size_t kc,
+    const int8_t* restrict a,
+    size_t a_stride,
+    const void* restrict w,
+    uint16_t* restrict c,
+    size_t cm_stride,
+    size_t cn_stride,
+    const union xnn_f16_qb4w_minmax_params params[restrict XNN_MIN_ELEMENTS(1)],
+    const struct xnn_qd8_quantization_params quantization_params[restrict XNN_MIN_ELEMENTS(1)]) XNN_OOB_READS
+{
+  assert(mr != 0);
+  assert(mr <= 6);
+  assert(nc != 0);
+  assert(kc != 0);
+  assert(kc % sizeof(int8_t) == 0);
+  assert(a != NULL);
+  assert(w != NULL);
+  assert(c != NULL);
+
+  kc = round_up_po2(kc, 4 * sizeof(int8_t));
+  const int8_t* a0 = a;
+  uint16_t* c0 = (uint16_t*) c;
+  const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
+  uint16_t* c1 = (uint16_t*) ((uintptr_t) c0 + cm_stride);
+  if XNN_UNPREDICTABLE(mr < 2) {
+    a1 = a0;
+    c1 = c0;
+  }
+  const int8_t* a2 = (const int8_t*) ((uintptr_t) a1 + a_stride);
+  uint16_t* c2 = (uint16_t*) ((uintptr_t) c1 + cm_stride);
+  if XNN_UNPREDICTABLE(mr <= 2) {
+    a2 = a1;
+    c2 = c1;
+  }
+  const int8_t* a3 = (const int8_t*) ((uintptr_t) a2 + a_stride);
+  uint16_t* c3 = (uint16_t*) ((uintptr_t) c2 + cm_stride);
+  if XNN_UNPREDICTABLE(mr < 4) {
+    a3 = a2;
+    c3 = c2;
+  }
+  const int8_t* a4 = (const int8_t*) ((uintptr_t) a3 + a_stride);
+  uint16_t* c4 = (uint16_t*) ((uintptr_t) c3 + cm_stride);
+  if XNN_UNPREDICTABLE(mr <= 4) {
+    a4 = a3;
+    c4 = c3;
+  }
+  const int8_t* a5 = (const int8_t*) ((uintptr_t) a4 + a_stride);
+  uint16_t* c5 = (uint16_t*) ((uintptr_t) c4 + cm_stride);
+  if XNN_UNPREDICTABLE(mr != 6) {
+    a5 = a4;
+    c5 = c4;
+  }
+
+  size_t bl = params->fp16arith.blocksize;
+  assert(bl <= kc);
+  assert(bl != 0);
+  size_t n_blocks = kc / bl;
+  const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
+  // Loop over groups of 8 columns.
+  do {
+    // Initialize accumulators with bias. 8 bias values are loaded from the
+    // weight matrix, at the start of the group of 8 columns.
+    const float32x4_t vinput_zero_point01 = vcvtq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    const float32x4_t vksum0123 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x0123 = vmulq_lane_f32(vksum0123, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x0123 = vmulq_lane_f32(vksum0123, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksum4567 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vinput_zero_point23 = vcvtq_f32_s32(vld1q_s32(&quantization_params[2].zero_point));
+    float32x4_t vout2x0123 = vmulq_lane_f32(vksum0123, vget_low_f32(vinput_zero_point23), 0);
+    float32x4_t vout3x0123 = vmulq_lane_f32(vksum0123, vget_high_f32(vinput_zero_point23), 0);
+    float32x4_t vout2x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point23), 0);
+    float32x4_t vout3x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point23), 0);
+    const float32x4_t vinput_zero_point45 = vcvtq_f32_s32(vld1q_s32(&quantization_params[4].zero_point));
+    float32x4_t vout4x0123 = vmulq_lane_f32(vksum0123, vget_low_f32(vinput_zero_point45), 0);
+    float32x4_t vout5x0123 = vmulq_lane_f32(vksum0123, vget_high_f32(vinput_zero_point45), 0);
+    float32x4_t vout4x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point45), 0);
+    float32x4_t vout5x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point45), 0);
+
+    for (size_t nb=0; nb < n_blocks; ++nb) {
+      int32x4_t vacc0x0123 = vdupq_n_s32(0);
+      int32x4_t vacc1x0123 = vdupq_n_s32(0);
+      int32x4_t vacc0x4567 = vdupq_n_s32(0);
+      int32x4_t vacc1x4567 = vdupq_n_s32(0);
+      int32x4_t vacc2x0123 = vdupq_n_s32(0);
+      int32x4_t vacc3x0123 = vdupq_n_s32(0);
+      int32x4_t vacc2x4567 = vdupq_n_s32(0);
+      int32x4_t vacc3x4567 = vdupq_n_s32(0);
+      int32x4_t vacc4x0123 = vdupq_n_s32(0);
+      int32x4_t vacc5x0123 = vdupq_n_s32(0);
+      int32x4_t vacc4x4567 = vdupq_n_s32(0);
+      int32x4_t vacc5x4567 = vdupq_n_s32(0);
+    // Inner accumulation loop along the 8 columns.
+    size_t k = bl;
+    // 2x partial unrolled loop to load 8 bytes at a time.
+    while (k >= 8 * sizeof(int8_t)) {
+      // Load a 6x8 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 8;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 8;
+      const int8x8_t va2x01234567 = vld1_s8(a2); a2 += 8;
+      const int8x8_t va3x01234567 = vld1_s8(a3); a3 += 8;
+      const int8x8_t va4x01234567 = vld1_s8(a4); a4 += 8;
+      const int8x8_t va5x01234567 = vld1_s8(a5); a5 += 8;
+
+      // Load a 8x8 block of weights.
+      const int8x16_t vb01234567x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x0123 = vshlq_n_s8(vb01234567x0123, 4);
+      const int8x16_t vb0123x4567 = vshlq_n_s8(vb01234567x4567, 4);
+      const int8x16_t vb4567x0123 = vandq_s8(vb01234567x0123, vmask);
+      const int8x16_t vb4567x4567 = vandq_s8(vb01234567x4567, vmask);
+
+      // Multiply-accumulate: 6x8 * 8x8 --> 6x8.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb0123x0123, va2x01234567, 0);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb0123x4567, va2x01234567, 0);
+      vacc3x0123 = vdotq_lane_s32(vacc3x0123, vb0123x0123, va3x01234567, 0);
+      vacc3x4567 = vdotq_lane_s32(vacc3x4567, vb0123x4567, va3x01234567, 0);
+      vacc4x0123 = vdotq_lane_s32(vacc4x0123, vb0123x0123, va4x01234567, 0);
+      vacc4x4567 = vdotq_lane_s32(vacc4x4567, vb0123x4567, va4x01234567, 0);
+      vacc5x0123 = vdotq_lane_s32(vacc5x0123, vb0123x0123, va5x01234567, 0);
+      vacc5x4567 = vdotq_lane_s32(vacc5x4567, vb0123x4567, va5x01234567, 0);
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb4567x0123, va0x01234567, 1);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb4567x4567, va0x01234567, 1);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb4567x0123, va1x01234567, 1);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb4567x4567, va1x01234567, 1);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb4567x0123, va2x01234567, 1);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb4567x4567, va2x01234567, 1);
+      vacc3x0123 = vdotq_lane_s32(vacc3x0123, vb4567x0123, va3x01234567, 1);
+      vacc3x4567 = vdotq_lane_s32(vacc3x4567, vb4567x4567, va3x01234567, 1);
+      vacc4x0123 = vdotq_lane_s32(vacc4x0123, vb4567x0123, va4x01234567, 1);
+      vacc4x4567 = vdotq_lane_s32(vacc4x4567, vb4567x4567, va4x01234567, 1);
+      vacc5x0123 = vdotq_lane_s32(vacc5x0123, vb4567x0123, va5x01234567, 1);
+      vacc5x4567 = vdotq_lane_s32(vacc5x4567, vb4567x4567, va5x01234567, 1);
+
+      k -= 8 * sizeof(int8_t);
+    }
+    // Handle up to 4 final positions of `k`
+    if XNN_UNLIKELY(k != 0) {
+      // Load a 6x4 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 4;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 4;
+      const int8x8_t va2x01234567 = vld1_s8(a2); a2 += 4;
+      const int8x8_t va3x01234567 = vld1_s8(a3); a3 += 4;
+      const int8x8_t va4x01234567 = vld1_s8(a4); a4 += 4;
+      const int8x8_t va5x01234567 = vld1_s8(a5); a5 += 4;
+
+      // Load a 4x8 block of weights.
+      const int8x16_t vb0123x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+
+      // Multiply-accumulate: 6x4 * 4x8 --> 6x8.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb0123x0123, va2x01234567, 0);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb0123x4567, va2x01234567, 0);
+      vacc3x0123 = vdotq_lane_s32(vacc3x0123, vb0123x0123, va3x01234567, 0);
+      vacc3x4567 = vdotq_lane_s32(vacc3x4567, vb0123x4567, va3x01234567, 0);
+      vacc4x0123 = vdotq_lane_s32(vacc4x0123, vb0123x0123, va4x01234567, 0);
+      vacc4x4567 = vdotq_lane_s32(vacc4x4567, vb0123x4567, va4x01234567, 0);
+      vacc5x0123 = vdotq_lane_s32(vacc5x0123, vb0123x0123, va5x01234567, 0);
+      vacc5x4567 = vdotq_lane_s32(vacc5x4567, vb0123x4567, va5x01234567, 0);
+    }
+    const float32x4_t vfilter_output_scale0123 = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scale4567 = vld1q_f32(w); w = (const float*) w + 4;
+
+    float32x4_t vf0x0123 = vcvtq_f32_s32(vacc0x0123);
+    float32x4_t vf1x0123 = vcvtq_f32_s32(vacc1x0123);
+    vout0x0123 = vfmaq_f32(vout0x0123, vf0x0123, vfilter_output_scale0123);
+    vout1x0123 = vfmaq_f32(vout1x0123, vf1x0123, vfilter_output_scale0123);
+    float32x4_t vf0x4567 = vcvtq_f32_s32(vacc0x4567);
+    float32x4_t vf1x4567 = vcvtq_f32_s32(vacc1x4567);
+    vout0x4567 = vfmaq_f32(vout0x4567, vf0x4567, vfilter_output_scale4567);
+    vout1x4567 = vfmaq_f32(vout1x4567, vf1x4567, vfilter_output_scale4567);
+    float32x4_t vf2x0123 = vcvtq_f32_s32(vacc2x0123);
+    float32x4_t vf3x0123 = vcvtq_f32_s32(vacc3x0123);
+    vout2x0123 = vfmaq_f32(vout2x0123, vf2x0123, vfilter_output_scale0123);
+    vout3x0123 = vfmaq_f32(vout3x0123, vf3x0123, vfilter_output_scale0123);
+    float32x4_t vf2x4567 = vcvtq_f32_s32(vacc2x4567);
+    float32x4_t vf3x4567 = vcvtq_f32_s32(vacc3x4567);
+    vout2x4567 = vfmaq_f32(vout2x4567, vf2x4567, vfilter_output_scale4567);
+    vout3x4567 = vfmaq_f32(vout3x4567, vf3x4567, vfilter_output_scale4567);
+    float32x4_t vf4x0123 = vcvtq_f32_s32(vacc4x0123);
+    float32x4_t vf5x0123 = vcvtq_f32_s32(vacc5x0123);
+    vout4x0123 = vfmaq_f32(vout4x0123, vf4x0123, vfilter_output_scale0123);
+    vout5x0123 = vfmaq_f32(vout5x0123, vf5x0123, vfilter_output_scale0123);
+    float32x4_t vf4x4567 = vcvtq_f32_s32(vacc4x4567);
+    float32x4_t vf5x4567 = vcvtq_f32_s32(vacc5x4567);
+    vout4x4567 = vfmaq_f32(vout4x4567, vf4x4567, vfilter_output_scale4567);
+    vout5x4567 = vfmaq_f32(vout5x4567, vf5x4567, vfilter_output_scale4567);
+    }
+
+    const float32x4_t one_sixteenth = vdupq_n_f32(1/16.0);
+    vout0x0123 = vmulq_f32(vout0x0123, one_sixteenth);
+    vout0x4567 = vmulq_f32(vout0x4567, one_sixteenth);
+    vout1x0123 = vmulq_f32(vout1x0123, one_sixteenth);
+    vout1x4567 = vmulq_f32(vout1x4567, one_sixteenth);
+    vout2x0123 = vmulq_f32(vout2x0123, one_sixteenth);
+    vout2x4567 = vmulq_f32(vout2x4567, one_sixteenth);
+    vout3x0123 = vmulq_f32(vout3x0123, one_sixteenth);
+    vout3x4567 = vmulq_f32(vout3x4567, one_sixteenth);
+    vout4x0123 = vmulq_f32(vout4x0123, one_sixteenth);
+    vout4x4567 = vmulq_f32(vout4x4567, one_sixteenth);
+    vout5x0123 = vmulq_f32(vout5x0123, one_sixteenth);
+    vout5x4567 = vmulq_f32(vout5x4567, one_sixteenth);
+    const float32x4_t vinput_scale01 = vreinterpretq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    vout0x0123 = vmulq_lane_f32(vout0x0123, vget_low_f32(vinput_scale01), 1);
+    vout1x0123 = vmulq_lane_f32(vout1x0123, vget_high_f32(vinput_scale01), 1);
+    vout0x4567 = vmulq_lane_f32(vout0x4567, vget_low_f32(vinput_scale01), 1);
+    vout1x4567 = vmulq_lane_f32(vout1x4567, vget_high_f32(vinput_scale01), 1);
+    const float32x4_t vinput_scale23 = vreinterpretq_f32_s32(vld1q_s32(&quantization_params[2].zero_point));
+    vout2x0123 = vmulq_lane_f32(vout2x0123, vget_low_f32(vinput_scale23), 1);
+    vout3x0123 = vmulq_lane_f32(vout3x0123, vget_high_f32(vinput_scale23), 1);
+    vout2x4567 = vmulq_lane_f32(vout2x4567, vget_low_f32(vinput_scale23), 1);
+    vout3x4567 = vmulq_lane_f32(vout3x4567, vget_high_f32(vinput_scale23), 1);
+    const float32x4_t vinput_scale45 = vreinterpretq_f32_s32(vld1q_s32(&quantization_params[4].zero_point));
+    vout4x0123 = vmulq_lane_f32(vout4x0123, vget_low_f32(vinput_scale45), 1);
+    vout5x0123 = vmulq_lane_f32(vout5x0123, vget_high_f32(vinput_scale45), 1);
+    vout4x4567 = vmulq_lane_f32(vout4x4567, vget_low_f32(vinput_scale45), 1);
+    vout5x4567 = vmulq_lane_f32(vout5x4567, vget_high_f32(vinput_scale45), 1);
+
+
+    const float32x4_t vbias0123 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x0123 = vaddq_f32(vbias0123, vout0x0123);
+    vout1x0123 = vaddq_f32(vbias0123, vout1x0123);
+    vout2x0123 = vaddq_f32(vbias0123, vout2x0123);
+    vout3x0123 = vaddq_f32(vbias0123, vout3x0123);
+    vout4x0123 = vaddq_f32(vbias0123, vout4x0123);
+    vout5x0123 = vaddq_f32(vbias0123, vout5x0123);
+    const float32x4_t vbias4567 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x4567 = vaddq_f32(vbias4567, vout0x4567);
+    vout1x4567 = vaddq_f32(vbias4567, vout1x4567);
+    vout2x4567 = vaddq_f32(vbias4567, vout2x4567);
+    vout3x4567 = vaddq_f32(vbias4567, vout3x4567);
+    vout4x4567 = vaddq_f32(vbias4567, vout4x4567);
+    vout5x4567 = vaddq_f32(vbias4567, vout5x4567);
+
+    float16x8_t vfp16out0x01234567 = vcombine_f16(vcvt_f16_f32(vout0x0123), vcvt_f16_f32(vout0x4567));
+    float16x8_t vfp16out1x01234567 = vcombine_f16(vcvt_f16_f32(vout1x0123), vcvt_f16_f32(vout1x4567));
+    float16x8_t vfp16out2x01234567 = vcombine_f16(vcvt_f16_f32(vout2x0123), vcvt_f16_f32(vout2x4567));
+    float16x8_t vfp16out3x01234567 = vcombine_f16(vcvt_f16_f32(vout3x0123), vcvt_f16_f32(vout3x4567));
+    float16x8_t vfp16out4x01234567 = vcombine_f16(vcvt_f16_f32(vout4x0123), vcvt_f16_f32(vout4x4567));
+    float16x8_t vfp16out5x01234567 = vcombine_f16(vcvt_f16_f32(vout5x0123), vcvt_f16_f32(vout5x4567));
+
+    const float16x8_t voutput_min = vreinterpretq_f16_u16(vld1q_dup_u16(&params->fp16arith.min));
+    vfp16out0x01234567 = vmaxq_f16(vfp16out0x01234567, voutput_min);
+    vfp16out1x01234567 = vmaxq_f16(vfp16out1x01234567, voutput_min);
+    vfp16out2x01234567 = vmaxq_f16(vfp16out2x01234567, voutput_min);
+    vfp16out3x01234567 = vmaxq_f16(vfp16out3x01234567, voutput_min);
+    vfp16out4x01234567 = vmaxq_f16(vfp16out4x01234567, voutput_min);
+    vfp16out5x01234567 = vmaxq_f16(vfp16out5x01234567, voutput_min);
+    const float16x8_t voutput_max = vreinterpretq_f16_u16(vld1q_dup_u16(&params->fp16arith.max));
+    vfp16out0x01234567 = vminq_f16(vfp16out0x01234567, voutput_max);
+    vfp16out1x01234567 = vminq_f16(vfp16out1x01234567, voutput_max);
+    vfp16out2x01234567 = vminq_f16(vfp16out2x01234567, voutput_max);
+    vfp16out3x01234567 = vminq_f16(vfp16out3x01234567, voutput_max);
+    vfp16out4x01234567 = vminq_f16(vfp16out4x01234567, voutput_max);
+    vfp16out5x01234567 = vminq_f16(vfp16out5x01234567, voutput_max);
+    if XNN_LIKELY(nc >= 8) {
+      vst1q_u16(c0, vreinterpretq_u16_f16(vfp16out0x01234567));
+      vst1q_u16(c1, vreinterpretq_u16_f16(vfp16out1x01234567));
+      vst1q_u16(c2, vreinterpretq_u16_f16(vfp16out2x01234567));
+      vst1q_u16(c3, vreinterpretq_u16_f16(vfp16out3x01234567));
+      vst1q_u16(c4, vreinterpretq_u16_f16(vfp16out4x01234567));
+      vst1q_u16(c5, vreinterpretq_u16_f16(vfp16out5x01234567));
+
+      a0 = (const int8_t*) ((uintptr_t) a0 - kc);
+      a1 = (const int8_t*) ((uintptr_t) a1 - kc);
+      a2 = (const int8_t*) ((uintptr_t) a2 - kc);
+      a3 = (const int8_t*) ((uintptr_t) a3 - kc);
+      a4 = (const int8_t*) ((uintptr_t) a4 - kc);
+      a5 = (const int8_t*) ((uintptr_t) a5 - kc);
+
+      c0 = (uint16_t*) ((uintptr_t) c0 + cn_stride);
+      c1 = (uint16_t*) ((uintptr_t) c1 + cn_stride);
+      c2 = (uint16_t*) ((uintptr_t) c2 + cn_stride);
+      c3 = (uint16_t*) ((uintptr_t) c3 + cn_stride);
+      c4 = (uint16_t*) ((uintptr_t) c4 + cn_stride);
+      c5 = (uint16_t*) ((uintptr_t) c5 + cn_stride);
+
+      nc -= 8;
+    } else {
+     float16x4_t vfp16out0x0123 = vget_low_f16(vfp16out0x01234567);
+     float16x4_t vfp16out1x0123 = vget_low_f16(vfp16out1x01234567);
+     float16x4_t vfp16out2x0123 = vget_low_f16(vfp16out2x01234567);
+     float16x4_t vfp16out3x0123 = vget_low_f16(vfp16out3x01234567);
+     float16x4_t vfp16out4x0123 = vget_low_f16(vfp16out4x01234567);
+     float16x4_t vfp16out5x0123 = vget_low_f16(vfp16out5x01234567);
+     if (nc & 4) {
+       vst1_u16(c0, vreinterpret_u16_f16(vfp16out0x0123)); c0 += 4;
+       vst1_u16(c1, vreinterpret_u16_f16(vfp16out1x0123)); c1 += 4;
+       vst1_u16(c2, vreinterpret_u16_f16(vfp16out2x0123)); c2 += 4;
+       vst1_u16(c3, vreinterpret_u16_f16(vfp16out3x0123)); c3 += 4;
+       vst1_u16(c4, vreinterpret_u16_f16(vfp16out4x0123)); c4 += 4;
+       vst1_u16(c5, vreinterpret_u16_f16(vfp16out5x0123)); c5 += 4;
+       vfp16out0x0123 = vget_high_f16(vfp16out0x01234567);
+       vfp16out1x0123 = vget_high_f16(vfp16out1x01234567);
+       vfp16out2x0123 = vget_high_f16(vfp16out2x01234567);
+       vfp16out3x0123 = vget_high_f16(vfp16out3x01234567);
+       vfp16out4x0123 = vget_high_f16(vfp16out4x01234567);
+       vfp16out5x0123 = vget_high_f16(vfp16out5x01234567);
+     }
+     if (nc & 2) {
+       vst1_lane_u32((void*) c0, vreinterpret_u32_f16(vfp16out0x0123), 0); c0 += 2;
+       vst1_lane_u32((void*) c1, vreinterpret_u32_f16(vfp16out1x0123), 0); c1 += 2;
+       vst1_lane_u32((void*) c2, vreinterpret_u32_f16(vfp16out2x0123), 0); c2 += 2;
+       vst1_lane_u32((void*) c3, vreinterpret_u32_f16(vfp16out3x0123), 0); c3 += 2;
+       vst1_lane_u32((void*) c4, vreinterpret_u32_f16(vfp16out4x0123), 0); c4 += 2;
+       vst1_lane_u32((void*) c5, vreinterpret_u32_f16(vfp16out5x0123), 0); c5 += 2;
+       vfp16out0x0123 = vext_f16(vfp16out0x0123, vfp16out0x0123, 2);
+       vfp16out1x0123 = vext_f16(vfp16out1x0123, vfp16out1x0123, 2);
+       vfp16out2x0123 = vext_f16(vfp16out2x0123, vfp16out2x0123, 2);
+       vfp16out3x0123 = vext_f16(vfp16out3x0123, vfp16out3x0123, 2);
+       vfp16out4x0123 = vext_f16(vfp16out4x0123, vfp16out4x0123, 2);
+       vfp16out5x0123 = vext_f16(vfp16out5x0123, vfp16out5x0123, 2);
+     }
+     if (nc & 1) {
+       vst1_lane_u16(c0, vreinterpret_u16_f16(vfp16out0x0123), 0);
+       vst1_lane_u16(c1, vreinterpret_u16_f16(vfp16out1x0123), 0);
+       vst1_lane_u16(c2, vreinterpret_u16_f16(vfp16out2x0123), 0);
+       vst1_lane_u16(c3, vreinterpret_u16_f16(vfp16out3x0123), 0);
+       vst1_lane_u16(c4, vreinterpret_u16_f16(vfp16out4x0123), 0);
+       vst1_lane_u16(c5, vreinterpret_u16_f16(vfp16out5x0123), 0);
+     }
+      nc = 0;
+    }
+  } while (nc != 0);
+}

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x16c4-minmax-neondot.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x16c4-minmax-neondot.c
@@ -1,0 +1,199 @@
+// Auto-generated file. Do not edit!
+//   Template: src/qs8-gemm/c4-neondot.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2020 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+
+#include <arm_neon.h>
+
+#include "xnnpack/gemm.h"
+#include "xnnpack/math.h"
+
+
+void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x16c4__neondot(
+    size_t mr,
+    size_t nc,
+    size_t kc,
+    const int8_t* restrict a,
+    size_t a_stride,
+    const void* restrict w,
+    float* restrict c,
+    size_t cm_stride,
+    size_t cn_stride,
+    const union xnn_f32_qb4w_minmax_params params[restrict XNN_MIN_ELEMENTS(1)],
+    const struct xnn_qd8_quantization_params quantization_params[restrict XNN_MIN_ELEMENTS(1)]) XNN_OOB_READS
+{
+  assert(mr != 0);
+  assert(mr <= 1);
+  assert(nc != 0);
+  assert(kc != 0);
+  assert(kc % sizeof(int8_t) == 0);
+  assert(a != NULL);
+  assert(w != NULL);
+  assert(c != NULL);
+
+  kc = round_up_po2(kc, 4 * sizeof(int8_t));
+  const int8_t* a0 = a;
+  float* c0 = c;
+
+  size_t bl = params->scalar.blocksize;
+  assert(bl <= kc);
+  assert(bl != 0);
+  size_t n_blocks = kc / bl;
+  const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
+  // Loop over groups of 16 columns.
+  do {
+    // Initialize accumulators with bias. 16 bias values are loaded from the
+    // weight matrix, at the start of the group of 16 columns.
+    const float32x4_t vinput_zero_point0 = vcvtq_f32_s32(vld1q_dup_s32(&quantization_params[0].zero_point));
+    const float32x4_t vksum0123 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x0123 = vmulq_f32(vksum0123, vinput_zero_point0);
+    const float32x4_t vksum4567 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x4567 = vmulq_f32(vksum4567, vinput_zero_point0);
+    const float32x4_t vksum89AB = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x89AB = vmulq_f32(vksum89AB, vinput_zero_point0);
+    const float32x4_t vksumCDEF = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0xCDEF = vmulq_f32(vksumCDEF, vinput_zero_point0);
+
+    for (size_t nb=0; nb < n_blocks; ++nb) {
+      int32x4_t vacc0x0123 = vdupq_n_s32(0);
+      int32x4_t vacc0x4567 = vdupq_n_s32(0);
+      int32x4_t vacc0x89AB = vdupq_n_s32(0);
+      int32x4_t vacc0xCDEF = vdupq_n_s32(0);
+    // Inner accumulation loop along the 16 columns.
+    size_t k = bl;
+    // 2x partial unrolled loop to load 8 bytes at a time.
+    while (k >= 8 * sizeof(int8_t)) {
+      // Load a 1x8 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 8;
+
+      // Load a 8x16 block of weights.
+      const int8x16_t vb01234567x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567x89AB = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567xCDEF = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x0123 = vshlq_n_s8(vb01234567x0123, 4);
+      const int8x16_t vb0123x4567 = vshlq_n_s8(vb01234567x4567, 4);
+      const int8x16_t vb0123x89AB = vshlq_n_s8(vb01234567x89AB, 4);
+      const int8x16_t vb0123xCDEF = vshlq_n_s8(vb01234567xCDEF, 4);
+      const int8x16_t vb4567x0123 = vandq_s8(vb01234567x0123, vmask);
+      const int8x16_t vb4567x4567 = vandq_s8(vb01234567x4567, vmask);
+      const int8x16_t vb4567x89AB = vandq_s8(vb01234567x89AB, vmask);
+      const int8x16_t vb4567xCDEF = vandq_s8(vb01234567xCDEF, vmask);
+
+      // Multiply-accumulate: 1x8 * 8x16 --> 1x16.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc0x89AB = vdotq_lane_s32(vacc0x89AB, vb0123x89AB, va0x01234567, 0);
+      vacc0xCDEF = vdotq_lane_s32(vacc0xCDEF, vb0123xCDEF, va0x01234567, 0);
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb4567x0123, va0x01234567, 1);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb4567x4567, va0x01234567, 1);
+      vacc0x89AB = vdotq_lane_s32(vacc0x89AB, vb4567x89AB, va0x01234567, 1);
+      vacc0xCDEF = vdotq_lane_s32(vacc0xCDEF, vb4567xCDEF, va0x01234567, 1);
+
+      k -= 8 * sizeof(int8_t);
+    }
+    // Handle up to 4 final positions of `k`
+    if XNN_UNLIKELY(k != 0) {
+      // Load a 1x4 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 4;
+
+      // Load a 4x16 block of weights.
+      const int8x16_t vb0123x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x89AB = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123xCDEF = vld1q_s8(w); w = (const int8_t*) w + 16;
+
+      // Multiply-accumulate: 1x4 * 4x16 --> 1x16.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc0x89AB = vdotq_lane_s32(vacc0x89AB, vb0123x89AB, va0x01234567, 0);
+      vacc0xCDEF = vdotq_lane_s32(vacc0xCDEF, vb0123xCDEF, va0x01234567, 0);
+    }
+    const float32x4_t vfilter_output_scale0123 = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scale4567 = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scale89AB = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scaleCDEF = vld1q_f32(w); w = (const float*) w + 4;
+
+    float32x4_t vf0x0123 = vcvtq_f32_s32(vacc0x0123);
+    vout0x0123 = vfmaq_f32(vout0x0123, vf0x0123, vfilter_output_scale0123);
+    float32x4_t vf0x4567 = vcvtq_f32_s32(vacc0x4567);
+    vout0x4567 = vfmaq_f32(vout0x4567, vf0x4567, vfilter_output_scale4567);
+    float32x4_t vf0x89AB = vcvtq_f32_s32(vacc0x89AB);
+    vout0x89AB = vfmaq_f32(vout0x89AB, vf0x89AB, vfilter_output_scale89AB);
+    float32x4_t vf0xCDEF = vcvtq_f32_s32(vacc0xCDEF);
+    vout0xCDEF = vfmaq_f32(vout0xCDEF, vf0xCDEF, vfilter_output_scaleCDEF);
+    }
+
+    const float32x4_t one_sixteenth = vdupq_n_f32(1/16.0);
+    vout0x0123 = vmulq_f32(vout0x0123, one_sixteenth);
+    vout0x4567 = vmulq_f32(vout0x4567, one_sixteenth);
+    vout0x89AB = vmulq_f32(vout0x89AB, one_sixteenth);
+    vout0xCDEF = vmulq_f32(vout0xCDEF, one_sixteenth);
+    const float32x4_t vinput_scale0 = vld1q_dup_f32(&quantization_params[0].inv_scale);
+    vout0x0123 = vmulq_f32(vout0x0123, vinput_scale0);
+    vout0x4567 = vmulq_f32(vout0x4567, vinput_scale0);
+    vout0x89AB = vmulq_f32(vout0x89AB, vinput_scale0);
+    vout0xCDEF = vmulq_f32(vout0xCDEF, vinput_scale0);
+
+
+    const float32x4_t vbias0123 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x0123 = vaddq_f32(vbias0123, vout0x0123);
+    const float32x4_t vbias4567 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x4567 = vaddq_f32(vbias4567, vout0x4567);
+    const float32x4_t vbias89AB = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x89AB = vaddq_f32(vbias89AB, vout0x89AB);
+    const float32x4_t vbiasCDEF = vld1q_f32(w); w = (const float*) w + 4;
+    vout0xCDEF = vaddq_f32(vbiasCDEF, vout0xCDEF);
+
+    const float32x4_t voutput_min = vld1q_dup_f32(&params->scalar.min);
+    vout0x0123 = vmaxq_f32(vout0x0123, voutput_min);
+    vout0x4567 = vmaxq_f32(vout0x4567, voutput_min);
+    vout0x89AB = vmaxq_f32(vout0x89AB, voutput_min);
+    vout0xCDEF = vmaxq_f32(vout0xCDEF, voutput_min);
+
+    const float32x4_t voutput_max = vld1q_dup_f32(&params->scalar.max);
+    vout0x0123 = vminq_f32(vout0x0123, voutput_max);
+    vout0x4567 = vminq_f32(vout0x4567, voutput_max);
+    vout0x89AB = vminq_f32(vout0x89AB, voutput_max);
+    vout0xCDEF = vminq_f32(vout0xCDEF, voutput_max);
+
+    if XNN_LIKELY(nc >= 16) {
+      vst1q_f32(c0, vout0x0123);
+      vst1q_f32(c0 + 4, vout0x4567);
+      vst1q_f32(c0 + 8, vout0x89AB);
+      vst1q_f32(c0 + 12, vout0xCDEF);
+
+      a0 = (const int8_t*) ((uintptr_t) a0 - kc);
+
+      c0 = (float*) ((uintptr_t) c0 + cn_stride);
+
+      nc -= 16;
+    } else {
+     if (nc & 8) {
+       vst1q_f32(c0, vout0x0123); c0 += 4;
+       vout0x0123 = vout0x89AB;
+       vst1q_f32(c0, vout0x4567); c0 += 4;
+       vout0x4567 = vout0xCDEF;
+     }
+     if (nc & 4) {
+       vst1q_f32(c0, vout0x0123); c0 += 4;
+       vout0x0123 = vout0x4567;
+     }
+     float32x2_t vout0x01 = vget_low_f32(vout0x0123);
+     if (nc & 2) {
+       vst1_f32(c0, vout0x01); c0 += 2;
+       vout0x01 = vget_high_f32(vout0x0123);
+     }
+     if (nc & 1) {
+       vst1_lane_f32(c0, vout0x01, 0);
+     }
+      nc = 0;
+    }
+  } while (nc != 0);
+}

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x8c4-minmax-neondot.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x8c4-minmax-neondot.c
@@ -1,0 +1,153 @@
+// Auto-generated file. Do not edit!
+//   Template: src/qs8-gemm/c4-neondot.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2020 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+
+#include <arm_neon.h>
+
+#include "xnnpack/gemm.h"
+#include "xnnpack/math.h"
+
+
+void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x8c4__neondot(
+    size_t mr,
+    size_t nc,
+    size_t kc,
+    const int8_t* restrict a,
+    size_t a_stride,
+    const void* restrict w,
+    float* restrict c,
+    size_t cm_stride,
+    size_t cn_stride,
+    const union xnn_f32_qb4w_minmax_params params[restrict XNN_MIN_ELEMENTS(1)],
+    const struct xnn_qd8_quantization_params quantization_params[restrict XNN_MIN_ELEMENTS(1)]) XNN_OOB_READS
+{
+  assert(mr != 0);
+  assert(mr <= 1);
+  assert(nc != 0);
+  assert(kc != 0);
+  assert(kc % sizeof(int8_t) == 0);
+  assert(a != NULL);
+  assert(w != NULL);
+  assert(c != NULL);
+
+  kc = round_up_po2(kc, 4 * sizeof(int8_t));
+  const int8_t* a0 = a;
+  float* c0 = c;
+
+  size_t bl = params->scalar.blocksize;
+  assert(bl <= kc);
+  assert(bl != 0);
+  size_t n_blocks = kc / bl;
+  const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
+  // Loop over groups of 8 columns.
+  do {
+    // Initialize accumulators with bias. 8 bias values are loaded from the
+    // weight matrix, at the start of the group of 8 columns.
+    const float32x4_t vinput_zero_point0 = vcvtq_f32_s32(vld1q_dup_s32(&quantization_params[0].zero_point));
+    const float32x4_t vksum0123 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x0123 = vmulq_f32(vksum0123, vinput_zero_point0);
+    const float32x4_t vksum4567 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x4567 = vmulq_f32(vksum4567, vinput_zero_point0);
+
+    for (size_t nb=0; nb < n_blocks; ++nb) {
+      int32x4_t vacc0x0123 = vdupq_n_s32(0);
+      int32x4_t vacc0x4567 = vdupq_n_s32(0);
+    // Inner accumulation loop along the 8 columns.
+    size_t k = bl;
+    // 2x partial unrolled loop to load 8 bytes at a time.
+    while (k >= 8 * sizeof(int8_t)) {
+      // Load a 1x8 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 8;
+
+      // Load a 8x8 block of weights.
+      const int8x16_t vb01234567x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x0123 = vshlq_n_s8(vb01234567x0123, 4);
+      const int8x16_t vb0123x4567 = vshlq_n_s8(vb01234567x4567, 4);
+      const int8x16_t vb4567x0123 = vandq_s8(vb01234567x0123, vmask);
+      const int8x16_t vb4567x4567 = vandq_s8(vb01234567x4567, vmask);
+
+      // Multiply-accumulate: 1x8 * 8x8 --> 1x8.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb4567x0123, va0x01234567, 1);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb4567x4567, va0x01234567, 1);
+
+      k -= 8 * sizeof(int8_t);
+    }
+    // Handle up to 4 final positions of `k`
+    if XNN_UNLIKELY(k != 0) {
+      // Load a 1x4 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 4;
+
+      // Load a 4x8 block of weights.
+      const int8x16_t vb0123x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+
+      // Multiply-accumulate: 1x4 * 4x8 --> 1x8.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+    }
+    const float32x4_t vfilter_output_scale0123 = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scale4567 = vld1q_f32(w); w = (const float*) w + 4;
+
+    float32x4_t vf0x0123 = vcvtq_f32_s32(vacc0x0123);
+    vout0x0123 = vfmaq_f32(vout0x0123, vf0x0123, vfilter_output_scale0123);
+    float32x4_t vf0x4567 = vcvtq_f32_s32(vacc0x4567);
+    vout0x4567 = vfmaq_f32(vout0x4567, vf0x4567, vfilter_output_scale4567);
+    }
+
+    const float32x4_t one_sixteenth = vdupq_n_f32(1/16.0);
+    vout0x0123 = vmulq_f32(vout0x0123, one_sixteenth);
+    vout0x4567 = vmulq_f32(vout0x4567, one_sixteenth);
+    const float32x4_t vinput_scale0 = vld1q_dup_f32(&quantization_params[0].inv_scale);
+    vout0x0123 = vmulq_f32(vout0x0123, vinput_scale0);
+    vout0x4567 = vmulq_f32(vout0x4567, vinput_scale0);
+
+
+    const float32x4_t vbias0123 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x0123 = vaddq_f32(vbias0123, vout0x0123);
+    const float32x4_t vbias4567 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x4567 = vaddq_f32(vbias4567, vout0x4567);
+
+    const float32x4_t voutput_min = vld1q_dup_f32(&params->scalar.min);
+    vout0x0123 = vmaxq_f32(vout0x0123, voutput_min);
+    vout0x4567 = vmaxq_f32(vout0x4567, voutput_min);
+
+    const float32x4_t voutput_max = vld1q_dup_f32(&params->scalar.max);
+    vout0x0123 = vminq_f32(vout0x0123, voutput_max);
+    vout0x4567 = vminq_f32(vout0x4567, voutput_max);
+
+    if XNN_LIKELY(nc >= 8) {
+      vst1q_f32(c0, vout0x0123);
+      vst1q_f32(c0 + 4, vout0x4567);
+
+      a0 = (const int8_t*) ((uintptr_t) a0 - kc);
+
+      c0 = (float*) ((uintptr_t) c0 + cn_stride);
+
+      nc -= 8;
+    } else {
+     if (nc & 4) {
+       vst1q_f32(c0, vout0x0123); c0 += 4;
+       vout0x0123 = vout0x4567;
+     }
+     float32x2_t vout0x01 = vget_low_f32(vout0x0123);
+     if (nc & 2) {
+       vst1_f32(c0, vout0x01); c0 += 2;
+       vout0x01 = vget_high_f32(vout0x0123);
+     }
+     if (nc & 1) {
+       vst1_lane_f32(c0, vout0x01, 0);
+     }
+      nc = 0;
+    }
+  } while (nc != 0);
+}

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x16c4-minmax-neondot.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x16c4-minmax-neondot.c
@@ -1,0 +1,271 @@
+// Auto-generated file. Do not edit!
+//   Template: src/qs8-gemm/c4-neondot.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2020 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+
+#include <arm_neon.h>
+
+#include "xnnpack/gemm.h"
+#include "xnnpack/math.h"
+
+
+void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x16c4__neondot(
+    size_t mr,
+    size_t nc,
+    size_t kc,
+    const int8_t* restrict a,
+    size_t a_stride,
+    const void* restrict w,
+    float* restrict c,
+    size_t cm_stride,
+    size_t cn_stride,
+    const union xnn_f32_qb4w_minmax_params params[restrict XNN_MIN_ELEMENTS(1)],
+    const struct xnn_qd8_quantization_params quantization_params[restrict XNN_MIN_ELEMENTS(1)]) XNN_OOB_READS
+{
+  assert(mr != 0);
+  assert(mr <= 2);
+  assert(nc != 0);
+  assert(kc != 0);
+  assert(kc % sizeof(int8_t) == 0);
+  assert(a != NULL);
+  assert(w != NULL);
+  assert(c != NULL);
+
+  kc = round_up_po2(kc, 4 * sizeof(int8_t));
+  const int8_t* a0 = a;
+  float* c0 = c;
+  const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
+  float* c1 = (float*) ((uintptr_t) c0 + cm_stride);
+  if XNN_UNPREDICTABLE(mr != 2) {
+    a1 = a0;
+    c1 = c0;
+  }
+
+  size_t bl = params->scalar.blocksize;
+  assert(bl <= kc);
+  assert(bl != 0);
+  size_t n_blocks = kc / bl;
+  const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
+  // Loop over groups of 16 columns.
+  do {
+    // Initialize accumulators with bias. 16 bias values are loaded from the
+    // weight matrix, at the start of the group of 16 columns.
+    const float32x4_t vinput_zero_point01 = vcvtq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    const float32x4_t vksum0123 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x0123 = vmulq_lane_f32(vksum0123, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x0123 = vmulq_lane_f32(vksum0123, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksum4567 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksum89AB = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x89AB = vmulq_lane_f32(vksum89AB, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x89AB = vmulq_lane_f32(vksum89AB, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksumCDEF = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0xCDEF = vmulq_lane_f32(vksumCDEF, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vinput_zero_point01), 0);
+
+    for (size_t nb=0; nb < n_blocks; ++nb) {
+      int32x4_t vacc0x0123 = vdupq_n_s32(0);
+      int32x4_t vacc1x0123 = vdupq_n_s32(0);
+      int32x4_t vacc0x4567 = vdupq_n_s32(0);
+      int32x4_t vacc1x4567 = vdupq_n_s32(0);
+      int32x4_t vacc0x89AB = vdupq_n_s32(0);
+      int32x4_t vacc1x89AB = vdupq_n_s32(0);
+      int32x4_t vacc0xCDEF = vdupq_n_s32(0);
+      int32x4_t vacc1xCDEF = vdupq_n_s32(0);
+    // Inner accumulation loop along the 16 columns.
+    size_t k = bl;
+    // 2x partial unrolled loop to load 8 bytes at a time.
+    while (k >= 8 * sizeof(int8_t)) {
+      // Load a 2x8 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 8;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 8;
+
+      // Load a 8x16 block of weights.
+      const int8x16_t vb01234567x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567x89AB = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567xCDEF = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x0123 = vshlq_n_s8(vb01234567x0123, 4);
+      const int8x16_t vb0123x4567 = vshlq_n_s8(vb01234567x4567, 4);
+      const int8x16_t vb0123x89AB = vshlq_n_s8(vb01234567x89AB, 4);
+      const int8x16_t vb0123xCDEF = vshlq_n_s8(vb01234567xCDEF, 4);
+      const int8x16_t vb4567x0123 = vandq_s8(vb01234567x0123, vmask);
+      const int8x16_t vb4567x4567 = vandq_s8(vb01234567x4567, vmask);
+      const int8x16_t vb4567x89AB = vandq_s8(vb01234567x89AB, vmask);
+      const int8x16_t vb4567xCDEF = vandq_s8(vb01234567xCDEF, vmask);
+
+      // Multiply-accumulate: 2x8 * 8x16 --> 2x16.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc0x89AB = vdotq_lane_s32(vacc0x89AB, vb0123x89AB, va0x01234567, 0);
+      vacc0xCDEF = vdotq_lane_s32(vacc0xCDEF, vb0123xCDEF, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+      vacc1x89AB = vdotq_lane_s32(vacc1x89AB, vb0123x89AB, va1x01234567, 0);
+      vacc1xCDEF = vdotq_lane_s32(vacc1xCDEF, vb0123xCDEF, va1x01234567, 0);
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb4567x0123, va0x01234567, 1);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb4567x4567, va0x01234567, 1);
+      vacc0x89AB = vdotq_lane_s32(vacc0x89AB, vb4567x89AB, va0x01234567, 1);
+      vacc0xCDEF = vdotq_lane_s32(vacc0xCDEF, vb4567xCDEF, va0x01234567, 1);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb4567x0123, va1x01234567, 1);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb4567x4567, va1x01234567, 1);
+      vacc1x89AB = vdotq_lane_s32(vacc1x89AB, vb4567x89AB, va1x01234567, 1);
+      vacc1xCDEF = vdotq_lane_s32(vacc1xCDEF, vb4567xCDEF, va1x01234567, 1);
+
+      k -= 8 * sizeof(int8_t);
+    }
+    // Handle up to 4 final positions of `k`
+    if XNN_UNLIKELY(k != 0) {
+      // Load a 2x4 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 4;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 4;
+
+      // Load a 4x16 block of weights.
+      const int8x16_t vb0123x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x89AB = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123xCDEF = vld1q_s8(w); w = (const int8_t*) w + 16;
+
+      // Multiply-accumulate: 2x4 * 4x16 --> 2x16.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc0x89AB = vdotq_lane_s32(vacc0x89AB, vb0123x89AB, va0x01234567, 0);
+      vacc0xCDEF = vdotq_lane_s32(vacc0xCDEF, vb0123xCDEF, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+      vacc1x89AB = vdotq_lane_s32(vacc1x89AB, vb0123x89AB, va1x01234567, 0);
+      vacc1xCDEF = vdotq_lane_s32(vacc1xCDEF, vb0123xCDEF, va1x01234567, 0);
+    }
+    const float32x4_t vfilter_output_scale0123 = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scale4567 = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scale89AB = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scaleCDEF = vld1q_f32(w); w = (const float*) w + 4;
+
+    float32x4_t vf0x0123 = vcvtq_f32_s32(vacc0x0123);
+    float32x4_t vf1x0123 = vcvtq_f32_s32(vacc1x0123);
+    vout0x0123 = vfmaq_f32(vout0x0123, vf0x0123, vfilter_output_scale0123);
+    vout1x0123 = vfmaq_f32(vout1x0123, vf1x0123, vfilter_output_scale0123);
+    float32x4_t vf0x4567 = vcvtq_f32_s32(vacc0x4567);
+    float32x4_t vf1x4567 = vcvtq_f32_s32(vacc1x4567);
+    vout0x4567 = vfmaq_f32(vout0x4567, vf0x4567, vfilter_output_scale4567);
+    vout1x4567 = vfmaq_f32(vout1x4567, vf1x4567, vfilter_output_scale4567);
+    float32x4_t vf0x89AB = vcvtq_f32_s32(vacc0x89AB);
+    float32x4_t vf1x89AB = vcvtq_f32_s32(vacc1x89AB);
+    vout0x89AB = vfmaq_f32(vout0x89AB, vf0x89AB, vfilter_output_scale89AB);
+    vout1x89AB = vfmaq_f32(vout1x89AB, vf1x89AB, vfilter_output_scale89AB);
+    float32x4_t vf0xCDEF = vcvtq_f32_s32(vacc0xCDEF);
+    float32x4_t vf1xCDEF = vcvtq_f32_s32(vacc1xCDEF);
+    vout0xCDEF = vfmaq_f32(vout0xCDEF, vf0xCDEF, vfilter_output_scaleCDEF);
+    vout1xCDEF = vfmaq_f32(vout1xCDEF, vf1xCDEF, vfilter_output_scaleCDEF);
+    }
+
+    const float32x4_t one_sixteenth = vdupq_n_f32(1/16.0);
+    vout0x0123 = vmulq_f32(vout0x0123, one_sixteenth);
+    vout0x4567 = vmulq_f32(vout0x4567, one_sixteenth);
+    vout0x89AB = vmulq_f32(vout0x89AB, one_sixteenth);
+    vout0xCDEF = vmulq_f32(vout0xCDEF, one_sixteenth);
+    vout1x0123 = vmulq_f32(vout1x0123, one_sixteenth);
+    vout1x4567 = vmulq_f32(vout1x4567, one_sixteenth);
+    vout1x89AB = vmulq_f32(vout1x89AB, one_sixteenth);
+    vout1xCDEF = vmulq_f32(vout1xCDEF, one_sixteenth);
+    const float32x4_t vinput_scale01 = vreinterpretq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    vout0x0123 = vmulq_lane_f32(vout0x0123, vget_low_f32(vinput_scale01), 1);
+    vout1x0123 = vmulq_lane_f32(vout1x0123, vget_high_f32(vinput_scale01), 1);
+    vout0x4567 = vmulq_lane_f32(vout0x4567, vget_low_f32(vinput_scale01), 1);
+    vout1x4567 = vmulq_lane_f32(vout1x4567, vget_high_f32(vinput_scale01), 1);
+    vout0x89AB = vmulq_lane_f32(vout0x89AB, vget_low_f32(vinput_scale01), 1);
+    vout1x89AB = vmulq_lane_f32(vout1x89AB, vget_high_f32(vinput_scale01), 1);
+    vout0xCDEF = vmulq_lane_f32(vout0xCDEF, vget_low_f32(vinput_scale01), 1);
+    vout1xCDEF = vmulq_lane_f32(vout1xCDEF, vget_high_f32(vinput_scale01), 1);
+
+
+    const float32x4_t vbias0123 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x0123 = vaddq_f32(vbias0123, vout0x0123);
+    vout1x0123 = vaddq_f32(vbias0123, vout1x0123);
+    const float32x4_t vbias4567 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x4567 = vaddq_f32(vbias4567, vout0x4567);
+    vout1x4567 = vaddq_f32(vbias4567, vout1x4567);
+    const float32x4_t vbias89AB = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x89AB = vaddq_f32(vbias89AB, vout0x89AB);
+    vout1x89AB = vaddq_f32(vbias89AB, vout1x89AB);
+    const float32x4_t vbiasCDEF = vld1q_f32(w); w = (const float*) w + 4;
+    vout0xCDEF = vaddq_f32(vbiasCDEF, vout0xCDEF);
+    vout1xCDEF = vaddq_f32(vbiasCDEF, vout1xCDEF);
+
+    const float32x4_t voutput_min = vld1q_dup_f32(&params->scalar.min);
+    vout0x0123 = vmaxq_f32(vout0x0123, voutput_min);
+    vout0x4567 = vmaxq_f32(vout0x4567, voutput_min);
+    vout0x89AB = vmaxq_f32(vout0x89AB, voutput_min);
+    vout0xCDEF = vmaxq_f32(vout0xCDEF, voutput_min);
+    vout1x0123 = vmaxq_f32(vout1x0123, voutput_min);
+    vout1x4567 = vmaxq_f32(vout1x4567, voutput_min);
+    vout1x89AB = vmaxq_f32(vout1x89AB, voutput_min);
+    vout1xCDEF = vmaxq_f32(vout1xCDEF, voutput_min);
+
+    const float32x4_t voutput_max = vld1q_dup_f32(&params->scalar.max);
+    vout0x0123 = vminq_f32(vout0x0123, voutput_max);
+    vout0x4567 = vminq_f32(vout0x4567, voutput_max);
+    vout0x89AB = vminq_f32(vout0x89AB, voutput_max);
+    vout0xCDEF = vminq_f32(vout0xCDEF, voutput_max);
+    vout1x0123 = vminq_f32(vout1x0123, voutput_max);
+    vout1x4567 = vminq_f32(vout1x4567, voutput_max);
+    vout1x89AB = vminq_f32(vout1x89AB, voutput_max);
+    vout1xCDEF = vminq_f32(vout1xCDEF, voutput_max);
+
+    if XNN_LIKELY(nc >= 16) {
+      vst1q_f32(c0, vout0x0123);
+      vst1q_f32(c0 + 4, vout0x4567);
+      vst1q_f32(c0 + 8, vout0x89AB);
+      vst1q_f32(c0 + 12, vout0xCDEF);
+      vst1q_f32(c1, vout1x0123);
+      vst1q_f32(c1 + 4, vout1x4567);
+      vst1q_f32(c1 + 8, vout1x89AB);
+      vst1q_f32(c1 + 12, vout1xCDEF);
+
+      a0 = (const int8_t*) ((uintptr_t) a0 - kc);
+      a1 = (const int8_t*) ((uintptr_t) a1 - kc);
+
+      c0 = (float*) ((uintptr_t) c0 + cn_stride);
+      c1 = (float*) ((uintptr_t) c1 + cn_stride);
+
+      nc -= 16;
+    } else {
+     if (nc & 8) {
+       vst1q_f32(c0, vout0x0123); c0 += 4;
+       vout0x0123 = vout0x89AB;
+       vst1q_f32(c1, vout1x0123); c1 += 4;
+       vout1x0123 = vout1x89AB;
+       vst1q_f32(c0, vout0x4567); c0 += 4;
+       vout0x4567 = vout0xCDEF;
+       vst1q_f32(c1, vout1x4567); c1 += 4;
+       vout1x4567 = vout1xCDEF;
+     }
+     if (nc & 4) {
+       vst1q_f32(c0, vout0x0123); c0 += 4;
+       vout0x0123 = vout0x4567;
+       vst1q_f32(c1, vout1x0123); c1 += 4;
+       vout1x0123 = vout1x4567;
+     }
+     float32x2_t vout0x01 = vget_low_f32(vout0x0123);
+     float32x2_t vout1x01 = vget_low_f32(vout1x0123);
+     if (nc & 2) {
+       vst1_f32(c0, vout0x01); c0 += 2;
+       vst1_f32(c1, vout1x01); c1 += 2;
+       vout0x01 = vget_high_f32(vout0x0123);
+       vout1x01 = vget_high_f32(vout1x0123);
+     }
+     if (nc & 1) {
+       vst1_lane_f32(c0, vout0x01, 0);
+       vst1_lane_f32(c1, vout1x01, 0);
+     }
+      nc = 0;
+    }
+  } while (nc != 0);
+}

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x8c4-minmax-neondot.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x8c4-minmax-neondot.c
@@ -1,0 +1,195 @@
+// Auto-generated file. Do not edit!
+//   Template: src/qs8-gemm/c4-neondot.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2020 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+
+#include <arm_neon.h>
+
+#include "xnnpack/gemm.h"
+#include "xnnpack/math.h"
+
+
+void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x8c4__neondot(
+    size_t mr,
+    size_t nc,
+    size_t kc,
+    const int8_t* restrict a,
+    size_t a_stride,
+    const void* restrict w,
+    float* restrict c,
+    size_t cm_stride,
+    size_t cn_stride,
+    const union xnn_f32_qb4w_minmax_params params[restrict XNN_MIN_ELEMENTS(1)],
+    const struct xnn_qd8_quantization_params quantization_params[restrict XNN_MIN_ELEMENTS(1)]) XNN_OOB_READS
+{
+  assert(mr != 0);
+  assert(mr <= 2);
+  assert(nc != 0);
+  assert(kc != 0);
+  assert(kc % sizeof(int8_t) == 0);
+  assert(a != NULL);
+  assert(w != NULL);
+  assert(c != NULL);
+
+  kc = round_up_po2(kc, 4 * sizeof(int8_t));
+  const int8_t* a0 = a;
+  float* c0 = c;
+  const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
+  float* c1 = (float*) ((uintptr_t) c0 + cm_stride);
+  if XNN_UNPREDICTABLE(mr != 2) {
+    a1 = a0;
+    c1 = c0;
+  }
+
+  size_t bl = params->scalar.blocksize;
+  assert(bl <= kc);
+  assert(bl != 0);
+  size_t n_blocks = kc / bl;
+  const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
+  // Loop over groups of 8 columns.
+  do {
+    // Initialize accumulators with bias. 8 bias values are loaded from the
+    // weight matrix, at the start of the group of 8 columns.
+    const float32x4_t vinput_zero_point01 = vcvtq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    const float32x4_t vksum0123 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x0123 = vmulq_lane_f32(vksum0123, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x0123 = vmulq_lane_f32(vksum0123, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksum4567 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point01), 0);
+
+    for (size_t nb=0; nb < n_blocks; ++nb) {
+      int32x4_t vacc0x0123 = vdupq_n_s32(0);
+      int32x4_t vacc1x0123 = vdupq_n_s32(0);
+      int32x4_t vacc0x4567 = vdupq_n_s32(0);
+      int32x4_t vacc1x4567 = vdupq_n_s32(0);
+    // Inner accumulation loop along the 8 columns.
+    size_t k = bl;
+    // 2x partial unrolled loop to load 8 bytes at a time.
+    while (k >= 8 * sizeof(int8_t)) {
+      // Load a 2x8 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 8;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 8;
+
+      // Load a 8x8 block of weights.
+      const int8x16_t vb01234567x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x0123 = vshlq_n_s8(vb01234567x0123, 4);
+      const int8x16_t vb0123x4567 = vshlq_n_s8(vb01234567x4567, 4);
+      const int8x16_t vb4567x0123 = vandq_s8(vb01234567x0123, vmask);
+      const int8x16_t vb4567x4567 = vandq_s8(vb01234567x4567, vmask);
+
+      // Multiply-accumulate: 2x8 * 8x8 --> 2x8.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb4567x0123, va0x01234567, 1);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb4567x4567, va0x01234567, 1);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb4567x0123, va1x01234567, 1);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb4567x4567, va1x01234567, 1);
+
+      k -= 8 * sizeof(int8_t);
+    }
+    // Handle up to 4 final positions of `k`
+    if XNN_UNLIKELY(k != 0) {
+      // Load a 2x4 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 4;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 4;
+
+      // Load a 4x8 block of weights.
+      const int8x16_t vb0123x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+
+      // Multiply-accumulate: 2x4 * 4x8 --> 2x8.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+    }
+    const float32x4_t vfilter_output_scale0123 = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scale4567 = vld1q_f32(w); w = (const float*) w + 4;
+
+    float32x4_t vf0x0123 = vcvtq_f32_s32(vacc0x0123);
+    float32x4_t vf1x0123 = vcvtq_f32_s32(vacc1x0123);
+    vout0x0123 = vfmaq_f32(vout0x0123, vf0x0123, vfilter_output_scale0123);
+    vout1x0123 = vfmaq_f32(vout1x0123, vf1x0123, vfilter_output_scale0123);
+    float32x4_t vf0x4567 = vcvtq_f32_s32(vacc0x4567);
+    float32x4_t vf1x4567 = vcvtq_f32_s32(vacc1x4567);
+    vout0x4567 = vfmaq_f32(vout0x4567, vf0x4567, vfilter_output_scale4567);
+    vout1x4567 = vfmaq_f32(vout1x4567, vf1x4567, vfilter_output_scale4567);
+    }
+
+    const float32x4_t one_sixteenth = vdupq_n_f32(1/16.0);
+    vout0x0123 = vmulq_f32(vout0x0123, one_sixteenth);
+    vout0x4567 = vmulq_f32(vout0x4567, one_sixteenth);
+    vout1x0123 = vmulq_f32(vout1x0123, one_sixteenth);
+    vout1x4567 = vmulq_f32(vout1x4567, one_sixteenth);
+    const float32x4_t vinput_scale01 = vreinterpretq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    vout0x0123 = vmulq_lane_f32(vout0x0123, vget_low_f32(vinput_scale01), 1);
+    vout1x0123 = vmulq_lane_f32(vout1x0123, vget_high_f32(vinput_scale01), 1);
+    vout0x4567 = vmulq_lane_f32(vout0x4567, vget_low_f32(vinput_scale01), 1);
+    vout1x4567 = vmulq_lane_f32(vout1x4567, vget_high_f32(vinput_scale01), 1);
+
+
+    const float32x4_t vbias0123 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x0123 = vaddq_f32(vbias0123, vout0x0123);
+    vout1x0123 = vaddq_f32(vbias0123, vout1x0123);
+    const float32x4_t vbias4567 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x4567 = vaddq_f32(vbias4567, vout0x4567);
+    vout1x4567 = vaddq_f32(vbias4567, vout1x4567);
+
+    const float32x4_t voutput_min = vld1q_dup_f32(&params->scalar.min);
+    vout0x0123 = vmaxq_f32(vout0x0123, voutput_min);
+    vout0x4567 = vmaxq_f32(vout0x4567, voutput_min);
+    vout1x0123 = vmaxq_f32(vout1x0123, voutput_min);
+    vout1x4567 = vmaxq_f32(vout1x4567, voutput_min);
+
+    const float32x4_t voutput_max = vld1q_dup_f32(&params->scalar.max);
+    vout0x0123 = vminq_f32(vout0x0123, voutput_max);
+    vout0x4567 = vminq_f32(vout0x4567, voutput_max);
+    vout1x0123 = vminq_f32(vout1x0123, voutput_max);
+    vout1x4567 = vminq_f32(vout1x4567, voutput_max);
+
+    if XNN_LIKELY(nc >= 8) {
+      vst1q_f32(c0, vout0x0123);
+      vst1q_f32(c0 + 4, vout0x4567);
+      vst1q_f32(c1, vout1x0123);
+      vst1q_f32(c1 + 4, vout1x4567);
+
+      a0 = (const int8_t*) ((uintptr_t) a0 - kc);
+      a1 = (const int8_t*) ((uintptr_t) a1 - kc);
+
+      c0 = (float*) ((uintptr_t) c0 + cn_stride);
+      c1 = (float*) ((uintptr_t) c1 + cn_stride);
+
+      nc -= 8;
+    } else {
+     if (nc & 4) {
+       vst1q_f32(c0, vout0x0123); c0 += 4;
+       vout0x0123 = vout0x4567;
+       vst1q_f32(c1, vout1x0123); c1 += 4;
+       vout1x0123 = vout1x4567;
+     }
+     float32x2_t vout0x01 = vget_low_f32(vout0x0123);
+     float32x2_t vout1x01 = vget_low_f32(vout1x0123);
+     if (nc & 2) {
+       vst1_f32(c0, vout0x01); c0 += 2;
+       vst1_f32(c1, vout1x01); c1 += 2;
+       vout0x01 = vget_high_f32(vout0x0123);
+       vout1x01 = vget_high_f32(vout1x0123);
+     }
+     if (nc & 1) {
+       vst1_lane_f32(c0, vout0x01, 0);
+       vst1_lane_f32(c1, vout1x01, 0);
+     }
+      nc = 0;
+    }
+  } while (nc != 0);
+}

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x16c4-minmax-neondot.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x16c4-minmax-neondot.c
@@ -1,0 +1,345 @@
+// Auto-generated file. Do not edit!
+//   Template: src/qs8-gemm/c4-neondot.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2020 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+
+#include <arm_neon.h>
+
+#include "xnnpack/gemm.h"
+#include "xnnpack/math.h"
+
+
+void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x16c4__neondot(
+    size_t mr,
+    size_t nc,
+    size_t kc,
+    const int8_t* restrict a,
+    size_t a_stride,
+    const void* restrict w,
+    float* restrict c,
+    size_t cm_stride,
+    size_t cn_stride,
+    const union xnn_f32_qb4w_minmax_params params[restrict XNN_MIN_ELEMENTS(1)],
+    const struct xnn_qd8_quantization_params quantization_params[restrict XNN_MIN_ELEMENTS(1)]) XNN_OOB_READS
+{
+  assert(mr != 0);
+  assert(mr <= 3);
+  assert(nc != 0);
+  assert(kc != 0);
+  assert(kc % sizeof(int8_t) == 0);
+  assert(a != NULL);
+  assert(w != NULL);
+  assert(c != NULL);
+
+  kc = round_up_po2(kc, 4 * sizeof(int8_t));
+  const int8_t* a0 = a;
+  float* c0 = c;
+  const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
+  float* c1 = (float*) ((uintptr_t) c0 + cm_stride);
+  if XNN_UNPREDICTABLE(mr < 2) {
+    a1 = a0;
+    c1 = c0;
+  }
+  const int8_t* a2 = (const int8_t*) ((uintptr_t) a1 + a_stride);
+  float* c2 = (float*) ((uintptr_t) c1 + cm_stride);
+  if XNN_UNPREDICTABLE(mr <= 2) {
+    a2 = a1;
+    c2 = c1;
+  }
+
+  size_t bl = params->scalar.blocksize;
+  assert(bl <= kc);
+  assert(bl != 0);
+  size_t n_blocks = kc / bl;
+  const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
+  // Loop over groups of 16 columns.
+  do {
+    // Initialize accumulators with bias. 16 bias values are loaded from the
+    // weight matrix, at the start of the group of 16 columns.
+    const float32x4_t vinput_zero_point01 = vcvtq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    const float32x4_t vksum0123 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x0123 = vmulq_lane_f32(vksum0123, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x0123 = vmulq_lane_f32(vksum0123, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksum4567 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksum89AB = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x89AB = vmulq_lane_f32(vksum89AB, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x89AB = vmulq_lane_f32(vksum89AB, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksumCDEF = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0xCDEF = vmulq_lane_f32(vksumCDEF, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vinput_zero_point2 = vcvtq_f32_s32(vld1q_dup_s32(&quantization_params[2].zero_point));
+    float32x4_t vout2x0123 = vmulq_f32(vksum0123, vinput_zero_point2);
+    float32x4_t vout2x4567 = vmulq_f32(vksum4567, vinput_zero_point2);
+    float32x4_t vout2x89AB = vmulq_f32(vksum89AB, vinput_zero_point2);
+    float32x4_t vout2xCDEF = vmulq_f32(vksumCDEF, vinput_zero_point2);
+
+    for (size_t nb=0; nb < n_blocks; ++nb) {
+      int32x4_t vacc0x0123 = vdupq_n_s32(0);
+      int32x4_t vacc1x0123 = vdupq_n_s32(0);
+      int32x4_t vacc0x4567 = vdupq_n_s32(0);
+      int32x4_t vacc1x4567 = vdupq_n_s32(0);
+      int32x4_t vacc0x89AB = vdupq_n_s32(0);
+      int32x4_t vacc1x89AB = vdupq_n_s32(0);
+      int32x4_t vacc0xCDEF = vdupq_n_s32(0);
+      int32x4_t vacc1xCDEF = vdupq_n_s32(0);
+      int32x4_t vacc2x0123 = vdupq_n_s32(0);
+      int32x4_t vacc2x4567 = vdupq_n_s32(0);
+      int32x4_t vacc2x89AB = vdupq_n_s32(0);
+      int32x4_t vacc2xCDEF = vdupq_n_s32(0);
+    // Inner accumulation loop along the 16 columns.
+    size_t k = bl;
+    // 2x partial unrolled loop to load 8 bytes at a time.
+    while (k >= 8 * sizeof(int8_t)) {
+      // Load a 3x8 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 8;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 8;
+      const int8x8_t va2x01234567 = vld1_s8(a2); a2 += 8;
+
+      // Load a 8x16 block of weights.
+      const int8x16_t vb01234567x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567x89AB = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567xCDEF = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x0123 = vshlq_n_s8(vb01234567x0123, 4);
+      const int8x16_t vb0123x4567 = vshlq_n_s8(vb01234567x4567, 4);
+      const int8x16_t vb0123x89AB = vshlq_n_s8(vb01234567x89AB, 4);
+      const int8x16_t vb0123xCDEF = vshlq_n_s8(vb01234567xCDEF, 4);
+      const int8x16_t vb4567x0123 = vandq_s8(vb01234567x0123, vmask);
+      const int8x16_t vb4567x4567 = vandq_s8(vb01234567x4567, vmask);
+      const int8x16_t vb4567x89AB = vandq_s8(vb01234567x89AB, vmask);
+      const int8x16_t vb4567xCDEF = vandq_s8(vb01234567xCDEF, vmask);
+
+      // Multiply-accumulate: 3x8 * 8x16 --> 3x16.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc0x89AB = vdotq_lane_s32(vacc0x89AB, vb0123x89AB, va0x01234567, 0);
+      vacc0xCDEF = vdotq_lane_s32(vacc0xCDEF, vb0123xCDEF, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+      vacc1x89AB = vdotq_lane_s32(vacc1x89AB, vb0123x89AB, va1x01234567, 0);
+      vacc1xCDEF = vdotq_lane_s32(vacc1xCDEF, vb0123xCDEF, va1x01234567, 0);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb0123x0123, va2x01234567, 0);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb0123x4567, va2x01234567, 0);
+      vacc2x89AB = vdotq_lane_s32(vacc2x89AB, vb0123x89AB, va2x01234567, 0);
+      vacc2xCDEF = vdotq_lane_s32(vacc2xCDEF, vb0123xCDEF, va2x01234567, 0);
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb4567x0123, va0x01234567, 1);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb4567x4567, va0x01234567, 1);
+      vacc0x89AB = vdotq_lane_s32(vacc0x89AB, vb4567x89AB, va0x01234567, 1);
+      vacc0xCDEF = vdotq_lane_s32(vacc0xCDEF, vb4567xCDEF, va0x01234567, 1);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb4567x0123, va1x01234567, 1);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb4567x4567, va1x01234567, 1);
+      vacc1x89AB = vdotq_lane_s32(vacc1x89AB, vb4567x89AB, va1x01234567, 1);
+      vacc1xCDEF = vdotq_lane_s32(vacc1xCDEF, vb4567xCDEF, va1x01234567, 1);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb4567x0123, va2x01234567, 1);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb4567x4567, va2x01234567, 1);
+      vacc2x89AB = vdotq_lane_s32(vacc2x89AB, vb4567x89AB, va2x01234567, 1);
+      vacc2xCDEF = vdotq_lane_s32(vacc2xCDEF, vb4567xCDEF, va2x01234567, 1);
+
+      k -= 8 * sizeof(int8_t);
+    }
+    // Handle up to 4 final positions of `k`
+    if XNN_UNLIKELY(k != 0) {
+      // Load a 3x4 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 4;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 4;
+      const int8x8_t va2x01234567 = vld1_s8(a2); a2 += 4;
+
+      // Load a 4x16 block of weights.
+      const int8x16_t vb0123x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x89AB = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123xCDEF = vld1q_s8(w); w = (const int8_t*) w + 16;
+
+      // Multiply-accumulate: 3x4 * 4x16 --> 3x16.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc0x89AB = vdotq_lane_s32(vacc0x89AB, vb0123x89AB, va0x01234567, 0);
+      vacc0xCDEF = vdotq_lane_s32(vacc0xCDEF, vb0123xCDEF, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+      vacc1x89AB = vdotq_lane_s32(vacc1x89AB, vb0123x89AB, va1x01234567, 0);
+      vacc1xCDEF = vdotq_lane_s32(vacc1xCDEF, vb0123xCDEF, va1x01234567, 0);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb0123x0123, va2x01234567, 0);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb0123x4567, va2x01234567, 0);
+      vacc2x89AB = vdotq_lane_s32(vacc2x89AB, vb0123x89AB, va2x01234567, 0);
+      vacc2xCDEF = vdotq_lane_s32(vacc2xCDEF, vb0123xCDEF, va2x01234567, 0);
+    }
+    const float32x4_t vfilter_output_scale0123 = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scale4567 = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scale89AB = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scaleCDEF = vld1q_f32(w); w = (const float*) w + 4;
+
+    float32x4_t vf0x0123 = vcvtq_f32_s32(vacc0x0123);
+    float32x4_t vf1x0123 = vcvtq_f32_s32(vacc1x0123);
+    vout0x0123 = vfmaq_f32(vout0x0123, vf0x0123, vfilter_output_scale0123);
+    vout1x0123 = vfmaq_f32(vout1x0123, vf1x0123, vfilter_output_scale0123);
+    float32x4_t vf0x4567 = vcvtq_f32_s32(vacc0x4567);
+    float32x4_t vf1x4567 = vcvtq_f32_s32(vacc1x4567);
+    vout0x4567 = vfmaq_f32(vout0x4567, vf0x4567, vfilter_output_scale4567);
+    vout1x4567 = vfmaq_f32(vout1x4567, vf1x4567, vfilter_output_scale4567);
+    float32x4_t vf0x89AB = vcvtq_f32_s32(vacc0x89AB);
+    float32x4_t vf1x89AB = vcvtq_f32_s32(vacc1x89AB);
+    vout0x89AB = vfmaq_f32(vout0x89AB, vf0x89AB, vfilter_output_scale89AB);
+    vout1x89AB = vfmaq_f32(vout1x89AB, vf1x89AB, vfilter_output_scale89AB);
+    float32x4_t vf0xCDEF = vcvtq_f32_s32(vacc0xCDEF);
+    float32x4_t vf1xCDEF = vcvtq_f32_s32(vacc1xCDEF);
+    vout0xCDEF = vfmaq_f32(vout0xCDEF, vf0xCDEF, vfilter_output_scaleCDEF);
+    vout1xCDEF = vfmaq_f32(vout1xCDEF, vf1xCDEF, vfilter_output_scaleCDEF);
+    float32x4_t vf2x0123 = vcvtq_f32_s32(vacc2x0123);
+    vout2x0123 = vfmaq_f32(vout2x0123, vf2x0123, vfilter_output_scale0123);
+    float32x4_t vf2x4567 = vcvtq_f32_s32(vacc2x4567);
+    vout2x4567 = vfmaq_f32(vout2x4567, vf2x4567, vfilter_output_scale4567);
+    float32x4_t vf2x89AB = vcvtq_f32_s32(vacc2x89AB);
+    vout2x89AB = vfmaq_f32(vout2x89AB, vf2x89AB, vfilter_output_scale89AB);
+    float32x4_t vf2xCDEF = vcvtq_f32_s32(vacc2xCDEF);
+    vout2xCDEF = vfmaq_f32(vout2xCDEF, vf2xCDEF, vfilter_output_scaleCDEF);
+    }
+
+    const float32x4_t one_sixteenth = vdupq_n_f32(1/16.0);
+    vout0x0123 = vmulq_f32(vout0x0123, one_sixteenth);
+    vout0x4567 = vmulq_f32(vout0x4567, one_sixteenth);
+    vout0x89AB = vmulq_f32(vout0x89AB, one_sixteenth);
+    vout0xCDEF = vmulq_f32(vout0xCDEF, one_sixteenth);
+    vout1x0123 = vmulq_f32(vout1x0123, one_sixteenth);
+    vout1x4567 = vmulq_f32(vout1x4567, one_sixteenth);
+    vout1x89AB = vmulq_f32(vout1x89AB, one_sixteenth);
+    vout1xCDEF = vmulq_f32(vout1xCDEF, one_sixteenth);
+    vout2x0123 = vmulq_f32(vout2x0123, one_sixteenth);
+    vout2x4567 = vmulq_f32(vout2x4567, one_sixteenth);
+    vout2x89AB = vmulq_f32(vout2x89AB, one_sixteenth);
+    vout2xCDEF = vmulq_f32(vout2xCDEF, one_sixteenth);
+    const float32x4_t vinput_scale01 = vreinterpretq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    vout0x0123 = vmulq_lane_f32(vout0x0123, vget_low_f32(vinput_scale01), 1);
+    vout1x0123 = vmulq_lane_f32(vout1x0123, vget_high_f32(vinput_scale01), 1);
+    vout0x4567 = vmulq_lane_f32(vout0x4567, vget_low_f32(vinput_scale01), 1);
+    vout1x4567 = vmulq_lane_f32(vout1x4567, vget_high_f32(vinput_scale01), 1);
+    vout0x89AB = vmulq_lane_f32(vout0x89AB, vget_low_f32(vinput_scale01), 1);
+    vout1x89AB = vmulq_lane_f32(vout1x89AB, vget_high_f32(vinput_scale01), 1);
+    vout0xCDEF = vmulq_lane_f32(vout0xCDEF, vget_low_f32(vinput_scale01), 1);
+    vout1xCDEF = vmulq_lane_f32(vout1xCDEF, vget_high_f32(vinput_scale01), 1);
+    const float32x4_t vinput_scale2 = vld1q_dup_f32(&quantization_params[2].inv_scale);
+    vout2x0123 = vmulq_f32(vout2x0123, vinput_scale2);
+    vout2x4567 = vmulq_f32(vout2x4567, vinput_scale2);
+    vout2x89AB = vmulq_f32(vout2x89AB, vinput_scale2);
+    vout2xCDEF = vmulq_f32(vout2xCDEF, vinput_scale2);
+
+
+    const float32x4_t vbias0123 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x0123 = vaddq_f32(vbias0123, vout0x0123);
+    vout1x0123 = vaddq_f32(vbias0123, vout1x0123);
+    vout2x0123 = vaddq_f32(vbias0123, vout2x0123);
+    const float32x4_t vbias4567 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x4567 = vaddq_f32(vbias4567, vout0x4567);
+    vout1x4567 = vaddq_f32(vbias4567, vout1x4567);
+    vout2x4567 = vaddq_f32(vbias4567, vout2x4567);
+    const float32x4_t vbias89AB = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x89AB = vaddq_f32(vbias89AB, vout0x89AB);
+    vout1x89AB = vaddq_f32(vbias89AB, vout1x89AB);
+    vout2x89AB = vaddq_f32(vbias89AB, vout2x89AB);
+    const float32x4_t vbiasCDEF = vld1q_f32(w); w = (const float*) w + 4;
+    vout0xCDEF = vaddq_f32(vbiasCDEF, vout0xCDEF);
+    vout1xCDEF = vaddq_f32(vbiasCDEF, vout1xCDEF);
+    vout2xCDEF = vaddq_f32(vbiasCDEF, vout2xCDEF);
+
+    const float32x4_t voutput_min = vld1q_dup_f32(&params->scalar.min);
+    vout0x0123 = vmaxq_f32(vout0x0123, voutput_min);
+    vout0x4567 = vmaxq_f32(vout0x4567, voutput_min);
+    vout0x89AB = vmaxq_f32(vout0x89AB, voutput_min);
+    vout0xCDEF = vmaxq_f32(vout0xCDEF, voutput_min);
+    vout1x0123 = vmaxq_f32(vout1x0123, voutput_min);
+    vout1x4567 = vmaxq_f32(vout1x4567, voutput_min);
+    vout1x89AB = vmaxq_f32(vout1x89AB, voutput_min);
+    vout1xCDEF = vmaxq_f32(vout1xCDEF, voutput_min);
+    vout2x0123 = vmaxq_f32(vout2x0123, voutput_min);
+    vout2x4567 = vmaxq_f32(vout2x4567, voutput_min);
+    vout2x89AB = vmaxq_f32(vout2x89AB, voutput_min);
+    vout2xCDEF = vmaxq_f32(vout2xCDEF, voutput_min);
+
+    const float32x4_t voutput_max = vld1q_dup_f32(&params->scalar.max);
+    vout0x0123 = vminq_f32(vout0x0123, voutput_max);
+    vout0x4567 = vminq_f32(vout0x4567, voutput_max);
+    vout0x89AB = vminq_f32(vout0x89AB, voutput_max);
+    vout0xCDEF = vminq_f32(vout0xCDEF, voutput_max);
+    vout1x0123 = vminq_f32(vout1x0123, voutput_max);
+    vout1x4567 = vminq_f32(vout1x4567, voutput_max);
+    vout1x89AB = vminq_f32(vout1x89AB, voutput_max);
+    vout1xCDEF = vminq_f32(vout1xCDEF, voutput_max);
+    vout2x0123 = vminq_f32(vout2x0123, voutput_max);
+    vout2x4567 = vminq_f32(vout2x4567, voutput_max);
+    vout2x89AB = vminq_f32(vout2x89AB, voutput_max);
+    vout2xCDEF = vminq_f32(vout2xCDEF, voutput_max);
+
+    if XNN_LIKELY(nc >= 16) {
+      vst1q_f32(c0, vout0x0123);
+      vst1q_f32(c0 + 4, vout0x4567);
+      vst1q_f32(c0 + 8, vout0x89AB);
+      vst1q_f32(c0 + 12, vout0xCDEF);
+      vst1q_f32(c1, vout1x0123);
+      vst1q_f32(c1 + 4, vout1x4567);
+      vst1q_f32(c1 + 8, vout1x89AB);
+      vst1q_f32(c1 + 12, vout1xCDEF);
+      vst1q_f32(c2, vout2x0123);
+      vst1q_f32(c2 + 4, vout2x4567);
+      vst1q_f32(c2 + 8, vout2x89AB);
+      vst1q_f32(c2 + 12, vout2xCDEF);
+
+      a0 = (const int8_t*) ((uintptr_t) a0 - kc);
+      a1 = (const int8_t*) ((uintptr_t) a1 - kc);
+      a2 = (const int8_t*) ((uintptr_t) a2 - kc);
+
+      c0 = (float*) ((uintptr_t) c0 + cn_stride);
+      c1 = (float*) ((uintptr_t) c1 + cn_stride);
+      c2 = (float*) ((uintptr_t) c2 + cn_stride);
+
+      nc -= 16;
+    } else {
+     if (nc & 8) {
+       vst1q_f32(c0, vout0x0123); c0 += 4;
+       vout0x0123 = vout0x89AB;
+       vst1q_f32(c1, vout1x0123); c1 += 4;
+       vout1x0123 = vout1x89AB;
+       vst1q_f32(c2, vout2x0123); c2 += 4;
+       vout2x0123 = vout2x89AB;
+       vst1q_f32(c0, vout0x4567); c0 += 4;
+       vout0x4567 = vout0xCDEF;
+       vst1q_f32(c1, vout1x4567); c1 += 4;
+       vout1x4567 = vout1xCDEF;
+       vst1q_f32(c2, vout2x4567); c2 += 4;
+       vout2x4567 = vout2xCDEF;
+     }
+     if (nc & 4) {
+       vst1q_f32(c0, vout0x0123); c0 += 4;
+       vout0x0123 = vout0x4567;
+       vst1q_f32(c1, vout1x0123); c1 += 4;
+       vout1x0123 = vout1x4567;
+       vst1q_f32(c2, vout2x0123); c2 += 4;
+       vout2x0123 = vout2x4567;
+     }
+     float32x2_t vout0x01 = vget_low_f32(vout0x0123);
+     float32x2_t vout1x01 = vget_low_f32(vout1x0123);
+     float32x2_t vout2x01 = vget_low_f32(vout2x0123);
+     if (nc & 2) {
+       vst1_f32(c0, vout0x01); c0 += 2;
+       vst1_f32(c1, vout1x01); c1 += 2;
+       vst1_f32(c2, vout2x01); c2 += 2;
+       vout0x01 = vget_high_f32(vout0x0123);
+       vout1x01 = vget_high_f32(vout1x0123);
+       vout2x01 = vget_high_f32(vout2x0123);
+     }
+     if (nc & 1) {
+       vst1_lane_f32(c0, vout0x01, 0);
+       vst1_lane_f32(c1, vout1x01, 0);
+       vst1_lane_f32(c2, vout2x01, 0);
+     }
+      nc = 0;
+    }
+  } while (nc != 0);
+}

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x8c4-minmax-neondot.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x8c4-minmax-neondot.c
@@ -1,0 +1,239 @@
+// Auto-generated file. Do not edit!
+//   Template: src/qs8-gemm/c4-neondot.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2020 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+
+#include <arm_neon.h>
+
+#include "xnnpack/gemm.h"
+#include "xnnpack/math.h"
+
+
+void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x8c4__neondot(
+    size_t mr,
+    size_t nc,
+    size_t kc,
+    const int8_t* restrict a,
+    size_t a_stride,
+    const void* restrict w,
+    float* restrict c,
+    size_t cm_stride,
+    size_t cn_stride,
+    const union xnn_f32_qb4w_minmax_params params[restrict XNN_MIN_ELEMENTS(1)],
+    const struct xnn_qd8_quantization_params quantization_params[restrict XNN_MIN_ELEMENTS(1)]) XNN_OOB_READS
+{
+  assert(mr != 0);
+  assert(mr <= 3);
+  assert(nc != 0);
+  assert(kc != 0);
+  assert(kc % sizeof(int8_t) == 0);
+  assert(a != NULL);
+  assert(w != NULL);
+  assert(c != NULL);
+
+  kc = round_up_po2(kc, 4 * sizeof(int8_t));
+  const int8_t* a0 = a;
+  float* c0 = c;
+  const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
+  float* c1 = (float*) ((uintptr_t) c0 + cm_stride);
+  if XNN_UNPREDICTABLE(mr < 2) {
+    a1 = a0;
+    c1 = c0;
+  }
+  const int8_t* a2 = (const int8_t*) ((uintptr_t) a1 + a_stride);
+  float* c2 = (float*) ((uintptr_t) c1 + cm_stride);
+  if XNN_UNPREDICTABLE(mr <= 2) {
+    a2 = a1;
+    c2 = c1;
+  }
+
+  size_t bl = params->scalar.blocksize;
+  assert(bl <= kc);
+  assert(bl != 0);
+  size_t n_blocks = kc / bl;
+  const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
+  // Loop over groups of 8 columns.
+  do {
+    // Initialize accumulators with bias. 8 bias values are loaded from the
+    // weight matrix, at the start of the group of 8 columns.
+    const float32x4_t vinput_zero_point01 = vcvtq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    const float32x4_t vksum0123 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x0123 = vmulq_lane_f32(vksum0123, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x0123 = vmulq_lane_f32(vksum0123, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksum4567 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vinput_zero_point2 = vcvtq_f32_s32(vld1q_dup_s32(&quantization_params[2].zero_point));
+    float32x4_t vout2x0123 = vmulq_f32(vksum0123, vinput_zero_point2);
+    float32x4_t vout2x4567 = vmulq_f32(vksum4567, vinput_zero_point2);
+
+    for (size_t nb=0; nb < n_blocks; ++nb) {
+      int32x4_t vacc0x0123 = vdupq_n_s32(0);
+      int32x4_t vacc1x0123 = vdupq_n_s32(0);
+      int32x4_t vacc0x4567 = vdupq_n_s32(0);
+      int32x4_t vacc1x4567 = vdupq_n_s32(0);
+      int32x4_t vacc2x0123 = vdupq_n_s32(0);
+      int32x4_t vacc2x4567 = vdupq_n_s32(0);
+    // Inner accumulation loop along the 8 columns.
+    size_t k = bl;
+    // 2x partial unrolled loop to load 8 bytes at a time.
+    while (k >= 8 * sizeof(int8_t)) {
+      // Load a 3x8 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 8;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 8;
+      const int8x8_t va2x01234567 = vld1_s8(a2); a2 += 8;
+
+      // Load a 8x8 block of weights.
+      const int8x16_t vb01234567x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x0123 = vshlq_n_s8(vb01234567x0123, 4);
+      const int8x16_t vb0123x4567 = vshlq_n_s8(vb01234567x4567, 4);
+      const int8x16_t vb4567x0123 = vandq_s8(vb01234567x0123, vmask);
+      const int8x16_t vb4567x4567 = vandq_s8(vb01234567x4567, vmask);
+
+      // Multiply-accumulate: 3x8 * 8x8 --> 3x8.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb0123x0123, va2x01234567, 0);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb0123x4567, va2x01234567, 0);
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb4567x0123, va0x01234567, 1);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb4567x4567, va0x01234567, 1);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb4567x0123, va1x01234567, 1);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb4567x4567, va1x01234567, 1);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb4567x0123, va2x01234567, 1);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb4567x4567, va2x01234567, 1);
+
+      k -= 8 * sizeof(int8_t);
+    }
+    // Handle up to 4 final positions of `k`
+    if XNN_UNLIKELY(k != 0) {
+      // Load a 3x4 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 4;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 4;
+      const int8x8_t va2x01234567 = vld1_s8(a2); a2 += 4;
+
+      // Load a 4x8 block of weights.
+      const int8x16_t vb0123x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+
+      // Multiply-accumulate: 3x4 * 4x8 --> 3x8.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb0123x0123, va2x01234567, 0);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb0123x4567, va2x01234567, 0);
+    }
+    const float32x4_t vfilter_output_scale0123 = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scale4567 = vld1q_f32(w); w = (const float*) w + 4;
+
+    float32x4_t vf0x0123 = vcvtq_f32_s32(vacc0x0123);
+    float32x4_t vf1x0123 = vcvtq_f32_s32(vacc1x0123);
+    vout0x0123 = vfmaq_f32(vout0x0123, vf0x0123, vfilter_output_scale0123);
+    vout1x0123 = vfmaq_f32(vout1x0123, vf1x0123, vfilter_output_scale0123);
+    float32x4_t vf0x4567 = vcvtq_f32_s32(vacc0x4567);
+    float32x4_t vf1x4567 = vcvtq_f32_s32(vacc1x4567);
+    vout0x4567 = vfmaq_f32(vout0x4567, vf0x4567, vfilter_output_scale4567);
+    vout1x4567 = vfmaq_f32(vout1x4567, vf1x4567, vfilter_output_scale4567);
+    float32x4_t vf2x0123 = vcvtq_f32_s32(vacc2x0123);
+    vout2x0123 = vfmaq_f32(vout2x0123, vf2x0123, vfilter_output_scale0123);
+    float32x4_t vf2x4567 = vcvtq_f32_s32(vacc2x4567);
+    vout2x4567 = vfmaq_f32(vout2x4567, vf2x4567, vfilter_output_scale4567);
+    }
+
+    const float32x4_t one_sixteenth = vdupq_n_f32(1/16.0);
+    vout0x0123 = vmulq_f32(vout0x0123, one_sixteenth);
+    vout0x4567 = vmulq_f32(vout0x4567, one_sixteenth);
+    vout1x0123 = vmulq_f32(vout1x0123, one_sixteenth);
+    vout1x4567 = vmulq_f32(vout1x4567, one_sixteenth);
+    vout2x0123 = vmulq_f32(vout2x0123, one_sixteenth);
+    vout2x4567 = vmulq_f32(vout2x4567, one_sixteenth);
+    const float32x4_t vinput_scale01 = vreinterpretq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    vout0x0123 = vmulq_lane_f32(vout0x0123, vget_low_f32(vinput_scale01), 1);
+    vout1x0123 = vmulq_lane_f32(vout1x0123, vget_high_f32(vinput_scale01), 1);
+    vout0x4567 = vmulq_lane_f32(vout0x4567, vget_low_f32(vinput_scale01), 1);
+    vout1x4567 = vmulq_lane_f32(vout1x4567, vget_high_f32(vinput_scale01), 1);
+    const float32x4_t vinput_scale2 = vld1q_dup_f32(&quantization_params[2].inv_scale);
+    vout2x0123 = vmulq_f32(vout2x0123, vinput_scale2);
+    vout2x4567 = vmulq_f32(vout2x4567, vinput_scale2);
+
+
+    const float32x4_t vbias0123 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x0123 = vaddq_f32(vbias0123, vout0x0123);
+    vout1x0123 = vaddq_f32(vbias0123, vout1x0123);
+    vout2x0123 = vaddq_f32(vbias0123, vout2x0123);
+    const float32x4_t vbias4567 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x4567 = vaddq_f32(vbias4567, vout0x4567);
+    vout1x4567 = vaddq_f32(vbias4567, vout1x4567);
+    vout2x4567 = vaddq_f32(vbias4567, vout2x4567);
+
+    const float32x4_t voutput_min = vld1q_dup_f32(&params->scalar.min);
+    vout0x0123 = vmaxq_f32(vout0x0123, voutput_min);
+    vout0x4567 = vmaxq_f32(vout0x4567, voutput_min);
+    vout1x0123 = vmaxq_f32(vout1x0123, voutput_min);
+    vout1x4567 = vmaxq_f32(vout1x4567, voutput_min);
+    vout2x0123 = vmaxq_f32(vout2x0123, voutput_min);
+    vout2x4567 = vmaxq_f32(vout2x4567, voutput_min);
+
+    const float32x4_t voutput_max = vld1q_dup_f32(&params->scalar.max);
+    vout0x0123 = vminq_f32(vout0x0123, voutput_max);
+    vout0x4567 = vminq_f32(vout0x4567, voutput_max);
+    vout1x0123 = vminq_f32(vout1x0123, voutput_max);
+    vout1x4567 = vminq_f32(vout1x4567, voutput_max);
+    vout2x0123 = vminq_f32(vout2x0123, voutput_max);
+    vout2x4567 = vminq_f32(vout2x4567, voutput_max);
+
+    if XNN_LIKELY(nc >= 8) {
+      vst1q_f32(c0, vout0x0123);
+      vst1q_f32(c0 + 4, vout0x4567);
+      vst1q_f32(c1, vout1x0123);
+      vst1q_f32(c1 + 4, vout1x4567);
+      vst1q_f32(c2, vout2x0123);
+      vst1q_f32(c2 + 4, vout2x4567);
+
+      a0 = (const int8_t*) ((uintptr_t) a0 - kc);
+      a1 = (const int8_t*) ((uintptr_t) a1 - kc);
+      a2 = (const int8_t*) ((uintptr_t) a2 - kc);
+
+      c0 = (float*) ((uintptr_t) c0 + cn_stride);
+      c1 = (float*) ((uintptr_t) c1 + cn_stride);
+      c2 = (float*) ((uintptr_t) c2 + cn_stride);
+
+      nc -= 8;
+    } else {
+     if (nc & 4) {
+       vst1q_f32(c0, vout0x0123); c0 += 4;
+       vout0x0123 = vout0x4567;
+       vst1q_f32(c1, vout1x0123); c1 += 4;
+       vout1x0123 = vout1x4567;
+       vst1q_f32(c2, vout2x0123); c2 += 4;
+       vout2x0123 = vout2x4567;
+     }
+     float32x2_t vout0x01 = vget_low_f32(vout0x0123);
+     float32x2_t vout1x01 = vget_low_f32(vout1x0123);
+     float32x2_t vout2x01 = vget_low_f32(vout2x0123);
+     if (nc & 2) {
+       vst1_f32(c0, vout0x01); c0 += 2;
+       vst1_f32(c1, vout1x01); c1 += 2;
+       vst1_f32(c2, vout2x01); c2 += 2;
+       vout0x01 = vget_high_f32(vout0x0123);
+       vout1x01 = vget_high_f32(vout1x0123);
+       vout2x01 = vget_high_f32(vout2x0123);
+     }
+     if (nc & 1) {
+       vst1_lane_f32(c0, vout0x01, 0);
+       vst1_lane_f32(c1, vout1x01, 0);
+       vst1_lane_f32(c2, vout2x01, 0);
+     }
+      nc = 0;
+    }
+  } while (nc != 0);
+}

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x16c4-minmax-neondot.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x16c4-minmax-neondot.c
@@ -1,0 +1,417 @@
+// Auto-generated file. Do not edit!
+//   Template: src/qs8-gemm/c4-neondot.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2020 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+
+#include <arm_neon.h>
+
+#include "xnnpack/gemm.h"
+#include "xnnpack/math.h"
+
+
+void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x16c4__neondot(
+    size_t mr,
+    size_t nc,
+    size_t kc,
+    const int8_t* restrict a,
+    size_t a_stride,
+    const void* restrict w,
+    float* restrict c,
+    size_t cm_stride,
+    size_t cn_stride,
+    const union xnn_f32_qb4w_minmax_params params[restrict XNN_MIN_ELEMENTS(1)],
+    const struct xnn_qd8_quantization_params quantization_params[restrict XNN_MIN_ELEMENTS(1)]) XNN_OOB_READS
+{
+  assert(mr != 0);
+  assert(mr <= 4);
+  assert(nc != 0);
+  assert(kc != 0);
+  assert(kc % sizeof(int8_t) == 0);
+  assert(a != NULL);
+  assert(w != NULL);
+  assert(c != NULL);
+
+  kc = round_up_po2(kc, 4 * sizeof(int8_t));
+  const int8_t* a0 = a;
+  float* c0 = c;
+  const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
+  float* c1 = (float*) ((uintptr_t) c0 + cm_stride);
+  if XNN_UNPREDICTABLE(mr < 2) {
+    a1 = a0;
+    c1 = c0;
+  }
+  const int8_t* a2 = (const int8_t*) ((uintptr_t) a1 + a_stride);
+  float* c2 = (float*) ((uintptr_t) c1 + cm_stride);
+  if XNN_UNPREDICTABLE(mr <= 2) {
+    a2 = a1;
+    c2 = c1;
+  }
+  const int8_t* a3 = (const int8_t*) ((uintptr_t) a2 + a_stride);
+  float* c3 = (float*) ((uintptr_t) c2 + cm_stride);
+  if XNN_UNPREDICTABLE(mr != 4) {
+    a3 = a2;
+    c3 = c2;
+  }
+
+  size_t bl = params->scalar.blocksize;
+  assert(bl <= kc);
+  assert(bl != 0);
+  size_t n_blocks = kc / bl;
+  const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
+  // Loop over groups of 16 columns.
+  do {
+    // Initialize accumulators with bias. 16 bias values are loaded from the
+    // weight matrix, at the start of the group of 16 columns.
+    const float32x4_t vinput_zero_point01 = vcvtq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    const float32x4_t vksum0123 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x0123 = vmulq_lane_f32(vksum0123, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x0123 = vmulq_lane_f32(vksum0123, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksum4567 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksum89AB = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x89AB = vmulq_lane_f32(vksum89AB, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x89AB = vmulq_lane_f32(vksum89AB, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksumCDEF = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0xCDEF = vmulq_lane_f32(vksumCDEF, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vinput_zero_point23 = vcvtq_f32_s32(vld1q_s32(&quantization_params[2].zero_point));
+    float32x4_t vout2x0123 = vmulq_lane_f32(vksum0123, vget_low_f32(vinput_zero_point23), 0);
+    float32x4_t vout3x0123 = vmulq_lane_f32(vksum0123, vget_high_f32(vinput_zero_point23), 0);
+    float32x4_t vout2x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point23), 0);
+    float32x4_t vout3x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point23), 0);
+    float32x4_t vout2x89AB = vmulq_lane_f32(vksum89AB, vget_low_f32(vinput_zero_point23), 0);
+    float32x4_t vout3x89AB = vmulq_lane_f32(vksum89AB, vget_high_f32(vinput_zero_point23), 0);
+    float32x4_t vout2xCDEF = vmulq_lane_f32(vksumCDEF, vget_low_f32(vinput_zero_point23), 0);
+    float32x4_t vout3xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vinput_zero_point23), 0);
+
+    for (size_t nb=0; nb < n_blocks; ++nb) {
+      int32x4_t vacc0x0123 = vdupq_n_s32(0);
+      int32x4_t vacc1x0123 = vdupq_n_s32(0);
+      int32x4_t vacc0x4567 = vdupq_n_s32(0);
+      int32x4_t vacc1x4567 = vdupq_n_s32(0);
+      int32x4_t vacc0x89AB = vdupq_n_s32(0);
+      int32x4_t vacc1x89AB = vdupq_n_s32(0);
+      int32x4_t vacc0xCDEF = vdupq_n_s32(0);
+      int32x4_t vacc1xCDEF = vdupq_n_s32(0);
+      int32x4_t vacc2x0123 = vdupq_n_s32(0);
+      int32x4_t vacc3x0123 = vdupq_n_s32(0);
+      int32x4_t vacc2x4567 = vdupq_n_s32(0);
+      int32x4_t vacc3x4567 = vdupq_n_s32(0);
+      int32x4_t vacc2x89AB = vdupq_n_s32(0);
+      int32x4_t vacc3x89AB = vdupq_n_s32(0);
+      int32x4_t vacc2xCDEF = vdupq_n_s32(0);
+      int32x4_t vacc3xCDEF = vdupq_n_s32(0);
+    // Inner accumulation loop along the 16 columns.
+    size_t k = bl;
+    // 2x partial unrolled loop to load 8 bytes at a time.
+    while (k >= 8 * sizeof(int8_t)) {
+      // Load a 4x8 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 8;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 8;
+      const int8x8_t va2x01234567 = vld1_s8(a2); a2 += 8;
+      const int8x8_t va3x01234567 = vld1_s8(a3); a3 += 8;
+
+      // Load a 8x16 block of weights.
+      const int8x16_t vb01234567x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567x89AB = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567xCDEF = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x0123 = vshlq_n_s8(vb01234567x0123, 4);
+      const int8x16_t vb0123x4567 = vshlq_n_s8(vb01234567x4567, 4);
+      const int8x16_t vb0123x89AB = vshlq_n_s8(vb01234567x89AB, 4);
+      const int8x16_t vb0123xCDEF = vshlq_n_s8(vb01234567xCDEF, 4);
+      const int8x16_t vb4567x0123 = vandq_s8(vb01234567x0123, vmask);
+      const int8x16_t vb4567x4567 = vandq_s8(vb01234567x4567, vmask);
+      const int8x16_t vb4567x89AB = vandq_s8(vb01234567x89AB, vmask);
+      const int8x16_t vb4567xCDEF = vandq_s8(vb01234567xCDEF, vmask);
+
+      // Multiply-accumulate: 4x8 * 8x16 --> 4x16.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc0x89AB = vdotq_lane_s32(vacc0x89AB, vb0123x89AB, va0x01234567, 0);
+      vacc0xCDEF = vdotq_lane_s32(vacc0xCDEF, vb0123xCDEF, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+      vacc1x89AB = vdotq_lane_s32(vacc1x89AB, vb0123x89AB, va1x01234567, 0);
+      vacc1xCDEF = vdotq_lane_s32(vacc1xCDEF, vb0123xCDEF, va1x01234567, 0);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb0123x0123, va2x01234567, 0);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb0123x4567, va2x01234567, 0);
+      vacc2x89AB = vdotq_lane_s32(vacc2x89AB, vb0123x89AB, va2x01234567, 0);
+      vacc2xCDEF = vdotq_lane_s32(vacc2xCDEF, vb0123xCDEF, va2x01234567, 0);
+      vacc3x0123 = vdotq_lane_s32(vacc3x0123, vb0123x0123, va3x01234567, 0);
+      vacc3x4567 = vdotq_lane_s32(vacc3x4567, vb0123x4567, va3x01234567, 0);
+      vacc3x89AB = vdotq_lane_s32(vacc3x89AB, vb0123x89AB, va3x01234567, 0);
+      vacc3xCDEF = vdotq_lane_s32(vacc3xCDEF, vb0123xCDEF, va3x01234567, 0);
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb4567x0123, va0x01234567, 1);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb4567x4567, va0x01234567, 1);
+      vacc0x89AB = vdotq_lane_s32(vacc0x89AB, vb4567x89AB, va0x01234567, 1);
+      vacc0xCDEF = vdotq_lane_s32(vacc0xCDEF, vb4567xCDEF, va0x01234567, 1);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb4567x0123, va1x01234567, 1);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb4567x4567, va1x01234567, 1);
+      vacc1x89AB = vdotq_lane_s32(vacc1x89AB, vb4567x89AB, va1x01234567, 1);
+      vacc1xCDEF = vdotq_lane_s32(vacc1xCDEF, vb4567xCDEF, va1x01234567, 1);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb4567x0123, va2x01234567, 1);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb4567x4567, va2x01234567, 1);
+      vacc2x89AB = vdotq_lane_s32(vacc2x89AB, vb4567x89AB, va2x01234567, 1);
+      vacc2xCDEF = vdotq_lane_s32(vacc2xCDEF, vb4567xCDEF, va2x01234567, 1);
+      vacc3x0123 = vdotq_lane_s32(vacc3x0123, vb4567x0123, va3x01234567, 1);
+      vacc3x4567 = vdotq_lane_s32(vacc3x4567, vb4567x4567, va3x01234567, 1);
+      vacc3x89AB = vdotq_lane_s32(vacc3x89AB, vb4567x89AB, va3x01234567, 1);
+      vacc3xCDEF = vdotq_lane_s32(vacc3xCDEF, vb4567xCDEF, va3x01234567, 1);
+
+      k -= 8 * sizeof(int8_t);
+    }
+    // Handle up to 4 final positions of `k`
+    if XNN_UNLIKELY(k != 0) {
+      // Load a 4x4 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 4;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 4;
+      const int8x8_t va2x01234567 = vld1_s8(a2); a2 += 4;
+      const int8x8_t va3x01234567 = vld1_s8(a3); a3 += 4;
+
+      // Load a 4x16 block of weights.
+      const int8x16_t vb0123x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x89AB = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123xCDEF = vld1q_s8(w); w = (const int8_t*) w + 16;
+
+      // Multiply-accumulate: 4x4 * 4x16 --> 4x16.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc0x89AB = vdotq_lane_s32(vacc0x89AB, vb0123x89AB, va0x01234567, 0);
+      vacc0xCDEF = vdotq_lane_s32(vacc0xCDEF, vb0123xCDEF, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+      vacc1x89AB = vdotq_lane_s32(vacc1x89AB, vb0123x89AB, va1x01234567, 0);
+      vacc1xCDEF = vdotq_lane_s32(vacc1xCDEF, vb0123xCDEF, va1x01234567, 0);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb0123x0123, va2x01234567, 0);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb0123x4567, va2x01234567, 0);
+      vacc2x89AB = vdotq_lane_s32(vacc2x89AB, vb0123x89AB, va2x01234567, 0);
+      vacc2xCDEF = vdotq_lane_s32(vacc2xCDEF, vb0123xCDEF, va2x01234567, 0);
+      vacc3x0123 = vdotq_lane_s32(vacc3x0123, vb0123x0123, va3x01234567, 0);
+      vacc3x4567 = vdotq_lane_s32(vacc3x4567, vb0123x4567, va3x01234567, 0);
+      vacc3x89AB = vdotq_lane_s32(vacc3x89AB, vb0123x89AB, va3x01234567, 0);
+      vacc3xCDEF = vdotq_lane_s32(vacc3xCDEF, vb0123xCDEF, va3x01234567, 0);
+    }
+    const float32x4_t vfilter_output_scale0123 = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scale4567 = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scale89AB = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scaleCDEF = vld1q_f32(w); w = (const float*) w + 4;
+
+    float32x4_t vf0x0123 = vcvtq_f32_s32(vacc0x0123);
+    float32x4_t vf1x0123 = vcvtq_f32_s32(vacc1x0123);
+    vout0x0123 = vfmaq_f32(vout0x0123, vf0x0123, vfilter_output_scale0123);
+    vout1x0123 = vfmaq_f32(vout1x0123, vf1x0123, vfilter_output_scale0123);
+    float32x4_t vf0x4567 = vcvtq_f32_s32(vacc0x4567);
+    float32x4_t vf1x4567 = vcvtq_f32_s32(vacc1x4567);
+    vout0x4567 = vfmaq_f32(vout0x4567, vf0x4567, vfilter_output_scale4567);
+    vout1x4567 = vfmaq_f32(vout1x4567, vf1x4567, vfilter_output_scale4567);
+    float32x4_t vf0x89AB = vcvtq_f32_s32(vacc0x89AB);
+    float32x4_t vf1x89AB = vcvtq_f32_s32(vacc1x89AB);
+    vout0x89AB = vfmaq_f32(vout0x89AB, vf0x89AB, vfilter_output_scale89AB);
+    vout1x89AB = vfmaq_f32(vout1x89AB, vf1x89AB, vfilter_output_scale89AB);
+    float32x4_t vf0xCDEF = vcvtq_f32_s32(vacc0xCDEF);
+    float32x4_t vf1xCDEF = vcvtq_f32_s32(vacc1xCDEF);
+    vout0xCDEF = vfmaq_f32(vout0xCDEF, vf0xCDEF, vfilter_output_scaleCDEF);
+    vout1xCDEF = vfmaq_f32(vout1xCDEF, vf1xCDEF, vfilter_output_scaleCDEF);
+    float32x4_t vf2x0123 = vcvtq_f32_s32(vacc2x0123);
+    float32x4_t vf3x0123 = vcvtq_f32_s32(vacc3x0123);
+    vout2x0123 = vfmaq_f32(vout2x0123, vf2x0123, vfilter_output_scale0123);
+    vout3x0123 = vfmaq_f32(vout3x0123, vf3x0123, vfilter_output_scale0123);
+    float32x4_t vf2x4567 = vcvtq_f32_s32(vacc2x4567);
+    float32x4_t vf3x4567 = vcvtq_f32_s32(vacc3x4567);
+    vout2x4567 = vfmaq_f32(vout2x4567, vf2x4567, vfilter_output_scale4567);
+    vout3x4567 = vfmaq_f32(vout3x4567, vf3x4567, vfilter_output_scale4567);
+    float32x4_t vf2x89AB = vcvtq_f32_s32(vacc2x89AB);
+    float32x4_t vf3x89AB = vcvtq_f32_s32(vacc3x89AB);
+    vout2x89AB = vfmaq_f32(vout2x89AB, vf2x89AB, vfilter_output_scale89AB);
+    vout3x89AB = vfmaq_f32(vout3x89AB, vf3x89AB, vfilter_output_scale89AB);
+    float32x4_t vf2xCDEF = vcvtq_f32_s32(vacc2xCDEF);
+    float32x4_t vf3xCDEF = vcvtq_f32_s32(vacc3xCDEF);
+    vout2xCDEF = vfmaq_f32(vout2xCDEF, vf2xCDEF, vfilter_output_scaleCDEF);
+    vout3xCDEF = vfmaq_f32(vout3xCDEF, vf3xCDEF, vfilter_output_scaleCDEF);
+    }
+
+    const float32x4_t one_sixteenth = vdupq_n_f32(1/16.0);
+    vout0x0123 = vmulq_f32(vout0x0123, one_sixteenth);
+    vout0x4567 = vmulq_f32(vout0x4567, one_sixteenth);
+    vout0x89AB = vmulq_f32(vout0x89AB, one_sixteenth);
+    vout0xCDEF = vmulq_f32(vout0xCDEF, one_sixteenth);
+    vout1x0123 = vmulq_f32(vout1x0123, one_sixteenth);
+    vout1x4567 = vmulq_f32(vout1x4567, one_sixteenth);
+    vout1x89AB = vmulq_f32(vout1x89AB, one_sixteenth);
+    vout1xCDEF = vmulq_f32(vout1xCDEF, one_sixteenth);
+    vout2x0123 = vmulq_f32(vout2x0123, one_sixteenth);
+    vout2x4567 = vmulq_f32(vout2x4567, one_sixteenth);
+    vout2x89AB = vmulq_f32(vout2x89AB, one_sixteenth);
+    vout2xCDEF = vmulq_f32(vout2xCDEF, one_sixteenth);
+    vout3x0123 = vmulq_f32(vout3x0123, one_sixteenth);
+    vout3x4567 = vmulq_f32(vout3x4567, one_sixteenth);
+    vout3x89AB = vmulq_f32(vout3x89AB, one_sixteenth);
+    vout3xCDEF = vmulq_f32(vout3xCDEF, one_sixteenth);
+    const float32x4_t vinput_scale01 = vreinterpretq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    vout0x0123 = vmulq_lane_f32(vout0x0123, vget_low_f32(vinput_scale01), 1);
+    vout1x0123 = vmulq_lane_f32(vout1x0123, vget_high_f32(vinput_scale01), 1);
+    vout0x4567 = vmulq_lane_f32(vout0x4567, vget_low_f32(vinput_scale01), 1);
+    vout1x4567 = vmulq_lane_f32(vout1x4567, vget_high_f32(vinput_scale01), 1);
+    vout0x89AB = vmulq_lane_f32(vout0x89AB, vget_low_f32(vinput_scale01), 1);
+    vout1x89AB = vmulq_lane_f32(vout1x89AB, vget_high_f32(vinput_scale01), 1);
+    vout0xCDEF = vmulq_lane_f32(vout0xCDEF, vget_low_f32(vinput_scale01), 1);
+    vout1xCDEF = vmulq_lane_f32(vout1xCDEF, vget_high_f32(vinput_scale01), 1);
+    const float32x4_t vinput_scale23 = vreinterpretq_f32_s32(vld1q_s32(&quantization_params[2].zero_point));
+    vout2x0123 = vmulq_lane_f32(vout2x0123, vget_low_f32(vinput_scale23), 1);
+    vout3x0123 = vmulq_lane_f32(vout3x0123, vget_high_f32(vinput_scale23), 1);
+    vout2x4567 = vmulq_lane_f32(vout2x4567, vget_low_f32(vinput_scale23), 1);
+    vout3x4567 = vmulq_lane_f32(vout3x4567, vget_high_f32(vinput_scale23), 1);
+    vout2x89AB = vmulq_lane_f32(vout2x89AB, vget_low_f32(vinput_scale23), 1);
+    vout3x89AB = vmulq_lane_f32(vout3x89AB, vget_high_f32(vinput_scale23), 1);
+    vout2xCDEF = vmulq_lane_f32(vout2xCDEF, vget_low_f32(vinput_scale23), 1);
+    vout3xCDEF = vmulq_lane_f32(vout3xCDEF, vget_high_f32(vinput_scale23), 1);
+
+
+    const float32x4_t vbias0123 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x0123 = vaddq_f32(vbias0123, vout0x0123);
+    vout1x0123 = vaddq_f32(vbias0123, vout1x0123);
+    vout2x0123 = vaddq_f32(vbias0123, vout2x0123);
+    vout3x0123 = vaddq_f32(vbias0123, vout3x0123);
+    const float32x4_t vbias4567 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x4567 = vaddq_f32(vbias4567, vout0x4567);
+    vout1x4567 = vaddq_f32(vbias4567, vout1x4567);
+    vout2x4567 = vaddq_f32(vbias4567, vout2x4567);
+    vout3x4567 = vaddq_f32(vbias4567, vout3x4567);
+    const float32x4_t vbias89AB = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x89AB = vaddq_f32(vbias89AB, vout0x89AB);
+    vout1x89AB = vaddq_f32(vbias89AB, vout1x89AB);
+    vout2x89AB = vaddq_f32(vbias89AB, vout2x89AB);
+    vout3x89AB = vaddq_f32(vbias89AB, vout3x89AB);
+    const float32x4_t vbiasCDEF = vld1q_f32(w); w = (const float*) w + 4;
+    vout0xCDEF = vaddq_f32(vbiasCDEF, vout0xCDEF);
+    vout1xCDEF = vaddq_f32(vbiasCDEF, vout1xCDEF);
+    vout2xCDEF = vaddq_f32(vbiasCDEF, vout2xCDEF);
+    vout3xCDEF = vaddq_f32(vbiasCDEF, vout3xCDEF);
+
+    const float32x4_t voutput_min = vld1q_dup_f32(&params->scalar.min);
+    vout0x0123 = vmaxq_f32(vout0x0123, voutput_min);
+    vout0x4567 = vmaxq_f32(vout0x4567, voutput_min);
+    vout0x89AB = vmaxq_f32(vout0x89AB, voutput_min);
+    vout0xCDEF = vmaxq_f32(vout0xCDEF, voutput_min);
+    vout1x0123 = vmaxq_f32(vout1x0123, voutput_min);
+    vout1x4567 = vmaxq_f32(vout1x4567, voutput_min);
+    vout1x89AB = vmaxq_f32(vout1x89AB, voutput_min);
+    vout1xCDEF = vmaxq_f32(vout1xCDEF, voutput_min);
+    vout2x0123 = vmaxq_f32(vout2x0123, voutput_min);
+    vout2x4567 = vmaxq_f32(vout2x4567, voutput_min);
+    vout2x89AB = vmaxq_f32(vout2x89AB, voutput_min);
+    vout2xCDEF = vmaxq_f32(vout2xCDEF, voutput_min);
+    vout3x0123 = vmaxq_f32(vout3x0123, voutput_min);
+    vout3x4567 = vmaxq_f32(vout3x4567, voutput_min);
+    vout3x89AB = vmaxq_f32(vout3x89AB, voutput_min);
+    vout3xCDEF = vmaxq_f32(vout3xCDEF, voutput_min);
+
+    const float32x4_t voutput_max = vld1q_dup_f32(&params->scalar.max);
+    vout0x0123 = vminq_f32(vout0x0123, voutput_max);
+    vout0x4567 = vminq_f32(vout0x4567, voutput_max);
+    vout0x89AB = vminq_f32(vout0x89AB, voutput_max);
+    vout0xCDEF = vminq_f32(vout0xCDEF, voutput_max);
+    vout1x0123 = vminq_f32(vout1x0123, voutput_max);
+    vout1x4567 = vminq_f32(vout1x4567, voutput_max);
+    vout1x89AB = vminq_f32(vout1x89AB, voutput_max);
+    vout1xCDEF = vminq_f32(vout1xCDEF, voutput_max);
+    vout2x0123 = vminq_f32(vout2x0123, voutput_max);
+    vout2x4567 = vminq_f32(vout2x4567, voutput_max);
+    vout2x89AB = vminq_f32(vout2x89AB, voutput_max);
+    vout2xCDEF = vminq_f32(vout2xCDEF, voutput_max);
+    vout3x0123 = vminq_f32(vout3x0123, voutput_max);
+    vout3x4567 = vminq_f32(vout3x4567, voutput_max);
+    vout3x89AB = vminq_f32(vout3x89AB, voutput_max);
+    vout3xCDEF = vminq_f32(vout3xCDEF, voutput_max);
+
+    if XNN_LIKELY(nc >= 16) {
+      vst1q_f32(c0, vout0x0123);
+      vst1q_f32(c0 + 4, vout0x4567);
+      vst1q_f32(c0 + 8, vout0x89AB);
+      vst1q_f32(c0 + 12, vout0xCDEF);
+      vst1q_f32(c1, vout1x0123);
+      vst1q_f32(c1 + 4, vout1x4567);
+      vst1q_f32(c1 + 8, vout1x89AB);
+      vst1q_f32(c1 + 12, vout1xCDEF);
+      vst1q_f32(c2, vout2x0123);
+      vst1q_f32(c2 + 4, vout2x4567);
+      vst1q_f32(c2 + 8, vout2x89AB);
+      vst1q_f32(c2 + 12, vout2xCDEF);
+      vst1q_f32(c3, vout3x0123);
+      vst1q_f32(c3 + 4, vout3x4567);
+      vst1q_f32(c3 + 8, vout3x89AB);
+      vst1q_f32(c3 + 12, vout3xCDEF);
+
+      a0 = (const int8_t*) ((uintptr_t) a0 - kc);
+      a1 = (const int8_t*) ((uintptr_t) a1 - kc);
+      a2 = (const int8_t*) ((uintptr_t) a2 - kc);
+      a3 = (const int8_t*) ((uintptr_t) a3 - kc);
+
+      c0 = (float*) ((uintptr_t) c0 + cn_stride);
+      c1 = (float*) ((uintptr_t) c1 + cn_stride);
+      c2 = (float*) ((uintptr_t) c2 + cn_stride);
+      c3 = (float*) ((uintptr_t) c3 + cn_stride);
+
+      nc -= 16;
+    } else {
+     if (nc & 8) {
+       vst1q_f32(c0, vout0x0123); c0 += 4;
+       vout0x0123 = vout0x89AB;
+       vst1q_f32(c1, vout1x0123); c1 += 4;
+       vout1x0123 = vout1x89AB;
+       vst1q_f32(c2, vout2x0123); c2 += 4;
+       vout2x0123 = vout2x89AB;
+       vst1q_f32(c3, vout3x0123); c3 += 4;
+       vout3x0123 = vout3x89AB;
+       vst1q_f32(c0, vout0x4567); c0 += 4;
+       vout0x4567 = vout0xCDEF;
+       vst1q_f32(c1, vout1x4567); c1 += 4;
+       vout1x4567 = vout1xCDEF;
+       vst1q_f32(c2, vout2x4567); c2 += 4;
+       vout2x4567 = vout2xCDEF;
+       vst1q_f32(c3, vout3x4567); c3 += 4;
+       vout3x4567 = vout3xCDEF;
+     }
+     if (nc & 4) {
+       vst1q_f32(c0, vout0x0123); c0 += 4;
+       vout0x0123 = vout0x4567;
+       vst1q_f32(c1, vout1x0123); c1 += 4;
+       vout1x0123 = vout1x4567;
+       vst1q_f32(c2, vout2x0123); c2 += 4;
+       vout2x0123 = vout2x4567;
+       vst1q_f32(c3, vout3x0123); c3 += 4;
+       vout3x0123 = vout3x4567;
+     }
+     float32x2_t vout0x01 = vget_low_f32(vout0x0123);
+     float32x2_t vout1x01 = vget_low_f32(vout1x0123);
+     float32x2_t vout2x01 = vget_low_f32(vout2x0123);
+     float32x2_t vout3x01 = vget_low_f32(vout3x0123);
+     if (nc & 2) {
+       vst1_f32(c0, vout0x01); c0 += 2;
+       vst1_f32(c1, vout1x01); c1 += 2;
+       vst1_f32(c2, vout2x01); c2 += 2;
+       vst1_f32(c3, vout3x01); c3 += 2;
+       vout0x01 = vget_high_f32(vout0x0123);
+       vout1x01 = vget_high_f32(vout1x0123);
+       vout2x01 = vget_high_f32(vout2x0123);
+       vout3x01 = vget_high_f32(vout3x0123);
+     }
+     if (nc & 1) {
+       vst1_lane_f32(c0, vout0x01, 0);
+       vst1_lane_f32(c1, vout1x01, 0);
+       vst1_lane_f32(c2, vout2x01, 0);
+       vst1_lane_f32(c3, vout3x01, 0);
+     }
+      nc = 0;
+    }
+  } while (nc != 0);
+}

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x8c4-minmax-neondot.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x8c4-minmax-neondot.c
@@ -1,0 +1,281 @@
+// Auto-generated file. Do not edit!
+//   Template: src/qs8-gemm/c4-neondot.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2020 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+
+#include <arm_neon.h>
+
+#include "xnnpack/gemm.h"
+#include "xnnpack/math.h"
+
+
+void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x8c4__neondot(
+    size_t mr,
+    size_t nc,
+    size_t kc,
+    const int8_t* restrict a,
+    size_t a_stride,
+    const void* restrict w,
+    float* restrict c,
+    size_t cm_stride,
+    size_t cn_stride,
+    const union xnn_f32_qb4w_minmax_params params[restrict XNN_MIN_ELEMENTS(1)],
+    const struct xnn_qd8_quantization_params quantization_params[restrict XNN_MIN_ELEMENTS(1)]) XNN_OOB_READS
+{
+  assert(mr != 0);
+  assert(mr <= 4);
+  assert(nc != 0);
+  assert(kc != 0);
+  assert(kc % sizeof(int8_t) == 0);
+  assert(a != NULL);
+  assert(w != NULL);
+  assert(c != NULL);
+
+  kc = round_up_po2(kc, 4 * sizeof(int8_t));
+  const int8_t* a0 = a;
+  float* c0 = c;
+  const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
+  float* c1 = (float*) ((uintptr_t) c0 + cm_stride);
+  if XNN_UNPREDICTABLE(mr < 2) {
+    a1 = a0;
+    c1 = c0;
+  }
+  const int8_t* a2 = (const int8_t*) ((uintptr_t) a1 + a_stride);
+  float* c2 = (float*) ((uintptr_t) c1 + cm_stride);
+  if XNN_UNPREDICTABLE(mr <= 2) {
+    a2 = a1;
+    c2 = c1;
+  }
+  const int8_t* a3 = (const int8_t*) ((uintptr_t) a2 + a_stride);
+  float* c3 = (float*) ((uintptr_t) c2 + cm_stride);
+  if XNN_UNPREDICTABLE(mr != 4) {
+    a3 = a2;
+    c3 = c2;
+  }
+
+  size_t bl = params->scalar.blocksize;
+  assert(bl <= kc);
+  assert(bl != 0);
+  size_t n_blocks = kc / bl;
+  const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
+  // Loop over groups of 8 columns.
+  do {
+    // Initialize accumulators with bias. 8 bias values are loaded from the
+    // weight matrix, at the start of the group of 8 columns.
+    const float32x4_t vinput_zero_point01 = vcvtq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    const float32x4_t vksum0123 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x0123 = vmulq_lane_f32(vksum0123, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x0123 = vmulq_lane_f32(vksum0123, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksum4567 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vinput_zero_point23 = vcvtq_f32_s32(vld1q_s32(&quantization_params[2].zero_point));
+    float32x4_t vout2x0123 = vmulq_lane_f32(vksum0123, vget_low_f32(vinput_zero_point23), 0);
+    float32x4_t vout3x0123 = vmulq_lane_f32(vksum0123, vget_high_f32(vinput_zero_point23), 0);
+    float32x4_t vout2x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point23), 0);
+    float32x4_t vout3x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point23), 0);
+
+    for (size_t nb=0; nb < n_blocks; ++nb) {
+      int32x4_t vacc0x0123 = vdupq_n_s32(0);
+      int32x4_t vacc1x0123 = vdupq_n_s32(0);
+      int32x4_t vacc0x4567 = vdupq_n_s32(0);
+      int32x4_t vacc1x4567 = vdupq_n_s32(0);
+      int32x4_t vacc2x0123 = vdupq_n_s32(0);
+      int32x4_t vacc3x0123 = vdupq_n_s32(0);
+      int32x4_t vacc2x4567 = vdupq_n_s32(0);
+      int32x4_t vacc3x4567 = vdupq_n_s32(0);
+    // Inner accumulation loop along the 8 columns.
+    size_t k = bl;
+    // 2x partial unrolled loop to load 8 bytes at a time.
+    while (k >= 8 * sizeof(int8_t)) {
+      // Load a 4x8 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 8;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 8;
+      const int8x8_t va2x01234567 = vld1_s8(a2); a2 += 8;
+      const int8x8_t va3x01234567 = vld1_s8(a3); a3 += 8;
+
+      // Load a 8x8 block of weights.
+      const int8x16_t vb01234567x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x0123 = vshlq_n_s8(vb01234567x0123, 4);
+      const int8x16_t vb0123x4567 = vshlq_n_s8(vb01234567x4567, 4);
+      const int8x16_t vb4567x0123 = vandq_s8(vb01234567x0123, vmask);
+      const int8x16_t vb4567x4567 = vandq_s8(vb01234567x4567, vmask);
+
+      // Multiply-accumulate: 4x8 * 8x8 --> 4x8.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb0123x0123, va2x01234567, 0);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb0123x4567, va2x01234567, 0);
+      vacc3x0123 = vdotq_lane_s32(vacc3x0123, vb0123x0123, va3x01234567, 0);
+      vacc3x4567 = vdotq_lane_s32(vacc3x4567, vb0123x4567, va3x01234567, 0);
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb4567x0123, va0x01234567, 1);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb4567x4567, va0x01234567, 1);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb4567x0123, va1x01234567, 1);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb4567x4567, va1x01234567, 1);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb4567x0123, va2x01234567, 1);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb4567x4567, va2x01234567, 1);
+      vacc3x0123 = vdotq_lane_s32(vacc3x0123, vb4567x0123, va3x01234567, 1);
+      vacc3x4567 = vdotq_lane_s32(vacc3x4567, vb4567x4567, va3x01234567, 1);
+
+      k -= 8 * sizeof(int8_t);
+    }
+    // Handle up to 4 final positions of `k`
+    if XNN_UNLIKELY(k != 0) {
+      // Load a 4x4 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 4;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 4;
+      const int8x8_t va2x01234567 = vld1_s8(a2); a2 += 4;
+      const int8x8_t va3x01234567 = vld1_s8(a3); a3 += 4;
+
+      // Load a 4x8 block of weights.
+      const int8x16_t vb0123x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+
+      // Multiply-accumulate: 4x4 * 4x8 --> 4x8.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb0123x0123, va2x01234567, 0);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb0123x4567, va2x01234567, 0);
+      vacc3x0123 = vdotq_lane_s32(vacc3x0123, vb0123x0123, va3x01234567, 0);
+      vacc3x4567 = vdotq_lane_s32(vacc3x4567, vb0123x4567, va3x01234567, 0);
+    }
+    const float32x4_t vfilter_output_scale0123 = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scale4567 = vld1q_f32(w); w = (const float*) w + 4;
+
+    float32x4_t vf0x0123 = vcvtq_f32_s32(vacc0x0123);
+    float32x4_t vf1x0123 = vcvtq_f32_s32(vacc1x0123);
+    vout0x0123 = vfmaq_f32(vout0x0123, vf0x0123, vfilter_output_scale0123);
+    vout1x0123 = vfmaq_f32(vout1x0123, vf1x0123, vfilter_output_scale0123);
+    float32x4_t vf0x4567 = vcvtq_f32_s32(vacc0x4567);
+    float32x4_t vf1x4567 = vcvtq_f32_s32(vacc1x4567);
+    vout0x4567 = vfmaq_f32(vout0x4567, vf0x4567, vfilter_output_scale4567);
+    vout1x4567 = vfmaq_f32(vout1x4567, vf1x4567, vfilter_output_scale4567);
+    float32x4_t vf2x0123 = vcvtq_f32_s32(vacc2x0123);
+    float32x4_t vf3x0123 = vcvtq_f32_s32(vacc3x0123);
+    vout2x0123 = vfmaq_f32(vout2x0123, vf2x0123, vfilter_output_scale0123);
+    vout3x0123 = vfmaq_f32(vout3x0123, vf3x0123, vfilter_output_scale0123);
+    float32x4_t vf2x4567 = vcvtq_f32_s32(vacc2x4567);
+    float32x4_t vf3x4567 = vcvtq_f32_s32(vacc3x4567);
+    vout2x4567 = vfmaq_f32(vout2x4567, vf2x4567, vfilter_output_scale4567);
+    vout3x4567 = vfmaq_f32(vout3x4567, vf3x4567, vfilter_output_scale4567);
+    }
+
+    const float32x4_t one_sixteenth = vdupq_n_f32(1/16.0);
+    vout0x0123 = vmulq_f32(vout0x0123, one_sixteenth);
+    vout0x4567 = vmulq_f32(vout0x4567, one_sixteenth);
+    vout1x0123 = vmulq_f32(vout1x0123, one_sixteenth);
+    vout1x4567 = vmulq_f32(vout1x4567, one_sixteenth);
+    vout2x0123 = vmulq_f32(vout2x0123, one_sixteenth);
+    vout2x4567 = vmulq_f32(vout2x4567, one_sixteenth);
+    vout3x0123 = vmulq_f32(vout3x0123, one_sixteenth);
+    vout3x4567 = vmulq_f32(vout3x4567, one_sixteenth);
+    const float32x4_t vinput_scale01 = vreinterpretq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    vout0x0123 = vmulq_lane_f32(vout0x0123, vget_low_f32(vinput_scale01), 1);
+    vout1x0123 = vmulq_lane_f32(vout1x0123, vget_high_f32(vinput_scale01), 1);
+    vout0x4567 = vmulq_lane_f32(vout0x4567, vget_low_f32(vinput_scale01), 1);
+    vout1x4567 = vmulq_lane_f32(vout1x4567, vget_high_f32(vinput_scale01), 1);
+    const float32x4_t vinput_scale23 = vreinterpretq_f32_s32(vld1q_s32(&quantization_params[2].zero_point));
+    vout2x0123 = vmulq_lane_f32(vout2x0123, vget_low_f32(vinput_scale23), 1);
+    vout3x0123 = vmulq_lane_f32(vout3x0123, vget_high_f32(vinput_scale23), 1);
+    vout2x4567 = vmulq_lane_f32(vout2x4567, vget_low_f32(vinput_scale23), 1);
+    vout3x4567 = vmulq_lane_f32(vout3x4567, vget_high_f32(vinput_scale23), 1);
+
+
+    const float32x4_t vbias0123 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x0123 = vaddq_f32(vbias0123, vout0x0123);
+    vout1x0123 = vaddq_f32(vbias0123, vout1x0123);
+    vout2x0123 = vaddq_f32(vbias0123, vout2x0123);
+    vout3x0123 = vaddq_f32(vbias0123, vout3x0123);
+    const float32x4_t vbias4567 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x4567 = vaddq_f32(vbias4567, vout0x4567);
+    vout1x4567 = vaddq_f32(vbias4567, vout1x4567);
+    vout2x4567 = vaddq_f32(vbias4567, vout2x4567);
+    vout3x4567 = vaddq_f32(vbias4567, vout3x4567);
+
+    const float32x4_t voutput_min = vld1q_dup_f32(&params->scalar.min);
+    vout0x0123 = vmaxq_f32(vout0x0123, voutput_min);
+    vout0x4567 = vmaxq_f32(vout0x4567, voutput_min);
+    vout1x0123 = vmaxq_f32(vout1x0123, voutput_min);
+    vout1x4567 = vmaxq_f32(vout1x4567, voutput_min);
+    vout2x0123 = vmaxq_f32(vout2x0123, voutput_min);
+    vout2x4567 = vmaxq_f32(vout2x4567, voutput_min);
+    vout3x0123 = vmaxq_f32(vout3x0123, voutput_min);
+    vout3x4567 = vmaxq_f32(vout3x4567, voutput_min);
+
+    const float32x4_t voutput_max = vld1q_dup_f32(&params->scalar.max);
+    vout0x0123 = vminq_f32(vout0x0123, voutput_max);
+    vout0x4567 = vminq_f32(vout0x4567, voutput_max);
+    vout1x0123 = vminq_f32(vout1x0123, voutput_max);
+    vout1x4567 = vminq_f32(vout1x4567, voutput_max);
+    vout2x0123 = vminq_f32(vout2x0123, voutput_max);
+    vout2x4567 = vminq_f32(vout2x4567, voutput_max);
+    vout3x0123 = vminq_f32(vout3x0123, voutput_max);
+    vout3x4567 = vminq_f32(vout3x4567, voutput_max);
+
+    if XNN_LIKELY(nc >= 8) {
+      vst1q_f32(c0, vout0x0123);
+      vst1q_f32(c0 + 4, vout0x4567);
+      vst1q_f32(c1, vout1x0123);
+      vst1q_f32(c1 + 4, vout1x4567);
+      vst1q_f32(c2, vout2x0123);
+      vst1q_f32(c2 + 4, vout2x4567);
+      vst1q_f32(c3, vout3x0123);
+      vst1q_f32(c3 + 4, vout3x4567);
+
+      a0 = (const int8_t*) ((uintptr_t) a0 - kc);
+      a1 = (const int8_t*) ((uintptr_t) a1 - kc);
+      a2 = (const int8_t*) ((uintptr_t) a2 - kc);
+      a3 = (const int8_t*) ((uintptr_t) a3 - kc);
+
+      c0 = (float*) ((uintptr_t) c0 + cn_stride);
+      c1 = (float*) ((uintptr_t) c1 + cn_stride);
+      c2 = (float*) ((uintptr_t) c2 + cn_stride);
+      c3 = (float*) ((uintptr_t) c3 + cn_stride);
+
+      nc -= 8;
+    } else {
+     if (nc & 4) {
+       vst1q_f32(c0, vout0x0123); c0 += 4;
+       vout0x0123 = vout0x4567;
+       vst1q_f32(c1, vout1x0123); c1 += 4;
+       vout1x0123 = vout1x4567;
+       vst1q_f32(c2, vout2x0123); c2 += 4;
+       vout2x0123 = vout2x4567;
+       vst1q_f32(c3, vout3x0123); c3 += 4;
+       vout3x0123 = vout3x4567;
+     }
+     float32x2_t vout0x01 = vget_low_f32(vout0x0123);
+     float32x2_t vout1x01 = vget_low_f32(vout1x0123);
+     float32x2_t vout2x01 = vget_low_f32(vout2x0123);
+     float32x2_t vout3x01 = vget_low_f32(vout3x0123);
+     if (nc & 2) {
+       vst1_f32(c0, vout0x01); c0 += 2;
+       vst1_f32(c1, vout1x01); c1 += 2;
+       vst1_f32(c2, vout2x01); c2 += 2;
+       vst1_f32(c3, vout3x01); c3 += 2;
+       vout0x01 = vget_high_f32(vout0x0123);
+       vout1x01 = vget_high_f32(vout1x0123);
+       vout2x01 = vget_high_f32(vout2x0123);
+       vout3x01 = vget_high_f32(vout3x0123);
+     }
+     if (nc & 1) {
+       vst1_lane_f32(c0, vout0x01, 0);
+       vst1_lane_f32(c1, vout1x01, 0);
+       vst1_lane_f32(c2, vout2x01, 0);
+       vst1_lane_f32(c3, vout3x01, 0);
+     }
+      nc = 0;
+    }
+  } while (nc != 0);
+}

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-5x16c4-minmax-neondot.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-5x16c4-minmax-neondot.c
@@ -1,0 +1,491 @@
+// Auto-generated file. Do not edit!
+//   Template: src/qs8-gemm/c4-neondot.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2020 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+
+#include <arm_neon.h>
+
+#include "xnnpack/gemm.h"
+#include "xnnpack/math.h"
+
+
+void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_5x16c4__neondot(
+    size_t mr,
+    size_t nc,
+    size_t kc,
+    const int8_t* restrict a,
+    size_t a_stride,
+    const void* restrict w,
+    float* restrict c,
+    size_t cm_stride,
+    size_t cn_stride,
+    const union xnn_f32_qb4w_minmax_params params[restrict XNN_MIN_ELEMENTS(1)],
+    const struct xnn_qd8_quantization_params quantization_params[restrict XNN_MIN_ELEMENTS(1)]) XNN_OOB_READS
+{
+  assert(mr != 0);
+  assert(mr <= 5);
+  assert(nc != 0);
+  assert(kc != 0);
+  assert(kc % sizeof(int8_t) == 0);
+  assert(a != NULL);
+  assert(w != NULL);
+  assert(c != NULL);
+
+  kc = round_up_po2(kc, 4 * sizeof(int8_t));
+  const int8_t* a0 = a;
+  float* c0 = c;
+  const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
+  float* c1 = (float*) ((uintptr_t) c0 + cm_stride);
+  if XNN_UNPREDICTABLE(mr < 2) {
+    a1 = a0;
+    c1 = c0;
+  }
+  const int8_t* a2 = (const int8_t*) ((uintptr_t) a1 + a_stride);
+  float* c2 = (float*) ((uintptr_t) c1 + cm_stride);
+  if XNN_UNPREDICTABLE(mr <= 2) {
+    a2 = a1;
+    c2 = c1;
+  }
+  const int8_t* a3 = (const int8_t*) ((uintptr_t) a2 + a_stride);
+  float* c3 = (float*) ((uintptr_t) c2 + cm_stride);
+  if XNN_UNPREDICTABLE(mr < 4) {
+    a3 = a2;
+    c3 = c2;
+  }
+  const int8_t* a4 = (const int8_t*) ((uintptr_t) a3 + a_stride);
+  float* c4 = (float*) ((uintptr_t) c3 + cm_stride);
+  if XNN_UNPREDICTABLE(mr <= 4) {
+    a4 = a3;
+    c4 = c3;
+  }
+
+  size_t bl = params->scalar.blocksize;
+  assert(bl <= kc);
+  assert(bl != 0);
+  size_t n_blocks = kc / bl;
+  const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
+  // Loop over groups of 16 columns.
+  do {
+    // Initialize accumulators with bias. 16 bias values are loaded from the
+    // weight matrix, at the start of the group of 16 columns.
+    const float32x4_t vinput_zero_point01 = vcvtq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    const float32x4_t vksum0123 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x0123 = vmulq_lane_f32(vksum0123, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x0123 = vmulq_lane_f32(vksum0123, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksum4567 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksum89AB = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x89AB = vmulq_lane_f32(vksum89AB, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x89AB = vmulq_lane_f32(vksum89AB, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksumCDEF = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0xCDEF = vmulq_lane_f32(vksumCDEF, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vinput_zero_point23 = vcvtq_f32_s32(vld1q_s32(&quantization_params[2].zero_point));
+    float32x4_t vout2x0123 = vmulq_lane_f32(vksum0123, vget_low_f32(vinput_zero_point23), 0);
+    float32x4_t vout3x0123 = vmulq_lane_f32(vksum0123, vget_high_f32(vinput_zero_point23), 0);
+    float32x4_t vout2x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point23), 0);
+    float32x4_t vout3x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point23), 0);
+    float32x4_t vout2x89AB = vmulq_lane_f32(vksum89AB, vget_low_f32(vinput_zero_point23), 0);
+    float32x4_t vout3x89AB = vmulq_lane_f32(vksum89AB, vget_high_f32(vinput_zero_point23), 0);
+    float32x4_t vout2xCDEF = vmulq_lane_f32(vksumCDEF, vget_low_f32(vinput_zero_point23), 0);
+    float32x4_t vout3xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vinput_zero_point23), 0);
+    const float32x4_t vinput_zero_point4 = vcvtq_f32_s32(vld1q_dup_s32(&quantization_params[4].zero_point));
+    float32x4_t vout4x0123 = vmulq_f32(vksum0123, vinput_zero_point4);
+    float32x4_t vout4x4567 = vmulq_f32(vksum4567, vinput_zero_point4);
+    float32x4_t vout4x89AB = vmulq_f32(vksum89AB, vinput_zero_point4);
+    float32x4_t vout4xCDEF = vmulq_f32(vksumCDEF, vinput_zero_point4);
+
+    for (size_t nb=0; nb < n_blocks; ++nb) {
+      int32x4_t vacc0x0123 = vdupq_n_s32(0);
+      int32x4_t vacc1x0123 = vdupq_n_s32(0);
+      int32x4_t vacc0x4567 = vdupq_n_s32(0);
+      int32x4_t vacc1x4567 = vdupq_n_s32(0);
+      int32x4_t vacc0x89AB = vdupq_n_s32(0);
+      int32x4_t vacc1x89AB = vdupq_n_s32(0);
+      int32x4_t vacc0xCDEF = vdupq_n_s32(0);
+      int32x4_t vacc1xCDEF = vdupq_n_s32(0);
+      int32x4_t vacc2x0123 = vdupq_n_s32(0);
+      int32x4_t vacc3x0123 = vdupq_n_s32(0);
+      int32x4_t vacc2x4567 = vdupq_n_s32(0);
+      int32x4_t vacc3x4567 = vdupq_n_s32(0);
+      int32x4_t vacc2x89AB = vdupq_n_s32(0);
+      int32x4_t vacc3x89AB = vdupq_n_s32(0);
+      int32x4_t vacc2xCDEF = vdupq_n_s32(0);
+      int32x4_t vacc3xCDEF = vdupq_n_s32(0);
+      int32x4_t vacc4x0123 = vdupq_n_s32(0);
+      int32x4_t vacc4x4567 = vdupq_n_s32(0);
+      int32x4_t vacc4x89AB = vdupq_n_s32(0);
+      int32x4_t vacc4xCDEF = vdupq_n_s32(0);
+    // Inner accumulation loop along the 16 columns.
+    size_t k = bl;
+    // 2x partial unrolled loop to load 8 bytes at a time.
+    while (k >= 8 * sizeof(int8_t)) {
+      // Load a 5x8 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 8;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 8;
+      const int8x8_t va2x01234567 = vld1_s8(a2); a2 += 8;
+      const int8x8_t va3x01234567 = vld1_s8(a3); a3 += 8;
+      const int8x8_t va4x01234567 = vld1_s8(a4); a4 += 8;
+
+      // Load a 8x16 block of weights.
+      const int8x16_t vb01234567x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567x89AB = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567xCDEF = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x0123 = vshlq_n_s8(vb01234567x0123, 4);
+      const int8x16_t vb0123x4567 = vshlq_n_s8(vb01234567x4567, 4);
+      const int8x16_t vb0123x89AB = vshlq_n_s8(vb01234567x89AB, 4);
+      const int8x16_t vb0123xCDEF = vshlq_n_s8(vb01234567xCDEF, 4);
+      const int8x16_t vb4567x0123 = vandq_s8(vb01234567x0123, vmask);
+      const int8x16_t vb4567x4567 = vandq_s8(vb01234567x4567, vmask);
+      const int8x16_t vb4567x89AB = vandq_s8(vb01234567x89AB, vmask);
+      const int8x16_t vb4567xCDEF = vandq_s8(vb01234567xCDEF, vmask);
+
+      // Multiply-accumulate: 5x8 * 8x16 --> 5x16.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc0x89AB = vdotq_lane_s32(vacc0x89AB, vb0123x89AB, va0x01234567, 0);
+      vacc0xCDEF = vdotq_lane_s32(vacc0xCDEF, vb0123xCDEF, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+      vacc1x89AB = vdotq_lane_s32(vacc1x89AB, vb0123x89AB, va1x01234567, 0);
+      vacc1xCDEF = vdotq_lane_s32(vacc1xCDEF, vb0123xCDEF, va1x01234567, 0);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb0123x0123, va2x01234567, 0);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb0123x4567, va2x01234567, 0);
+      vacc2x89AB = vdotq_lane_s32(vacc2x89AB, vb0123x89AB, va2x01234567, 0);
+      vacc2xCDEF = vdotq_lane_s32(vacc2xCDEF, vb0123xCDEF, va2x01234567, 0);
+      vacc3x0123 = vdotq_lane_s32(vacc3x0123, vb0123x0123, va3x01234567, 0);
+      vacc3x4567 = vdotq_lane_s32(vacc3x4567, vb0123x4567, va3x01234567, 0);
+      vacc3x89AB = vdotq_lane_s32(vacc3x89AB, vb0123x89AB, va3x01234567, 0);
+      vacc3xCDEF = vdotq_lane_s32(vacc3xCDEF, vb0123xCDEF, va3x01234567, 0);
+      vacc4x0123 = vdotq_lane_s32(vacc4x0123, vb0123x0123, va4x01234567, 0);
+      vacc4x4567 = vdotq_lane_s32(vacc4x4567, vb0123x4567, va4x01234567, 0);
+      vacc4x89AB = vdotq_lane_s32(vacc4x89AB, vb0123x89AB, va4x01234567, 0);
+      vacc4xCDEF = vdotq_lane_s32(vacc4xCDEF, vb0123xCDEF, va4x01234567, 0);
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb4567x0123, va0x01234567, 1);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb4567x4567, va0x01234567, 1);
+      vacc0x89AB = vdotq_lane_s32(vacc0x89AB, vb4567x89AB, va0x01234567, 1);
+      vacc0xCDEF = vdotq_lane_s32(vacc0xCDEF, vb4567xCDEF, va0x01234567, 1);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb4567x0123, va1x01234567, 1);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb4567x4567, va1x01234567, 1);
+      vacc1x89AB = vdotq_lane_s32(vacc1x89AB, vb4567x89AB, va1x01234567, 1);
+      vacc1xCDEF = vdotq_lane_s32(vacc1xCDEF, vb4567xCDEF, va1x01234567, 1);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb4567x0123, va2x01234567, 1);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb4567x4567, va2x01234567, 1);
+      vacc2x89AB = vdotq_lane_s32(vacc2x89AB, vb4567x89AB, va2x01234567, 1);
+      vacc2xCDEF = vdotq_lane_s32(vacc2xCDEF, vb4567xCDEF, va2x01234567, 1);
+      vacc3x0123 = vdotq_lane_s32(vacc3x0123, vb4567x0123, va3x01234567, 1);
+      vacc3x4567 = vdotq_lane_s32(vacc3x4567, vb4567x4567, va3x01234567, 1);
+      vacc3x89AB = vdotq_lane_s32(vacc3x89AB, vb4567x89AB, va3x01234567, 1);
+      vacc3xCDEF = vdotq_lane_s32(vacc3xCDEF, vb4567xCDEF, va3x01234567, 1);
+      vacc4x0123 = vdotq_lane_s32(vacc4x0123, vb4567x0123, va4x01234567, 1);
+      vacc4x4567 = vdotq_lane_s32(vacc4x4567, vb4567x4567, va4x01234567, 1);
+      vacc4x89AB = vdotq_lane_s32(vacc4x89AB, vb4567x89AB, va4x01234567, 1);
+      vacc4xCDEF = vdotq_lane_s32(vacc4xCDEF, vb4567xCDEF, va4x01234567, 1);
+
+      k -= 8 * sizeof(int8_t);
+    }
+    // Handle up to 4 final positions of `k`
+    if XNN_UNLIKELY(k != 0) {
+      // Load a 5x4 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 4;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 4;
+      const int8x8_t va2x01234567 = vld1_s8(a2); a2 += 4;
+      const int8x8_t va3x01234567 = vld1_s8(a3); a3 += 4;
+      const int8x8_t va4x01234567 = vld1_s8(a4); a4 += 4;
+
+      // Load a 4x16 block of weights.
+      const int8x16_t vb0123x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x89AB = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123xCDEF = vld1q_s8(w); w = (const int8_t*) w + 16;
+
+      // Multiply-accumulate: 5x4 * 4x16 --> 5x16.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc0x89AB = vdotq_lane_s32(vacc0x89AB, vb0123x89AB, va0x01234567, 0);
+      vacc0xCDEF = vdotq_lane_s32(vacc0xCDEF, vb0123xCDEF, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+      vacc1x89AB = vdotq_lane_s32(vacc1x89AB, vb0123x89AB, va1x01234567, 0);
+      vacc1xCDEF = vdotq_lane_s32(vacc1xCDEF, vb0123xCDEF, va1x01234567, 0);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb0123x0123, va2x01234567, 0);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb0123x4567, va2x01234567, 0);
+      vacc2x89AB = vdotq_lane_s32(vacc2x89AB, vb0123x89AB, va2x01234567, 0);
+      vacc2xCDEF = vdotq_lane_s32(vacc2xCDEF, vb0123xCDEF, va2x01234567, 0);
+      vacc3x0123 = vdotq_lane_s32(vacc3x0123, vb0123x0123, va3x01234567, 0);
+      vacc3x4567 = vdotq_lane_s32(vacc3x4567, vb0123x4567, va3x01234567, 0);
+      vacc3x89AB = vdotq_lane_s32(vacc3x89AB, vb0123x89AB, va3x01234567, 0);
+      vacc3xCDEF = vdotq_lane_s32(vacc3xCDEF, vb0123xCDEF, va3x01234567, 0);
+      vacc4x0123 = vdotq_lane_s32(vacc4x0123, vb0123x0123, va4x01234567, 0);
+      vacc4x4567 = vdotq_lane_s32(vacc4x4567, vb0123x4567, va4x01234567, 0);
+      vacc4x89AB = vdotq_lane_s32(vacc4x89AB, vb0123x89AB, va4x01234567, 0);
+      vacc4xCDEF = vdotq_lane_s32(vacc4xCDEF, vb0123xCDEF, va4x01234567, 0);
+    }
+    const float32x4_t vfilter_output_scale0123 = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scale4567 = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scale89AB = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scaleCDEF = vld1q_f32(w); w = (const float*) w + 4;
+
+    float32x4_t vf0x0123 = vcvtq_f32_s32(vacc0x0123);
+    float32x4_t vf1x0123 = vcvtq_f32_s32(vacc1x0123);
+    vout0x0123 = vfmaq_f32(vout0x0123, vf0x0123, vfilter_output_scale0123);
+    vout1x0123 = vfmaq_f32(vout1x0123, vf1x0123, vfilter_output_scale0123);
+    float32x4_t vf0x4567 = vcvtq_f32_s32(vacc0x4567);
+    float32x4_t vf1x4567 = vcvtq_f32_s32(vacc1x4567);
+    vout0x4567 = vfmaq_f32(vout0x4567, vf0x4567, vfilter_output_scale4567);
+    vout1x4567 = vfmaq_f32(vout1x4567, vf1x4567, vfilter_output_scale4567);
+    float32x4_t vf0x89AB = vcvtq_f32_s32(vacc0x89AB);
+    float32x4_t vf1x89AB = vcvtq_f32_s32(vacc1x89AB);
+    vout0x89AB = vfmaq_f32(vout0x89AB, vf0x89AB, vfilter_output_scale89AB);
+    vout1x89AB = vfmaq_f32(vout1x89AB, vf1x89AB, vfilter_output_scale89AB);
+    float32x4_t vf0xCDEF = vcvtq_f32_s32(vacc0xCDEF);
+    float32x4_t vf1xCDEF = vcvtq_f32_s32(vacc1xCDEF);
+    vout0xCDEF = vfmaq_f32(vout0xCDEF, vf0xCDEF, vfilter_output_scaleCDEF);
+    vout1xCDEF = vfmaq_f32(vout1xCDEF, vf1xCDEF, vfilter_output_scaleCDEF);
+    float32x4_t vf2x0123 = vcvtq_f32_s32(vacc2x0123);
+    float32x4_t vf3x0123 = vcvtq_f32_s32(vacc3x0123);
+    vout2x0123 = vfmaq_f32(vout2x0123, vf2x0123, vfilter_output_scale0123);
+    vout3x0123 = vfmaq_f32(vout3x0123, vf3x0123, vfilter_output_scale0123);
+    float32x4_t vf2x4567 = vcvtq_f32_s32(vacc2x4567);
+    float32x4_t vf3x4567 = vcvtq_f32_s32(vacc3x4567);
+    vout2x4567 = vfmaq_f32(vout2x4567, vf2x4567, vfilter_output_scale4567);
+    vout3x4567 = vfmaq_f32(vout3x4567, vf3x4567, vfilter_output_scale4567);
+    float32x4_t vf2x89AB = vcvtq_f32_s32(vacc2x89AB);
+    float32x4_t vf3x89AB = vcvtq_f32_s32(vacc3x89AB);
+    vout2x89AB = vfmaq_f32(vout2x89AB, vf2x89AB, vfilter_output_scale89AB);
+    vout3x89AB = vfmaq_f32(vout3x89AB, vf3x89AB, vfilter_output_scale89AB);
+    float32x4_t vf2xCDEF = vcvtq_f32_s32(vacc2xCDEF);
+    float32x4_t vf3xCDEF = vcvtq_f32_s32(vacc3xCDEF);
+    vout2xCDEF = vfmaq_f32(vout2xCDEF, vf2xCDEF, vfilter_output_scaleCDEF);
+    vout3xCDEF = vfmaq_f32(vout3xCDEF, vf3xCDEF, vfilter_output_scaleCDEF);
+    float32x4_t vf4x0123 = vcvtq_f32_s32(vacc4x0123);
+    vout4x0123 = vfmaq_f32(vout4x0123, vf4x0123, vfilter_output_scale0123);
+    float32x4_t vf4x4567 = vcvtq_f32_s32(vacc4x4567);
+    vout4x4567 = vfmaq_f32(vout4x4567, vf4x4567, vfilter_output_scale4567);
+    float32x4_t vf4x89AB = vcvtq_f32_s32(vacc4x89AB);
+    vout4x89AB = vfmaq_f32(vout4x89AB, vf4x89AB, vfilter_output_scale89AB);
+    float32x4_t vf4xCDEF = vcvtq_f32_s32(vacc4xCDEF);
+    vout4xCDEF = vfmaq_f32(vout4xCDEF, vf4xCDEF, vfilter_output_scaleCDEF);
+    }
+
+    const float32x4_t one_sixteenth = vdupq_n_f32(1/16.0);
+    vout0x0123 = vmulq_f32(vout0x0123, one_sixteenth);
+    vout0x4567 = vmulq_f32(vout0x4567, one_sixteenth);
+    vout0x89AB = vmulq_f32(vout0x89AB, one_sixteenth);
+    vout0xCDEF = vmulq_f32(vout0xCDEF, one_sixteenth);
+    vout1x0123 = vmulq_f32(vout1x0123, one_sixteenth);
+    vout1x4567 = vmulq_f32(vout1x4567, one_sixteenth);
+    vout1x89AB = vmulq_f32(vout1x89AB, one_sixteenth);
+    vout1xCDEF = vmulq_f32(vout1xCDEF, one_sixteenth);
+    vout2x0123 = vmulq_f32(vout2x0123, one_sixteenth);
+    vout2x4567 = vmulq_f32(vout2x4567, one_sixteenth);
+    vout2x89AB = vmulq_f32(vout2x89AB, one_sixteenth);
+    vout2xCDEF = vmulq_f32(vout2xCDEF, one_sixteenth);
+    vout3x0123 = vmulq_f32(vout3x0123, one_sixteenth);
+    vout3x4567 = vmulq_f32(vout3x4567, one_sixteenth);
+    vout3x89AB = vmulq_f32(vout3x89AB, one_sixteenth);
+    vout3xCDEF = vmulq_f32(vout3xCDEF, one_sixteenth);
+    vout4x0123 = vmulq_f32(vout4x0123, one_sixteenth);
+    vout4x4567 = vmulq_f32(vout4x4567, one_sixteenth);
+    vout4x89AB = vmulq_f32(vout4x89AB, one_sixteenth);
+    vout4xCDEF = vmulq_f32(vout4xCDEF, one_sixteenth);
+    const float32x4_t vinput_scale01 = vreinterpretq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    vout0x0123 = vmulq_lane_f32(vout0x0123, vget_low_f32(vinput_scale01), 1);
+    vout1x0123 = vmulq_lane_f32(vout1x0123, vget_high_f32(vinput_scale01), 1);
+    vout0x4567 = vmulq_lane_f32(vout0x4567, vget_low_f32(vinput_scale01), 1);
+    vout1x4567 = vmulq_lane_f32(vout1x4567, vget_high_f32(vinput_scale01), 1);
+    vout0x89AB = vmulq_lane_f32(vout0x89AB, vget_low_f32(vinput_scale01), 1);
+    vout1x89AB = vmulq_lane_f32(vout1x89AB, vget_high_f32(vinput_scale01), 1);
+    vout0xCDEF = vmulq_lane_f32(vout0xCDEF, vget_low_f32(vinput_scale01), 1);
+    vout1xCDEF = vmulq_lane_f32(vout1xCDEF, vget_high_f32(vinput_scale01), 1);
+    const float32x4_t vinput_scale23 = vreinterpretq_f32_s32(vld1q_s32(&quantization_params[2].zero_point));
+    vout2x0123 = vmulq_lane_f32(vout2x0123, vget_low_f32(vinput_scale23), 1);
+    vout3x0123 = vmulq_lane_f32(vout3x0123, vget_high_f32(vinput_scale23), 1);
+    vout2x4567 = vmulq_lane_f32(vout2x4567, vget_low_f32(vinput_scale23), 1);
+    vout3x4567 = vmulq_lane_f32(vout3x4567, vget_high_f32(vinput_scale23), 1);
+    vout2x89AB = vmulq_lane_f32(vout2x89AB, vget_low_f32(vinput_scale23), 1);
+    vout3x89AB = vmulq_lane_f32(vout3x89AB, vget_high_f32(vinput_scale23), 1);
+    vout2xCDEF = vmulq_lane_f32(vout2xCDEF, vget_low_f32(vinput_scale23), 1);
+    vout3xCDEF = vmulq_lane_f32(vout3xCDEF, vget_high_f32(vinput_scale23), 1);
+    const float32x4_t vinput_scale4 = vld1q_dup_f32(&quantization_params[4].inv_scale);
+    vout4x0123 = vmulq_f32(vout4x0123, vinput_scale4);
+    vout4x4567 = vmulq_f32(vout4x4567, vinput_scale4);
+    vout4x89AB = vmulq_f32(vout4x89AB, vinput_scale4);
+    vout4xCDEF = vmulq_f32(vout4xCDEF, vinput_scale4);
+
+
+    const float32x4_t vbias0123 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x0123 = vaddq_f32(vbias0123, vout0x0123);
+    vout1x0123 = vaddq_f32(vbias0123, vout1x0123);
+    vout2x0123 = vaddq_f32(vbias0123, vout2x0123);
+    vout3x0123 = vaddq_f32(vbias0123, vout3x0123);
+    vout4x0123 = vaddq_f32(vbias0123, vout4x0123);
+    const float32x4_t vbias4567 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x4567 = vaddq_f32(vbias4567, vout0x4567);
+    vout1x4567 = vaddq_f32(vbias4567, vout1x4567);
+    vout2x4567 = vaddq_f32(vbias4567, vout2x4567);
+    vout3x4567 = vaddq_f32(vbias4567, vout3x4567);
+    vout4x4567 = vaddq_f32(vbias4567, vout4x4567);
+    const float32x4_t vbias89AB = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x89AB = vaddq_f32(vbias89AB, vout0x89AB);
+    vout1x89AB = vaddq_f32(vbias89AB, vout1x89AB);
+    vout2x89AB = vaddq_f32(vbias89AB, vout2x89AB);
+    vout3x89AB = vaddq_f32(vbias89AB, vout3x89AB);
+    vout4x89AB = vaddq_f32(vbias89AB, vout4x89AB);
+    const float32x4_t vbiasCDEF = vld1q_f32(w); w = (const float*) w + 4;
+    vout0xCDEF = vaddq_f32(vbiasCDEF, vout0xCDEF);
+    vout1xCDEF = vaddq_f32(vbiasCDEF, vout1xCDEF);
+    vout2xCDEF = vaddq_f32(vbiasCDEF, vout2xCDEF);
+    vout3xCDEF = vaddq_f32(vbiasCDEF, vout3xCDEF);
+    vout4xCDEF = vaddq_f32(vbiasCDEF, vout4xCDEF);
+
+    const float32x4_t voutput_min = vld1q_dup_f32(&params->scalar.min);
+    vout0x0123 = vmaxq_f32(vout0x0123, voutput_min);
+    vout0x4567 = vmaxq_f32(vout0x4567, voutput_min);
+    vout0x89AB = vmaxq_f32(vout0x89AB, voutput_min);
+    vout0xCDEF = vmaxq_f32(vout0xCDEF, voutput_min);
+    vout1x0123 = vmaxq_f32(vout1x0123, voutput_min);
+    vout1x4567 = vmaxq_f32(vout1x4567, voutput_min);
+    vout1x89AB = vmaxq_f32(vout1x89AB, voutput_min);
+    vout1xCDEF = vmaxq_f32(vout1xCDEF, voutput_min);
+    vout2x0123 = vmaxq_f32(vout2x0123, voutput_min);
+    vout2x4567 = vmaxq_f32(vout2x4567, voutput_min);
+    vout2x89AB = vmaxq_f32(vout2x89AB, voutput_min);
+    vout2xCDEF = vmaxq_f32(vout2xCDEF, voutput_min);
+    vout3x0123 = vmaxq_f32(vout3x0123, voutput_min);
+    vout3x4567 = vmaxq_f32(vout3x4567, voutput_min);
+    vout3x89AB = vmaxq_f32(vout3x89AB, voutput_min);
+    vout3xCDEF = vmaxq_f32(vout3xCDEF, voutput_min);
+    vout4x0123 = vmaxq_f32(vout4x0123, voutput_min);
+    vout4x4567 = vmaxq_f32(vout4x4567, voutput_min);
+    vout4x89AB = vmaxq_f32(vout4x89AB, voutput_min);
+    vout4xCDEF = vmaxq_f32(vout4xCDEF, voutput_min);
+
+    const float32x4_t voutput_max = vld1q_dup_f32(&params->scalar.max);
+    vout0x0123 = vminq_f32(vout0x0123, voutput_max);
+    vout0x4567 = vminq_f32(vout0x4567, voutput_max);
+    vout0x89AB = vminq_f32(vout0x89AB, voutput_max);
+    vout0xCDEF = vminq_f32(vout0xCDEF, voutput_max);
+    vout1x0123 = vminq_f32(vout1x0123, voutput_max);
+    vout1x4567 = vminq_f32(vout1x4567, voutput_max);
+    vout1x89AB = vminq_f32(vout1x89AB, voutput_max);
+    vout1xCDEF = vminq_f32(vout1xCDEF, voutput_max);
+    vout2x0123 = vminq_f32(vout2x0123, voutput_max);
+    vout2x4567 = vminq_f32(vout2x4567, voutput_max);
+    vout2x89AB = vminq_f32(vout2x89AB, voutput_max);
+    vout2xCDEF = vminq_f32(vout2xCDEF, voutput_max);
+    vout3x0123 = vminq_f32(vout3x0123, voutput_max);
+    vout3x4567 = vminq_f32(vout3x4567, voutput_max);
+    vout3x89AB = vminq_f32(vout3x89AB, voutput_max);
+    vout3xCDEF = vminq_f32(vout3xCDEF, voutput_max);
+    vout4x0123 = vminq_f32(vout4x0123, voutput_max);
+    vout4x4567 = vminq_f32(vout4x4567, voutput_max);
+    vout4x89AB = vminq_f32(vout4x89AB, voutput_max);
+    vout4xCDEF = vminq_f32(vout4xCDEF, voutput_max);
+
+    if XNN_LIKELY(nc >= 16) {
+      vst1q_f32(c0, vout0x0123);
+      vst1q_f32(c0 + 4, vout0x4567);
+      vst1q_f32(c0 + 8, vout0x89AB);
+      vst1q_f32(c0 + 12, vout0xCDEF);
+      vst1q_f32(c1, vout1x0123);
+      vst1q_f32(c1 + 4, vout1x4567);
+      vst1q_f32(c1 + 8, vout1x89AB);
+      vst1q_f32(c1 + 12, vout1xCDEF);
+      vst1q_f32(c2, vout2x0123);
+      vst1q_f32(c2 + 4, vout2x4567);
+      vst1q_f32(c2 + 8, vout2x89AB);
+      vst1q_f32(c2 + 12, vout2xCDEF);
+      vst1q_f32(c3, vout3x0123);
+      vst1q_f32(c3 + 4, vout3x4567);
+      vst1q_f32(c3 + 8, vout3x89AB);
+      vst1q_f32(c3 + 12, vout3xCDEF);
+      vst1q_f32(c4, vout4x0123);
+      vst1q_f32(c4 + 4, vout4x4567);
+      vst1q_f32(c4 + 8, vout4x89AB);
+      vst1q_f32(c4 + 12, vout4xCDEF);
+
+      a0 = (const int8_t*) ((uintptr_t) a0 - kc);
+      a1 = (const int8_t*) ((uintptr_t) a1 - kc);
+      a2 = (const int8_t*) ((uintptr_t) a2 - kc);
+      a3 = (const int8_t*) ((uintptr_t) a3 - kc);
+      a4 = (const int8_t*) ((uintptr_t) a4 - kc);
+
+      c0 = (float*) ((uintptr_t) c0 + cn_stride);
+      c1 = (float*) ((uintptr_t) c1 + cn_stride);
+      c2 = (float*) ((uintptr_t) c2 + cn_stride);
+      c3 = (float*) ((uintptr_t) c3 + cn_stride);
+      c4 = (float*) ((uintptr_t) c4 + cn_stride);
+
+      nc -= 16;
+    } else {
+     if (nc & 8) {
+       vst1q_f32(c0, vout0x0123); c0 += 4;
+       vout0x0123 = vout0x89AB;
+       vst1q_f32(c1, vout1x0123); c1 += 4;
+       vout1x0123 = vout1x89AB;
+       vst1q_f32(c2, vout2x0123); c2 += 4;
+       vout2x0123 = vout2x89AB;
+       vst1q_f32(c3, vout3x0123); c3 += 4;
+       vout3x0123 = vout3x89AB;
+       vst1q_f32(c4, vout4x0123); c4 += 4;
+       vout4x0123 = vout4x89AB;
+       vst1q_f32(c0, vout0x4567); c0 += 4;
+       vout0x4567 = vout0xCDEF;
+       vst1q_f32(c1, vout1x4567); c1 += 4;
+       vout1x4567 = vout1xCDEF;
+       vst1q_f32(c2, vout2x4567); c2 += 4;
+       vout2x4567 = vout2xCDEF;
+       vst1q_f32(c3, vout3x4567); c3 += 4;
+       vout3x4567 = vout3xCDEF;
+       vst1q_f32(c4, vout4x4567); c4 += 4;
+       vout4x4567 = vout4xCDEF;
+     }
+     if (nc & 4) {
+       vst1q_f32(c0, vout0x0123); c0 += 4;
+       vout0x0123 = vout0x4567;
+       vst1q_f32(c1, vout1x0123); c1 += 4;
+       vout1x0123 = vout1x4567;
+       vst1q_f32(c2, vout2x0123); c2 += 4;
+       vout2x0123 = vout2x4567;
+       vst1q_f32(c3, vout3x0123); c3 += 4;
+       vout3x0123 = vout3x4567;
+       vst1q_f32(c4, vout4x0123); c4 += 4;
+       vout4x0123 = vout4x4567;
+     }
+     float32x2_t vout0x01 = vget_low_f32(vout0x0123);
+     float32x2_t vout1x01 = vget_low_f32(vout1x0123);
+     float32x2_t vout2x01 = vget_low_f32(vout2x0123);
+     float32x2_t vout3x01 = vget_low_f32(vout3x0123);
+     float32x2_t vout4x01 = vget_low_f32(vout4x0123);
+     if (nc & 2) {
+       vst1_f32(c0, vout0x01); c0 += 2;
+       vst1_f32(c1, vout1x01); c1 += 2;
+       vst1_f32(c2, vout2x01); c2 += 2;
+       vst1_f32(c3, vout3x01); c3 += 2;
+       vst1_f32(c4, vout4x01); c4 += 2;
+       vout0x01 = vget_high_f32(vout0x0123);
+       vout1x01 = vget_high_f32(vout1x0123);
+       vout2x01 = vget_high_f32(vout2x0123);
+       vout3x01 = vget_high_f32(vout3x0123);
+       vout4x01 = vget_high_f32(vout4x0123);
+     }
+     if (nc & 1) {
+       vst1_lane_f32(c0, vout0x01, 0);
+       vst1_lane_f32(c1, vout1x01, 0);
+       vst1_lane_f32(c2, vout2x01, 0);
+       vst1_lane_f32(c3, vout3x01, 0);
+       vst1_lane_f32(c4, vout4x01, 0);
+     }
+      nc = 0;
+    }
+  } while (nc != 0);
+}

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-5x8c4-minmax-neondot.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-5x8c4-minmax-neondot.c
@@ -1,0 +1,325 @@
+// Auto-generated file. Do not edit!
+//   Template: src/qs8-gemm/c4-neondot.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2020 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+
+#include <arm_neon.h>
+
+#include "xnnpack/gemm.h"
+#include "xnnpack/math.h"
+
+
+void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_5x8c4__neondot(
+    size_t mr,
+    size_t nc,
+    size_t kc,
+    const int8_t* restrict a,
+    size_t a_stride,
+    const void* restrict w,
+    float* restrict c,
+    size_t cm_stride,
+    size_t cn_stride,
+    const union xnn_f32_qb4w_minmax_params params[restrict XNN_MIN_ELEMENTS(1)],
+    const struct xnn_qd8_quantization_params quantization_params[restrict XNN_MIN_ELEMENTS(1)]) XNN_OOB_READS
+{
+  assert(mr != 0);
+  assert(mr <= 5);
+  assert(nc != 0);
+  assert(kc != 0);
+  assert(kc % sizeof(int8_t) == 0);
+  assert(a != NULL);
+  assert(w != NULL);
+  assert(c != NULL);
+
+  kc = round_up_po2(kc, 4 * sizeof(int8_t));
+  const int8_t* a0 = a;
+  float* c0 = c;
+  const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
+  float* c1 = (float*) ((uintptr_t) c0 + cm_stride);
+  if XNN_UNPREDICTABLE(mr < 2) {
+    a1 = a0;
+    c1 = c0;
+  }
+  const int8_t* a2 = (const int8_t*) ((uintptr_t) a1 + a_stride);
+  float* c2 = (float*) ((uintptr_t) c1 + cm_stride);
+  if XNN_UNPREDICTABLE(mr <= 2) {
+    a2 = a1;
+    c2 = c1;
+  }
+  const int8_t* a3 = (const int8_t*) ((uintptr_t) a2 + a_stride);
+  float* c3 = (float*) ((uintptr_t) c2 + cm_stride);
+  if XNN_UNPREDICTABLE(mr < 4) {
+    a3 = a2;
+    c3 = c2;
+  }
+  const int8_t* a4 = (const int8_t*) ((uintptr_t) a3 + a_stride);
+  float* c4 = (float*) ((uintptr_t) c3 + cm_stride);
+  if XNN_UNPREDICTABLE(mr <= 4) {
+    a4 = a3;
+    c4 = c3;
+  }
+
+  size_t bl = params->scalar.blocksize;
+  assert(bl <= kc);
+  assert(bl != 0);
+  size_t n_blocks = kc / bl;
+  const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
+  // Loop over groups of 8 columns.
+  do {
+    // Initialize accumulators with bias. 8 bias values are loaded from the
+    // weight matrix, at the start of the group of 8 columns.
+    const float32x4_t vinput_zero_point01 = vcvtq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    const float32x4_t vksum0123 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x0123 = vmulq_lane_f32(vksum0123, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x0123 = vmulq_lane_f32(vksum0123, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksum4567 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vinput_zero_point23 = vcvtq_f32_s32(vld1q_s32(&quantization_params[2].zero_point));
+    float32x4_t vout2x0123 = vmulq_lane_f32(vksum0123, vget_low_f32(vinput_zero_point23), 0);
+    float32x4_t vout3x0123 = vmulq_lane_f32(vksum0123, vget_high_f32(vinput_zero_point23), 0);
+    float32x4_t vout2x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point23), 0);
+    float32x4_t vout3x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point23), 0);
+    const float32x4_t vinput_zero_point4 = vcvtq_f32_s32(vld1q_dup_s32(&quantization_params[4].zero_point));
+    float32x4_t vout4x0123 = vmulq_f32(vksum0123, vinput_zero_point4);
+    float32x4_t vout4x4567 = vmulq_f32(vksum4567, vinput_zero_point4);
+
+    for (size_t nb=0; nb < n_blocks; ++nb) {
+      int32x4_t vacc0x0123 = vdupq_n_s32(0);
+      int32x4_t vacc1x0123 = vdupq_n_s32(0);
+      int32x4_t vacc0x4567 = vdupq_n_s32(0);
+      int32x4_t vacc1x4567 = vdupq_n_s32(0);
+      int32x4_t vacc2x0123 = vdupq_n_s32(0);
+      int32x4_t vacc3x0123 = vdupq_n_s32(0);
+      int32x4_t vacc2x4567 = vdupq_n_s32(0);
+      int32x4_t vacc3x4567 = vdupq_n_s32(0);
+      int32x4_t vacc4x0123 = vdupq_n_s32(0);
+      int32x4_t vacc4x4567 = vdupq_n_s32(0);
+    // Inner accumulation loop along the 8 columns.
+    size_t k = bl;
+    // 2x partial unrolled loop to load 8 bytes at a time.
+    while (k >= 8 * sizeof(int8_t)) {
+      // Load a 5x8 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 8;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 8;
+      const int8x8_t va2x01234567 = vld1_s8(a2); a2 += 8;
+      const int8x8_t va3x01234567 = vld1_s8(a3); a3 += 8;
+      const int8x8_t va4x01234567 = vld1_s8(a4); a4 += 8;
+
+      // Load a 8x8 block of weights.
+      const int8x16_t vb01234567x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x0123 = vshlq_n_s8(vb01234567x0123, 4);
+      const int8x16_t vb0123x4567 = vshlq_n_s8(vb01234567x4567, 4);
+      const int8x16_t vb4567x0123 = vandq_s8(vb01234567x0123, vmask);
+      const int8x16_t vb4567x4567 = vandq_s8(vb01234567x4567, vmask);
+
+      // Multiply-accumulate: 5x8 * 8x8 --> 5x8.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb0123x0123, va2x01234567, 0);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb0123x4567, va2x01234567, 0);
+      vacc3x0123 = vdotq_lane_s32(vacc3x0123, vb0123x0123, va3x01234567, 0);
+      vacc3x4567 = vdotq_lane_s32(vacc3x4567, vb0123x4567, va3x01234567, 0);
+      vacc4x0123 = vdotq_lane_s32(vacc4x0123, vb0123x0123, va4x01234567, 0);
+      vacc4x4567 = vdotq_lane_s32(vacc4x4567, vb0123x4567, va4x01234567, 0);
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb4567x0123, va0x01234567, 1);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb4567x4567, va0x01234567, 1);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb4567x0123, va1x01234567, 1);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb4567x4567, va1x01234567, 1);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb4567x0123, va2x01234567, 1);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb4567x4567, va2x01234567, 1);
+      vacc3x0123 = vdotq_lane_s32(vacc3x0123, vb4567x0123, va3x01234567, 1);
+      vacc3x4567 = vdotq_lane_s32(vacc3x4567, vb4567x4567, va3x01234567, 1);
+      vacc4x0123 = vdotq_lane_s32(vacc4x0123, vb4567x0123, va4x01234567, 1);
+      vacc4x4567 = vdotq_lane_s32(vacc4x4567, vb4567x4567, va4x01234567, 1);
+
+      k -= 8 * sizeof(int8_t);
+    }
+    // Handle up to 4 final positions of `k`
+    if XNN_UNLIKELY(k != 0) {
+      // Load a 5x4 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 4;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 4;
+      const int8x8_t va2x01234567 = vld1_s8(a2); a2 += 4;
+      const int8x8_t va3x01234567 = vld1_s8(a3); a3 += 4;
+      const int8x8_t va4x01234567 = vld1_s8(a4); a4 += 4;
+
+      // Load a 4x8 block of weights.
+      const int8x16_t vb0123x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+
+      // Multiply-accumulate: 5x4 * 4x8 --> 5x8.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb0123x0123, va2x01234567, 0);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb0123x4567, va2x01234567, 0);
+      vacc3x0123 = vdotq_lane_s32(vacc3x0123, vb0123x0123, va3x01234567, 0);
+      vacc3x4567 = vdotq_lane_s32(vacc3x4567, vb0123x4567, va3x01234567, 0);
+      vacc4x0123 = vdotq_lane_s32(vacc4x0123, vb0123x0123, va4x01234567, 0);
+      vacc4x4567 = vdotq_lane_s32(vacc4x4567, vb0123x4567, va4x01234567, 0);
+    }
+    const float32x4_t vfilter_output_scale0123 = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scale4567 = vld1q_f32(w); w = (const float*) w + 4;
+
+    float32x4_t vf0x0123 = vcvtq_f32_s32(vacc0x0123);
+    float32x4_t vf1x0123 = vcvtq_f32_s32(vacc1x0123);
+    vout0x0123 = vfmaq_f32(vout0x0123, vf0x0123, vfilter_output_scale0123);
+    vout1x0123 = vfmaq_f32(vout1x0123, vf1x0123, vfilter_output_scale0123);
+    float32x4_t vf0x4567 = vcvtq_f32_s32(vacc0x4567);
+    float32x4_t vf1x4567 = vcvtq_f32_s32(vacc1x4567);
+    vout0x4567 = vfmaq_f32(vout0x4567, vf0x4567, vfilter_output_scale4567);
+    vout1x4567 = vfmaq_f32(vout1x4567, vf1x4567, vfilter_output_scale4567);
+    float32x4_t vf2x0123 = vcvtq_f32_s32(vacc2x0123);
+    float32x4_t vf3x0123 = vcvtq_f32_s32(vacc3x0123);
+    vout2x0123 = vfmaq_f32(vout2x0123, vf2x0123, vfilter_output_scale0123);
+    vout3x0123 = vfmaq_f32(vout3x0123, vf3x0123, vfilter_output_scale0123);
+    float32x4_t vf2x4567 = vcvtq_f32_s32(vacc2x4567);
+    float32x4_t vf3x4567 = vcvtq_f32_s32(vacc3x4567);
+    vout2x4567 = vfmaq_f32(vout2x4567, vf2x4567, vfilter_output_scale4567);
+    vout3x4567 = vfmaq_f32(vout3x4567, vf3x4567, vfilter_output_scale4567);
+    float32x4_t vf4x0123 = vcvtq_f32_s32(vacc4x0123);
+    vout4x0123 = vfmaq_f32(vout4x0123, vf4x0123, vfilter_output_scale0123);
+    float32x4_t vf4x4567 = vcvtq_f32_s32(vacc4x4567);
+    vout4x4567 = vfmaq_f32(vout4x4567, vf4x4567, vfilter_output_scale4567);
+    }
+
+    const float32x4_t one_sixteenth = vdupq_n_f32(1/16.0);
+    vout0x0123 = vmulq_f32(vout0x0123, one_sixteenth);
+    vout0x4567 = vmulq_f32(vout0x4567, one_sixteenth);
+    vout1x0123 = vmulq_f32(vout1x0123, one_sixteenth);
+    vout1x4567 = vmulq_f32(vout1x4567, one_sixteenth);
+    vout2x0123 = vmulq_f32(vout2x0123, one_sixteenth);
+    vout2x4567 = vmulq_f32(vout2x4567, one_sixteenth);
+    vout3x0123 = vmulq_f32(vout3x0123, one_sixteenth);
+    vout3x4567 = vmulq_f32(vout3x4567, one_sixteenth);
+    vout4x0123 = vmulq_f32(vout4x0123, one_sixteenth);
+    vout4x4567 = vmulq_f32(vout4x4567, one_sixteenth);
+    const float32x4_t vinput_scale01 = vreinterpretq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    vout0x0123 = vmulq_lane_f32(vout0x0123, vget_low_f32(vinput_scale01), 1);
+    vout1x0123 = vmulq_lane_f32(vout1x0123, vget_high_f32(vinput_scale01), 1);
+    vout0x4567 = vmulq_lane_f32(vout0x4567, vget_low_f32(vinput_scale01), 1);
+    vout1x4567 = vmulq_lane_f32(vout1x4567, vget_high_f32(vinput_scale01), 1);
+    const float32x4_t vinput_scale23 = vreinterpretq_f32_s32(vld1q_s32(&quantization_params[2].zero_point));
+    vout2x0123 = vmulq_lane_f32(vout2x0123, vget_low_f32(vinput_scale23), 1);
+    vout3x0123 = vmulq_lane_f32(vout3x0123, vget_high_f32(vinput_scale23), 1);
+    vout2x4567 = vmulq_lane_f32(vout2x4567, vget_low_f32(vinput_scale23), 1);
+    vout3x4567 = vmulq_lane_f32(vout3x4567, vget_high_f32(vinput_scale23), 1);
+    const float32x4_t vinput_scale4 = vld1q_dup_f32(&quantization_params[4].inv_scale);
+    vout4x0123 = vmulq_f32(vout4x0123, vinput_scale4);
+    vout4x4567 = vmulq_f32(vout4x4567, vinput_scale4);
+
+
+    const float32x4_t vbias0123 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x0123 = vaddq_f32(vbias0123, vout0x0123);
+    vout1x0123 = vaddq_f32(vbias0123, vout1x0123);
+    vout2x0123 = vaddq_f32(vbias0123, vout2x0123);
+    vout3x0123 = vaddq_f32(vbias0123, vout3x0123);
+    vout4x0123 = vaddq_f32(vbias0123, vout4x0123);
+    const float32x4_t vbias4567 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x4567 = vaddq_f32(vbias4567, vout0x4567);
+    vout1x4567 = vaddq_f32(vbias4567, vout1x4567);
+    vout2x4567 = vaddq_f32(vbias4567, vout2x4567);
+    vout3x4567 = vaddq_f32(vbias4567, vout3x4567);
+    vout4x4567 = vaddq_f32(vbias4567, vout4x4567);
+
+    const float32x4_t voutput_min = vld1q_dup_f32(&params->scalar.min);
+    vout0x0123 = vmaxq_f32(vout0x0123, voutput_min);
+    vout0x4567 = vmaxq_f32(vout0x4567, voutput_min);
+    vout1x0123 = vmaxq_f32(vout1x0123, voutput_min);
+    vout1x4567 = vmaxq_f32(vout1x4567, voutput_min);
+    vout2x0123 = vmaxq_f32(vout2x0123, voutput_min);
+    vout2x4567 = vmaxq_f32(vout2x4567, voutput_min);
+    vout3x0123 = vmaxq_f32(vout3x0123, voutput_min);
+    vout3x4567 = vmaxq_f32(vout3x4567, voutput_min);
+    vout4x0123 = vmaxq_f32(vout4x0123, voutput_min);
+    vout4x4567 = vmaxq_f32(vout4x4567, voutput_min);
+
+    const float32x4_t voutput_max = vld1q_dup_f32(&params->scalar.max);
+    vout0x0123 = vminq_f32(vout0x0123, voutput_max);
+    vout0x4567 = vminq_f32(vout0x4567, voutput_max);
+    vout1x0123 = vminq_f32(vout1x0123, voutput_max);
+    vout1x4567 = vminq_f32(vout1x4567, voutput_max);
+    vout2x0123 = vminq_f32(vout2x0123, voutput_max);
+    vout2x4567 = vminq_f32(vout2x4567, voutput_max);
+    vout3x0123 = vminq_f32(vout3x0123, voutput_max);
+    vout3x4567 = vminq_f32(vout3x4567, voutput_max);
+    vout4x0123 = vminq_f32(vout4x0123, voutput_max);
+    vout4x4567 = vminq_f32(vout4x4567, voutput_max);
+
+    if XNN_LIKELY(nc >= 8) {
+      vst1q_f32(c0, vout0x0123);
+      vst1q_f32(c0 + 4, vout0x4567);
+      vst1q_f32(c1, vout1x0123);
+      vst1q_f32(c1 + 4, vout1x4567);
+      vst1q_f32(c2, vout2x0123);
+      vst1q_f32(c2 + 4, vout2x4567);
+      vst1q_f32(c3, vout3x0123);
+      vst1q_f32(c3 + 4, vout3x4567);
+      vst1q_f32(c4, vout4x0123);
+      vst1q_f32(c4 + 4, vout4x4567);
+
+      a0 = (const int8_t*) ((uintptr_t) a0 - kc);
+      a1 = (const int8_t*) ((uintptr_t) a1 - kc);
+      a2 = (const int8_t*) ((uintptr_t) a2 - kc);
+      a3 = (const int8_t*) ((uintptr_t) a3 - kc);
+      a4 = (const int8_t*) ((uintptr_t) a4 - kc);
+
+      c0 = (float*) ((uintptr_t) c0 + cn_stride);
+      c1 = (float*) ((uintptr_t) c1 + cn_stride);
+      c2 = (float*) ((uintptr_t) c2 + cn_stride);
+      c3 = (float*) ((uintptr_t) c3 + cn_stride);
+      c4 = (float*) ((uintptr_t) c4 + cn_stride);
+
+      nc -= 8;
+    } else {
+     if (nc & 4) {
+       vst1q_f32(c0, vout0x0123); c0 += 4;
+       vout0x0123 = vout0x4567;
+       vst1q_f32(c1, vout1x0123); c1 += 4;
+       vout1x0123 = vout1x4567;
+       vst1q_f32(c2, vout2x0123); c2 += 4;
+       vout2x0123 = vout2x4567;
+       vst1q_f32(c3, vout3x0123); c3 += 4;
+       vout3x0123 = vout3x4567;
+       vst1q_f32(c4, vout4x0123); c4 += 4;
+       vout4x0123 = vout4x4567;
+     }
+     float32x2_t vout0x01 = vget_low_f32(vout0x0123);
+     float32x2_t vout1x01 = vget_low_f32(vout1x0123);
+     float32x2_t vout2x01 = vget_low_f32(vout2x0123);
+     float32x2_t vout3x01 = vget_low_f32(vout3x0123);
+     float32x2_t vout4x01 = vget_low_f32(vout4x0123);
+     if (nc & 2) {
+       vst1_f32(c0, vout0x01); c0 += 2;
+       vst1_f32(c1, vout1x01); c1 += 2;
+       vst1_f32(c2, vout2x01); c2 += 2;
+       vst1_f32(c3, vout3x01); c3 += 2;
+       vst1_f32(c4, vout4x01); c4 += 2;
+       vout0x01 = vget_high_f32(vout0x0123);
+       vout1x01 = vget_high_f32(vout1x0123);
+       vout2x01 = vget_high_f32(vout2x0123);
+       vout3x01 = vget_high_f32(vout3x0123);
+       vout4x01 = vget_high_f32(vout4x0123);
+     }
+     if (nc & 1) {
+       vst1_lane_f32(c0, vout0x01, 0);
+       vst1_lane_f32(c1, vout1x01, 0);
+       vst1_lane_f32(c2, vout2x01, 0);
+       vst1_lane_f32(c3, vout3x01, 0);
+       vst1_lane_f32(c4, vout4x01, 0);
+     }
+      nc = 0;
+    }
+  } while (nc != 0);
+}

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-6x16c4-minmax-neondot.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-6x16c4-minmax-neondot.c
@@ -1,0 +1,563 @@
+// Auto-generated file. Do not edit!
+//   Template: src/qs8-gemm/c4-neondot.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2020 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+
+#include <arm_neon.h>
+
+#include "xnnpack/gemm.h"
+#include "xnnpack/math.h"
+
+
+void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_6x16c4__neondot(
+    size_t mr,
+    size_t nc,
+    size_t kc,
+    const int8_t* restrict a,
+    size_t a_stride,
+    const void* restrict w,
+    float* restrict c,
+    size_t cm_stride,
+    size_t cn_stride,
+    const union xnn_f32_qb4w_minmax_params params[restrict XNN_MIN_ELEMENTS(1)],
+    const struct xnn_qd8_quantization_params quantization_params[restrict XNN_MIN_ELEMENTS(1)]) XNN_OOB_READS
+{
+  assert(mr != 0);
+  assert(mr <= 6);
+  assert(nc != 0);
+  assert(kc != 0);
+  assert(kc % sizeof(int8_t) == 0);
+  assert(a != NULL);
+  assert(w != NULL);
+  assert(c != NULL);
+
+  kc = round_up_po2(kc, 4 * sizeof(int8_t));
+  const int8_t* a0 = a;
+  float* c0 = c;
+  const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
+  float* c1 = (float*) ((uintptr_t) c0 + cm_stride);
+  if XNN_UNPREDICTABLE(mr < 2) {
+    a1 = a0;
+    c1 = c0;
+  }
+  const int8_t* a2 = (const int8_t*) ((uintptr_t) a1 + a_stride);
+  float* c2 = (float*) ((uintptr_t) c1 + cm_stride);
+  if XNN_UNPREDICTABLE(mr <= 2) {
+    a2 = a1;
+    c2 = c1;
+  }
+  const int8_t* a3 = (const int8_t*) ((uintptr_t) a2 + a_stride);
+  float* c3 = (float*) ((uintptr_t) c2 + cm_stride);
+  if XNN_UNPREDICTABLE(mr < 4) {
+    a3 = a2;
+    c3 = c2;
+  }
+  const int8_t* a4 = (const int8_t*) ((uintptr_t) a3 + a_stride);
+  float* c4 = (float*) ((uintptr_t) c3 + cm_stride);
+  if XNN_UNPREDICTABLE(mr <= 4) {
+    a4 = a3;
+    c4 = c3;
+  }
+  const int8_t* a5 = (const int8_t*) ((uintptr_t) a4 + a_stride);
+  float* c5 = (float*) ((uintptr_t) c4 + cm_stride);
+  if XNN_UNPREDICTABLE(mr != 6) {
+    a5 = a4;
+    c5 = c4;
+  }
+
+  size_t bl = params->scalar.blocksize;
+  assert(bl <= kc);
+  assert(bl != 0);
+  size_t n_blocks = kc / bl;
+  const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
+  // Loop over groups of 16 columns.
+  do {
+    // Initialize accumulators with bias. 16 bias values are loaded from the
+    // weight matrix, at the start of the group of 16 columns.
+    const float32x4_t vinput_zero_point01 = vcvtq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    const float32x4_t vksum0123 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x0123 = vmulq_lane_f32(vksum0123, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x0123 = vmulq_lane_f32(vksum0123, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksum4567 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksum89AB = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x89AB = vmulq_lane_f32(vksum89AB, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x89AB = vmulq_lane_f32(vksum89AB, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksumCDEF = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0xCDEF = vmulq_lane_f32(vksumCDEF, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vinput_zero_point23 = vcvtq_f32_s32(vld1q_s32(&quantization_params[2].zero_point));
+    float32x4_t vout2x0123 = vmulq_lane_f32(vksum0123, vget_low_f32(vinput_zero_point23), 0);
+    float32x4_t vout3x0123 = vmulq_lane_f32(vksum0123, vget_high_f32(vinput_zero_point23), 0);
+    float32x4_t vout2x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point23), 0);
+    float32x4_t vout3x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point23), 0);
+    float32x4_t vout2x89AB = vmulq_lane_f32(vksum89AB, vget_low_f32(vinput_zero_point23), 0);
+    float32x4_t vout3x89AB = vmulq_lane_f32(vksum89AB, vget_high_f32(vinput_zero_point23), 0);
+    float32x4_t vout2xCDEF = vmulq_lane_f32(vksumCDEF, vget_low_f32(vinput_zero_point23), 0);
+    float32x4_t vout3xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vinput_zero_point23), 0);
+    const float32x4_t vinput_zero_point45 = vcvtq_f32_s32(vld1q_s32(&quantization_params[4].zero_point));
+    float32x4_t vout4x0123 = vmulq_lane_f32(vksum0123, vget_low_f32(vinput_zero_point45), 0);
+    float32x4_t vout5x0123 = vmulq_lane_f32(vksum0123, vget_high_f32(vinput_zero_point45), 0);
+    float32x4_t vout4x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point45), 0);
+    float32x4_t vout5x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point45), 0);
+    float32x4_t vout4x89AB = vmulq_lane_f32(vksum89AB, vget_low_f32(vinput_zero_point45), 0);
+    float32x4_t vout5x89AB = vmulq_lane_f32(vksum89AB, vget_high_f32(vinput_zero_point45), 0);
+    float32x4_t vout4xCDEF = vmulq_lane_f32(vksumCDEF, vget_low_f32(vinput_zero_point45), 0);
+    float32x4_t vout5xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vinput_zero_point45), 0);
+
+    for (size_t nb=0; nb < n_blocks; ++nb) {
+      int32x4_t vacc0x0123 = vdupq_n_s32(0);
+      int32x4_t vacc1x0123 = vdupq_n_s32(0);
+      int32x4_t vacc0x4567 = vdupq_n_s32(0);
+      int32x4_t vacc1x4567 = vdupq_n_s32(0);
+      int32x4_t vacc0x89AB = vdupq_n_s32(0);
+      int32x4_t vacc1x89AB = vdupq_n_s32(0);
+      int32x4_t vacc0xCDEF = vdupq_n_s32(0);
+      int32x4_t vacc1xCDEF = vdupq_n_s32(0);
+      int32x4_t vacc2x0123 = vdupq_n_s32(0);
+      int32x4_t vacc3x0123 = vdupq_n_s32(0);
+      int32x4_t vacc2x4567 = vdupq_n_s32(0);
+      int32x4_t vacc3x4567 = vdupq_n_s32(0);
+      int32x4_t vacc2x89AB = vdupq_n_s32(0);
+      int32x4_t vacc3x89AB = vdupq_n_s32(0);
+      int32x4_t vacc2xCDEF = vdupq_n_s32(0);
+      int32x4_t vacc3xCDEF = vdupq_n_s32(0);
+      int32x4_t vacc4x0123 = vdupq_n_s32(0);
+      int32x4_t vacc5x0123 = vdupq_n_s32(0);
+      int32x4_t vacc4x4567 = vdupq_n_s32(0);
+      int32x4_t vacc5x4567 = vdupq_n_s32(0);
+      int32x4_t vacc4x89AB = vdupq_n_s32(0);
+      int32x4_t vacc5x89AB = vdupq_n_s32(0);
+      int32x4_t vacc4xCDEF = vdupq_n_s32(0);
+      int32x4_t vacc5xCDEF = vdupq_n_s32(0);
+    // Inner accumulation loop along the 16 columns.
+    size_t k = bl;
+    // 2x partial unrolled loop to load 8 bytes at a time.
+    while (k >= 8 * sizeof(int8_t)) {
+      // Load a 6x8 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 8;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 8;
+      const int8x8_t va2x01234567 = vld1_s8(a2); a2 += 8;
+      const int8x8_t va3x01234567 = vld1_s8(a3); a3 += 8;
+      const int8x8_t va4x01234567 = vld1_s8(a4); a4 += 8;
+      const int8x8_t va5x01234567 = vld1_s8(a5); a5 += 8;
+
+      // Load a 8x16 block of weights.
+      const int8x16_t vb01234567x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567x89AB = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567xCDEF = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x0123 = vshlq_n_s8(vb01234567x0123, 4);
+      const int8x16_t vb0123x4567 = vshlq_n_s8(vb01234567x4567, 4);
+      const int8x16_t vb0123x89AB = vshlq_n_s8(vb01234567x89AB, 4);
+      const int8x16_t vb0123xCDEF = vshlq_n_s8(vb01234567xCDEF, 4);
+      const int8x16_t vb4567x0123 = vandq_s8(vb01234567x0123, vmask);
+      const int8x16_t vb4567x4567 = vandq_s8(vb01234567x4567, vmask);
+      const int8x16_t vb4567x89AB = vandq_s8(vb01234567x89AB, vmask);
+      const int8x16_t vb4567xCDEF = vandq_s8(vb01234567xCDEF, vmask);
+
+      // Multiply-accumulate: 6x8 * 8x16 --> 6x16.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc0x89AB = vdotq_lane_s32(vacc0x89AB, vb0123x89AB, va0x01234567, 0);
+      vacc0xCDEF = vdotq_lane_s32(vacc0xCDEF, vb0123xCDEF, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+      vacc1x89AB = vdotq_lane_s32(vacc1x89AB, vb0123x89AB, va1x01234567, 0);
+      vacc1xCDEF = vdotq_lane_s32(vacc1xCDEF, vb0123xCDEF, va1x01234567, 0);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb0123x0123, va2x01234567, 0);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb0123x4567, va2x01234567, 0);
+      vacc2x89AB = vdotq_lane_s32(vacc2x89AB, vb0123x89AB, va2x01234567, 0);
+      vacc2xCDEF = vdotq_lane_s32(vacc2xCDEF, vb0123xCDEF, va2x01234567, 0);
+      vacc3x0123 = vdotq_lane_s32(vacc3x0123, vb0123x0123, va3x01234567, 0);
+      vacc3x4567 = vdotq_lane_s32(vacc3x4567, vb0123x4567, va3x01234567, 0);
+      vacc3x89AB = vdotq_lane_s32(vacc3x89AB, vb0123x89AB, va3x01234567, 0);
+      vacc3xCDEF = vdotq_lane_s32(vacc3xCDEF, vb0123xCDEF, va3x01234567, 0);
+      vacc4x0123 = vdotq_lane_s32(vacc4x0123, vb0123x0123, va4x01234567, 0);
+      vacc4x4567 = vdotq_lane_s32(vacc4x4567, vb0123x4567, va4x01234567, 0);
+      vacc4x89AB = vdotq_lane_s32(vacc4x89AB, vb0123x89AB, va4x01234567, 0);
+      vacc4xCDEF = vdotq_lane_s32(vacc4xCDEF, vb0123xCDEF, va4x01234567, 0);
+      vacc5x0123 = vdotq_lane_s32(vacc5x0123, vb0123x0123, va5x01234567, 0);
+      vacc5x4567 = vdotq_lane_s32(vacc5x4567, vb0123x4567, va5x01234567, 0);
+      vacc5x89AB = vdotq_lane_s32(vacc5x89AB, vb0123x89AB, va5x01234567, 0);
+      vacc5xCDEF = vdotq_lane_s32(vacc5xCDEF, vb0123xCDEF, va5x01234567, 0);
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb4567x0123, va0x01234567, 1);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb4567x4567, va0x01234567, 1);
+      vacc0x89AB = vdotq_lane_s32(vacc0x89AB, vb4567x89AB, va0x01234567, 1);
+      vacc0xCDEF = vdotq_lane_s32(vacc0xCDEF, vb4567xCDEF, va0x01234567, 1);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb4567x0123, va1x01234567, 1);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb4567x4567, va1x01234567, 1);
+      vacc1x89AB = vdotq_lane_s32(vacc1x89AB, vb4567x89AB, va1x01234567, 1);
+      vacc1xCDEF = vdotq_lane_s32(vacc1xCDEF, vb4567xCDEF, va1x01234567, 1);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb4567x0123, va2x01234567, 1);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb4567x4567, va2x01234567, 1);
+      vacc2x89AB = vdotq_lane_s32(vacc2x89AB, vb4567x89AB, va2x01234567, 1);
+      vacc2xCDEF = vdotq_lane_s32(vacc2xCDEF, vb4567xCDEF, va2x01234567, 1);
+      vacc3x0123 = vdotq_lane_s32(vacc3x0123, vb4567x0123, va3x01234567, 1);
+      vacc3x4567 = vdotq_lane_s32(vacc3x4567, vb4567x4567, va3x01234567, 1);
+      vacc3x89AB = vdotq_lane_s32(vacc3x89AB, vb4567x89AB, va3x01234567, 1);
+      vacc3xCDEF = vdotq_lane_s32(vacc3xCDEF, vb4567xCDEF, va3x01234567, 1);
+      vacc4x0123 = vdotq_lane_s32(vacc4x0123, vb4567x0123, va4x01234567, 1);
+      vacc4x4567 = vdotq_lane_s32(vacc4x4567, vb4567x4567, va4x01234567, 1);
+      vacc4x89AB = vdotq_lane_s32(vacc4x89AB, vb4567x89AB, va4x01234567, 1);
+      vacc4xCDEF = vdotq_lane_s32(vacc4xCDEF, vb4567xCDEF, va4x01234567, 1);
+      vacc5x0123 = vdotq_lane_s32(vacc5x0123, vb4567x0123, va5x01234567, 1);
+      vacc5x4567 = vdotq_lane_s32(vacc5x4567, vb4567x4567, va5x01234567, 1);
+      vacc5x89AB = vdotq_lane_s32(vacc5x89AB, vb4567x89AB, va5x01234567, 1);
+      vacc5xCDEF = vdotq_lane_s32(vacc5xCDEF, vb4567xCDEF, va5x01234567, 1);
+
+      k -= 8 * sizeof(int8_t);
+    }
+    // Handle up to 4 final positions of `k`
+    if XNN_UNLIKELY(k != 0) {
+      // Load a 6x4 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 4;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 4;
+      const int8x8_t va2x01234567 = vld1_s8(a2); a2 += 4;
+      const int8x8_t va3x01234567 = vld1_s8(a3); a3 += 4;
+      const int8x8_t va4x01234567 = vld1_s8(a4); a4 += 4;
+      const int8x8_t va5x01234567 = vld1_s8(a5); a5 += 4;
+
+      // Load a 4x16 block of weights.
+      const int8x16_t vb0123x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x89AB = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123xCDEF = vld1q_s8(w); w = (const int8_t*) w + 16;
+
+      // Multiply-accumulate: 6x4 * 4x16 --> 6x16.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc0x89AB = vdotq_lane_s32(vacc0x89AB, vb0123x89AB, va0x01234567, 0);
+      vacc0xCDEF = vdotq_lane_s32(vacc0xCDEF, vb0123xCDEF, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+      vacc1x89AB = vdotq_lane_s32(vacc1x89AB, vb0123x89AB, va1x01234567, 0);
+      vacc1xCDEF = vdotq_lane_s32(vacc1xCDEF, vb0123xCDEF, va1x01234567, 0);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb0123x0123, va2x01234567, 0);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb0123x4567, va2x01234567, 0);
+      vacc2x89AB = vdotq_lane_s32(vacc2x89AB, vb0123x89AB, va2x01234567, 0);
+      vacc2xCDEF = vdotq_lane_s32(vacc2xCDEF, vb0123xCDEF, va2x01234567, 0);
+      vacc3x0123 = vdotq_lane_s32(vacc3x0123, vb0123x0123, va3x01234567, 0);
+      vacc3x4567 = vdotq_lane_s32(vacc3x4567, vb0123x4567, va3x01234567, 0);
+      vacc3x89AB = vdotq_lane_s32(vacc3x89AB, vb0123x89AB, va3x01234567, 0);
+      vacc3xCDEF = vdotq_lane_s32(vacc3xCDEF, vb0123xCDEF, va3x01234567, 0);
+      vacc4x0123 = vdotq_lane_s32(vacc4x0123, vb0123x0123, va4x01234567, 0);
+      vacc4x4567 = vdotq_lane_s32(vacc4x4567, vb0123x4567, va4x01234567, 0);
+      vacc4x89AB = vdotq_lane_s32(vacc4x89AB, vb0123x89AB, va4x01234567, 0);
+      vacc4xCDEF = vdotq_lane_s32(vacc4xCDEF, vb0123xCDEF, va4x01234567, 0);
+      vacc5x0123 = vdotq_lane_s32(vacc5x0123, vb0123x0123, va5x01234567, 0);
+      vacc5x4567 = vdotq_lane_s32(vacc5x4567, vb0123x4567, va5x01234567, 0);
+      vacc5x89AB = vdotq_lane_s32(vacc5x89AB, vb0123x89AB, va5x01234567, 0);
+      vacc5xCDEF = vdotq_lane_s32(vacc5xCDEF, vb0123xCDEF, va5x01234567, 0);
+    }
+    const float32x4_t vfilter_output_scale0123 = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scale4567 = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scale89AB = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scaleCDEF = vld1q_f32(w); w = (const float*) w + 4;
+
+    float32x4_t vf0x0123 = vcvtq_f32_s32(vacc0x0123);
+    float32x4_t vf1x0123 = vcvtq_f32_s32(vacc1x0123);
+    vout0x0123 = vfmaq_f32(vout0x0123, vf0x0123, vfilter_output_scale0123);
+    vout1x0123 = vfmaq_f32(vout1x0123, vf1x0123, vfilter_output_scale0123);
+    float32x4_t vf0x4567 = vcvtq_f32_s32(vacc0x4567);
+    float32x4_t vf1x4567 = vcvtq_f32_s32(vacc1x4567);
+    vout0x4567 = vfmaq_f32(vout0x4567, vf0x4567, vfilter_output_scale4567);
+    vout1x4567 = vfmaq_f32(vout1x4567, vf1x4567, vfilter_output_scale4567);
+    float32x4_t vf0x89AB = vcvtq_f32_s32(vacc0x89AB);
+    float32x4_t vf1x89AB = vcvtq_f32_s32(vacc1x89AB);
+    vout0x89AB = vfmaq_f32(vout0x89AB, vf0x89AB, vfilter_output_scale89AB);
+    vout1x89AB = vfmaq_f32(vout1x89AB, vf1x89AB, vfilter_output_scale89AB);
+    float32x4_t vf0xCDEF = vcvtq_f32_s32(vacc0xCDEF);
+    float32x4_t vf1xCDEF = vcvtq_f32_s32(vacc1xCDEF);
+    vout0xCDEF = vfmaq_f32(vout0xCDEF, vf0xCDEF, vfilter_output_scaleCDEF);
+    vout1xCDEF = vfmaq_f32(vout1xCDEF, vf1xCDEF, vfilter_output_scaleCDEF);
+    float32x4_t vf2x0123 = vcvtq_f32_s32(vacc2x0123);
+    float32x4_t vf3x0123 = vcvtq_f32_s32(vacc3x0123);
+    vout2x0123 = vfmaq_f32(vout2x0123, vf2x0123, vfilter_output_scale0123);
+    vout3x0123 = vfmaq_f32(vout3x0123, vf3x0123, vfilter_output_scale0123);
+    float32x4_t vf2x4567 = vcvtq_f32_s32(vacc2x4567);
+    float32x4_t vf3x4567 = vcvtq_f32_s32(vacc3x4567);
+    vout2x4567 = vfmaq_f32(vout2x4567, vf2x4567, vfilter_output_scale4567);
+    vout3x4567 = vfmaq_f32(vout3x4567, vf3x4567, vfilter_output_scale4567);
+    float32x4_t vf2x89AB = vcvtq_f32_s32(vacc2x89AB);
+    float32x4_t vf3x89AB = vcvtq_f32_s32(vacc3x89AB);
+    vout2x89AB = vfmaq_f32(vout2x89AB, vf2x89AB, vfilter_output_scale89AB);
+    vout3x89AB = vfmaq_f32(vout3x89AB, vf3x89AB, vfilter_output_scale89AB);
+    float32x4_t vf2xCDEF = vcvtq_f32_s32(vacc2xCDEF);
+    float32x4_t vf3xCDEF = vcvtq_f32_s32(vacc3xCDEF);
+    vout2xCDEF = vfmaq_f32(vout2xCDEF, vf2xCDEF, vfilter_output_scaleCDEF);
+    vout3xCDEF = vfmaq_f32(vout3xCDEF, vf3xCDEF, vfilter_output_scaleCDEF);
+    float32x4_t vf4x0123 = vcvtq_f32_s32(vacc4x0123);
+    float32x4_t vf5x0123 = vcvtq_f32_s32(vacc5x0123);
+    vout4x0123 = vfmaq_f32(vout4x0123, vf4x0123, vfilter_output_scale0123);
+    vout5x0123 = vfmaq_f32(vout5x0123, vf5x0123, vfilter_output_scale0123);
+    float32x4_t vf4x4567 = vcvtq_f32_s32(vacc4x4567);
+    float32x4_t vf5x4567 = vcvtq_f32_s32(vacc5x4567);
+    vout4x4567 = vfmaq_f32(vout4x4567, vf4x4567, vfilter_output_scale4567);
+    vout5x4567 = vfmaq_f32(vout5x4567, vf5x4567, vfilter_output_scale4567);
+    float32x4_t vf4x89AB = vcvtq_f32_s32(vacc4x89AB);
+    float32x4_t vf5x89AB = vcvtq_f32_s32(vacc5x89AB);
+    vout4x89AB = vfmaq_f32(vout4x89AB, vf4x89AB, vfilter_output_scale89AB);
+    vout5x89AB = vfmaq_f32(vout5x89AB, vf5x89AB, vfilter_output_scale89AB);
+    float32x4_t vf4xCDEF = vcvtq_f32_s32(vacc4xCDEF);
+    float32x4_t vf5xCDEF = vcvtq_f32_s32(vacc5xCDEF);
+    vout4xCDEF = vfmaq_f32(vout4xCDEF, vf4xCDEF, vfilter_output_scaleCDEF);
+    vout5xCDEF = vfmaq_f32(vout5xCDEF, vf5xCDEF, vfilter_output_scaleCDEF);
+    }
+
+    const float32x4_t one_sixteenth = vdupq_n_f32(1/16.0);
+    vout0x0123 = vmulq_f32(vout0x0123, one_sixteenth);
+    vout0x4567 = vmulq_f32(vout0x4567, one_sixteenth);
+    vout0x89AB = vmulq_f32(vout0x89AB, one_sixteenth);
+    vout0xCDEF = vmulq_f32(vout0xCDEF, one_sixteenth);
+    vout1x0123 = vmulq_f32(vout1x0123, one_sixteenth);
+    vout1x4567 = vmulq_f32(vout1x4567, one_sixteenth);
+    vout1x89AB = vmulq_f32(vout1x89AB, one_sixteenth);
+    vout1xCDEF = vmulq_f32(vout1xCDEF, one_sixteenth);
+    vout2x0123 = vmulq_f32(vout2x0123, one_sixteenth);
+    vout2x4567 = vmulq_f32(vout2x4567, one_sixteenth);
+    vout2x89AB = vmulq_f32(vout2x89AB, one_sixteenth);
+    vout2xCDEF = vmulq_f32(vout2xCDEF, one_sixteenth);
+    vout3x0123 = vmulq_f32(vout3x0123, one_sixteenth);
+    vout3x4567 = vmulq_f32(vout3x4567, one_sixteenth);
+    vout3x89AB = vmulq_f32(vout3x89AB, one_sixteenth);
+    vout3xCDEF = vmulq_f32(vout3xCDEF, one_sixteenth);
+    vout4x0123 = vmulq_f32(vout4x0123, one_sixteenth);
+    vout4x4567 = vmulq_f32(vout4x4567, one_sixteenth);
+    vout4x89AB = vmulq_f32(vout4x89AB, one_sixteenth);
+    vout4xCDEF = vmulq_f32(vout4xCDEF, one_sixteenth);
+    vout5x0123 = vmulq_f32(vout5x0123, one_sixteenth);
+    vout5x4567 = vmulq_f32(vout5x4567, one_sixteenth);
+    vout5x89AB = vmulq_f32(vout5x89AB, one_sixteenth);
+    vout5xCDEF = vmulq_f32(vout5xCDEF, one_sixteenth);
+    const float32x4_t vinput_scale01 = vreinterpretq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    vout0x0123 = vmulq_lane_f32(vout0x0123, vget_low_f32(vinput_scale01), 1);
+    vout1x0123 = vmulq_lane_f32(vout1x0123, vget_high_f32(vinput_scale01), 1);
+    vout0x4567 = vmulq_lane_f32(vout0x4567, vget_low_f32(vinput_scale01), 1);
+    vout1x4567 = vmulq_lane_f32(vout1x4567, vget_high_f32(vinput_scale01), 1);
+    vout0x89AB = vmulq_lane_f32(vout0x89AB, vget_low_f32(vinput_scale01), 1);
+    vout1x89AB = vmulq_lane_f32(vout1x89AB, vget_high_f32(vinput_scale01), 1);
+    vout0xCDEF = vmulq_lane_f32(vout0xCDEF, vget_low_f32(vinput_scale01), 1);
+    vout1xCDEF = vmulq_lane_f32(vout1xCDEF, vget_high_f32(vinput_scale01), 1);
+    const float32x4_t vinput_scale23 = vreinterpretq_f32_s32(vld1q_s32(&quantization_params[2].zero_point));
+    vout2x0123 = vmulq_lane_f32(vout2x0123, vget_low_f32(vinput_scale23), 1);
+    vout3x0123 = vmulq_lane_f32(vout3x0123, vget_high_f32(vinput_scale23), 1);
+    vout2x4567 = vmulq_lane_f32(vout2x4567, vget_low_f32(vinput_scale23), 1);
+    vout3x4567 = vmulq_lane_f32(vout3x4567, vget_high_f32(vinput_scale23), 1);
+    vout2x89AB = vmulq_lane_f32(vout2x89AB, vget_low_f32(vinput_scale23), 1);
+    vout3x89AB = vmulq_lane_f32(vout3x89AB, vget_high_f32(vinput_scale23), 1);
+    vout2xCDEF = vmulq_lane_f32(vout2xCDEF, vget_low_f32(vinput_scale23), 1);
+    vout3xCDEF = vmulq_lane_f32(vout3xCDEF, vget_high_f32(vinput_scale23), 1);
+    const float32x4_t vinput_scale45 = vreinterpretq_f32_s32(vld1q_s32(&quantization_params[4].zero_point));
+    vout4x0123 = vmulq_lane_f32(vout4x0123, vget_low_f32(vinput_scale45), 1);
+    vout5x0123 = vmulq_lane_f32(vout5x0123, vget_high_f32(vinput_scale45), 1);
+    vout4x4567 = vmulq_lane_f32(vout4x4567, vget_low_f32(vinput_scale45), 1);
+    vout5x4567 = vmulq_lane_f32(vout5x4567, vget_high_f32(vinput_scale45), 1);
+    vout4x89AB = vmulq_lane_f32(vout4x89AB, vget_low_f32(vinput_scale45), 1);
+    vout5x89AB = vmulq_lane_f32(vout5x89AB, vget_high_f32(vinput_scale45), 1);
+    vout4xCDEF = vmulq_lane_f32(vout4xCDEF, vget_low_f32(vinput_scale45), 1);
+    vout5xCDEF = vmulq_lane_f32(vout5xCDEF, vget_high_f32(vinput_scale45), 1);
+
+
+    const float32x4_t vbias0123 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x0123 = vaddq_f32(vbias0123, vout0x0123);
+    vout1x0123 = vaddq_f32(vbias0123, vout1x0123);
+    vout2x0123 = vaddq_f32(vbias0123, vout2x0123);
+    vout3x0123 = vaddq_f32(vbias0123, vout3x0123);
+    vout4x0123 = vaddq_f32(vbias0123, vout4x0123);
+    vout5x0123 = vaddq_f32(vbias0123, vout5x0123);
+    const float32x4_t vbias4567 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x4567 = vaddq_f32(vbias4567, vout0x4567);
+    vout1x4567 = vaddq_f32(vbias4567, vout1x4567);
+    vout2x4567 = vaddq_f32(vbias4567, vout2x4567);
+    vout3x4567 = vaddq_f32(vbias4567, vout3x4567);
+    vout4x4567 = vaddq_f32(vbias4567, vout4x4567);
+    vout5x4567 = vaddq_f32(vbias4567, vout5x4567);
+    const float32x4_t vbias89AB = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x89AB = vaddq_f32(vbias89AB, vout0x89AB);
+    vout1x89AB = vaddq_f32(vbias89AB, vout1x89AB);
+    vout2x89AB = vaddq_f32(vbias89AB, vout2x89AB);
+    vout3x89AB = vaddq_f32(vbias89AB, vout3x89AB);
+    vout4x89AB = vaddq_f32(vbias89AB, vout4x89AB);
+    vout5x89AB = vaddq_f32(vbias89AB, vout5x89AB);
+    const float32x4_t vbiasCDEF = vld1q_f32(w); w = (const float*) w + 4;
+    vout0xCDEF = vaddq_f32(vbiasCDEF, vout0xCDEF);
+    vout1xCDEF = vaddq_f32(vbiasCDEF, vout1xCDEF);
+    vout2xCDEF = vaddq_f32(vbiasCDEF, vout2xCDEF);
+    vout3xCDEF = vaddq_f32(vbiasCDEF, vout3xCDEF);
+    vout4xCDEF = vaddq_f32(vbiasCDEF, vout4xCDEF);
+    vout5xCDEF = vaddq_f32(vbiasCDEF, vout5xCDEF);
+
+    const float32x4_t voutput_min = vld1q_dup_f32(&params->scalar.min);
+    vout0x0123 = vmaxq_f32(vout0x0123, voutput_min);
+    vout0x4567 = vmaxq_f32(vout0x4567, voutput_min);
+    vout0x89AB = vmaxq_f32(vout0x89AB, voutput_min);
+    vout0xCDEF = vmaxq_f32(vout0xCDEF, voutput_min);
+    vout1x0123 = vmaxq_f32(vout1x0123, voutput_min);
+    vout1x4567 = vmaxq_f32(vout1x4567, voutput_min);
+    vout1x89AB = vmaxq_f32(vout1x89AB, voutput_min);
+    vout1xCDEF = vmaxq_f32(vout1xCDEF, voutput_min);
+    vout2x0123 = vmaxq_f32(vout2x0123, voutput_min);
+    vout2x4567 = vmaxq_f32(vout2x4567, voutput_min);
+    vout2x89AB = vmaxq_f32(vout2x89AB, voutput_min);
+    vout2xCDEF = vmaxq_f32(vout2xCDEF, voutput_min);
+    vout3x0123 = vmaxq_f32(vout3x0123, voutput_min);
+    vout3x4567 = vmaxq_f32(vout3x4567, voutput_min);
+    vout3x89AB = vmaxq_f32(vout3x89AB, voutput_min);
+    vout3xCDEF = vmaxq_f32(vout3xCDEF, voutput_min);
+    vout4x0123 = vmaxq_f32(vout4x0123, voutput_min);
+    vout4x4567 = vmaxq_f32(vout4x4567, voutput_min);
+    vout4x89AB = vmaxq_f32(vout4x89AB, voutput_min);
+    vout4xCDEF = vmaxq_f32(vout4xCDEF, voutput_min);
+    vout5x0123 = vmaxq_f32(vout5x0123, voutput_min);
+    vout5x4567 = vmaxq_f32(vout5x4567, voutput_min);
+    vout5x89AB = vmaxq_f32(vout5x89AB, voutput_min);
+    vout5xCDEF = vmaxq_f32(vout5xCDEF, voutput_min);
+
+    const float32x4_t voutput_max = vld1q_dup_f32(&params->scalar.max);
+    vout0x0123 = vminq_f32(vout0x0123, voutput_max);
+    vout0x4567 = vminq_f32(vout0x4567, voutput_max);
+    vout0x89AB = vminq_f32(vout0x89AB, voutput_max);
+    vout0xCDEF = vminq_f32(vout0xCDEF, voutput_max);
+    vout1x0123 = vminq_f32(vout1x0123, voutput_max);
+    vout1x4567 = vminq_f32(vout1x4567, voutput_max);
+    vout1x89AB = vminq_f32(vout1x89AB, voutput_max);
+    vout1xCDEF = vminq_f32(vout1xCDEF, voutput_max);
+    vout2x0123 = vminq_f32(vout2x0123, voutput_max);
+    vout2x4567 = vminq_f32(vout2x4567, voutput_max);
+    vout2x89AB = vminq_f32(vout2x89AB, voutput_max);
+    vout2xCDEF = vminq_f32(vout2xCDEF, voutput_max);
+    vout3x0123 = vminq_f32(vout3x0123, voutput_max);
+    vout3x4567 = vminq_f32(vout3x4567, voutput_max);
+    vout3x89AB = vminq_f32(vout3x89AB, voutput_max);
+    vout3xCDEF = vminq_f32(vout3xCDEF, voutput_max);
+    vout4x0123 = vminq_f32(vout4x0123, voutput_max);
+    vout4x4567 = vminq_f32(vout4x4567, voutput_max);
+    vout4x89AB = vminq_f32(vout4x89AB, voutput_max);
+    vout4xCDEF = vminq_f32(vout4xCDEF, voutput_max);
+    vout5x0123 = vminq_f32(vout5x0123, voutput_max);
+    vout5x4567 = vminq_f32(vout5x4567, voutput_max);
+    vout5x89AB = vminq_f32(vout5x89AB, voutput_max);
+    vout5xCDEF = vminq_f32(vout5xCDEF, voutput_max);
+
+    if XNN_LIKELY(nc >= 16) {
+      vst1q_f32(c0, vout0x0123);
+      vst1q_f32(c0 + 4, vout0x4567);
+      vst1q_f32(c0 + 8, vout0x89AB);
+      vst1q_f32(c0 + 12, vout0xCDEF);
+      vst1q_f32(c1, vout1x0123);
+      vst1q_f32(c1 + 4, vout1x4567);
+      vst1q_f32(c1 + 8, vout1x89AB);
+      vst1q_f32(c1 + 12, vout1xCDEF);
+      vst1q_f32(c2, vout2x0123);
+      vst1q_f32(c2 + 4, vout2x4567);
+      vst1q_f32(c2 + 8, vout2x89AB);
+      vst1q_f32(c2 + 12, vout2xCDEF);
+      vst1q_f32(c3, vout3x0123);
+      vst1q_f32(c3 + 4, vout3x4567);
+      vst1q_f32(c3 + 8, vout3x89AB);
+      vst1q_f32(c3 + 12, vout3xCDEF);
+      vst1q_f32(c4, vout4x0123);
+      vst1q_f32(c4 + 4, vout4x4567);
+      vst1q_f32(c4 + 8, vout4x89AB);
+      vst1q_f32(c4 + 12, vout4xCDEF);
+      vst1q_f32(c5, vout5x0123);
+      vst1q_f32(c5 + 4, vout5x4567);
+      vst1q_f32(c5 + 8, vout5x89AB);
+      vst1q_f32(c5 + 12, vout5xCDEF);
+
+      a0 = (const int8_t*) ((uintptr_t) a0 - kc);
+      a1 = (const int8_t*) ((uintptr_t) a1 - kc);
+      a2 = (const int8_t*) ((uintptr_t) a2 - kc);
+      a3 = (const int8_t*) ((uintptr_t) a3 - kc);
+      a4 = (const int8_t*) ((uintptr_t) a4 - kc);
+      a5 = (const int8_t*) ((uintptr_t) a5 - kc);
+
+      c0 = (float*) ((uintptr_t) c0 + cn_stride);
+      c1 = (float*) ((uintptr_t) c1 + cn_stride);
+      c2 = (float*) ((uintptr_t) c2 + cn_stride);
+      c3 = (float*) ((uintptr_t) c3 + cn_stride);
+      c4 = (float*) ((uintptr_t) c4 + cn_stride);
+      c5 = (float*) ((uintptr_t) c5 + cn_stride);
+
+      nc -= 16;
+    } else {
+     if (nc & 8) {
+       vst1q_f32(c0, vout0x0123); c0 += 4;
+       vout0x0123 = vout0x89AB;
+       vst1q_f32(c1, vout1x0123); c1 += 4;
+       vout1x0123 = vout1x89AB;
+       vst1q_f32(c2, vout2x0123); c2 += 4;
+       vout2x0123 = vout2x89AB;
+       vst1q_f32(c3, vout3x0123); c3 += 4;
+       vout3x0123 = vout3x89AB;
+       vst1q_f32(c4, vout4x0123); c4 += 4;
+       vout4x0123 = vout4x89AB;
+       vst1q_f32(c5, vout5x0123); c5 += 4;
+       vout5x0123 = vout5x89AB;
+       vst1q_f32(c0, vout0x4567); c0 += 4;
+       vout0x4567 = vout0xCDEF;
+       vst1q_f32(c1, vout1x4567); c1 += 4;
+       vout1x4567 = vout1xCDEF;
+       vst1q_f32(c2, vout2x4567); c2 += 4;
+       vout2x4567 = vout2xCDEF;
+       vst1q_f32(c3, vout3x4567); c3 += 4;
+       vout3x4567 = vout3xCDEF;
+       vst1q_f32(c4, vout4x4567); c4 += 4;
+       vout4x4567 = vout4xCDEF;
+       vst1q_f32(c5, vout5x4567); c5 += 4;
+       vout5x4567 = vout5xCDEF;
+     }
+     if (nc & 4) {
+       vst1q_f32(c0, vout0x0123); c0 += 4;
+       vout0x0123 = vout0x4567;
+       vst1q_f32(c1, vout1x0123); c1 += 4;
+       vout1x0123 = vout1x4567;
+       vst1q_f32(c2, vout2x0123); c2 += 4;
+       vout2x0123 = vout2x4567;
+       vst1q_f32(c3, vout3x0123); c3 += 4;
+       vout3x0123 = vout3x4567;
+       vst1q_f32(c4, vout4x0123); c4 += 4;
+       vout4x0123 = vout4x4567;
+       vst1q_f32(c5, vout5x0123); c5 += 4;
+       vout5x0123 = vout5x4567;
+     }
+     float32x2_t vout0x01 = vget_low_f32(vout0x0123);
+     float32x2_t vout1x01 = vget_low_f32(vout1x0123);
+     float32x2_t vout2x01 = vget_low_f32(vout2x0123);
+     float32x2_t vout3x01 = vget_low_f32(vout3x0123);
+     float32x2_t vout4x01 = vget_low_f32(vout4x0123);
+     float32x2_t vout5x01 = vget_low_f32(vout5x0123);
+     if (nc & 2) {
+       vst1_f32(c0, vout0x01); c0 += 2;
+       vst1_f32(c1, vout1x01); c1 += 2;
+       vst1_f32(c2, vout2x01); c2 += 2;
+       vst1_f32(c3, vout3x01); c3 += 2;
+       vst1_f32(c4, vout4x01); c4 += 2;
+       vst1_f32(c5, vout5x01); c5 += 2;
+       vout0x01 = vget_high_f32(vout0x0123);
+       vout1x01 = vget_high_f32(vout1x0123);
+       vout2x01 = vget_high_f32(vout2x0123);
+       vout3x01 = vget_high_f32(vout3x0123);
+       vout4x01 = vget_high_f32(vout4x0123);
+       vout5x01 = vget_high_f32(vout5x0123);
+     }
+     if (nc & 1) {
+       vst1_lane_f32(c0, vout0x01, 0);
+       vst1_lane_f32(c1, vout1x01, 0);
+       vst1_lane_f32(c2, vout2x01, 0);
+       vst1_lane_f32(c3, vout3x01, 0);
+       vst1_lane_f32(c4, vout4x01, 0);
+       vst1_lane_f32(c5, vout5x01, 0);
+     }
+      nc = 0;
+    }
+  } while (nc != 0);
+}

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-6x8c4-minmax-neondot.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-6x8c4-minmax-neondot.c
@@ -1,0 +1,367 @@
+// Auto-generated file. Do not edit!
+//   Template: src/qs8-gemm/c4-neondot.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2020 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+
+#include <arm_neon.h>
+
+#include "xnnpack/gemm.h"
+#include "xnnpack/math.h"
+
+
+void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_6x8c4__neondot(
+    size_t mr,
+    size_t nc,
+    size_t kc,
+    const int8_t* restrict a,
+    size_t a_stride,
+    const void* restrict w,
+    float* restrict c,
+    size_t cm_stride,
+    size_t cn_stride,
+    const union xnn_f32_qb4w_minmax_params params[restrict XNN_MIN_ELEMENTS(1)],
+    const struct xnn_qd8_quantization_params quantization_params[restrict XNN_MIN_ELEMENTS(1)]) XNN_OOB_READS
+{
+  assert(mr != 0);
+  assert(mr <= 6);
+  assert(nc != 0);
+  assert(kc != 0);
+  assert(kc % sizeof(int8_t) == 0);
+  assert(a != NULL);
+  assert(w != NULL);
+  assert(c != NULL);
+
+  kc = round_up_po2(kc, 4 * sizeof(int8_t));
+  const int8_t* a0 = a;
+  float* c0 = c;
+  const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
+  float* c1 = (float*) ((uintptr_t) c0 + cm_stride);
+  if XNN_UNPREDICTABLE(mr < 2) {
+    a1 = a0;
+    c1 = c0;
+  }
+  const int8_t* a2 = (const int8_t*) ((uintptr_t) a1 + a_stride);
+  float* c2 = (float*) ((uintptr_t) c1 + cm_stride);
+  if XNN_UNPREDICTABLE(mr <= 2) {
+    a2 = a1;
+    c2 = c1;
+  }
+  const int8_t* a3 = (const int8_t*) ((uintptr_t) a2 + a_stride);
+  float* c3 = (float*) ((uintptr_t) c2 + cm_stride);
+  if XNN_UNPREDICTABLE(mr < 4) {
+    a3 = a2;
+    c3 = c2;
+  }
+  const int8_t* a4 = (const int8_t*) ((uintptr_t) a3 + a_stride);
+  float* c4 = (float*) ((uintptr_t) c3 + cm_stride);
+  if XNN_UNPREDICTABLE(mr <= 4) {
+    a4 = a3;
+    c4 = c3;
+  }
+  const int8_t* a5 = (const int8_t*) ((uintptr_t) a4 + a_stride);
+  float* c5 = (float*) ((uintptr_t) c4 + cm_stride);
+  if XNN_UNPREDICTABLE(mr != 6) {
+    a5 = a4;
+    c5 = c4;
+  }
+
+  size_t bl = params->scalar.blocksize;
+  assert(bl <= kc);
+  assert(bl != 0);
+  size_t n_blocks = kc / bl;
+  const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
+  // Loop over groups of 8 columns.
+  do {
+    // Initialize accumulators with bias. 8 bias values are loaded from the
+    // weight matrix, at the start of the group of 8 columns.
+    const float32x4_t vinput_zero_point01 = vcvtq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    const float32x4_t vksum0123 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x0123 = vmulq_lane_f32(vksum0123, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x0123 = vmulq_lane_f32(vksum0123, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vksum4567 = vld1q_f32(w); w = (const float*) w + 4;
+    float32x4_t vout0x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point01), 0);
+    float32x4_t vout1x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point01), 0);
+    const float32x4_t vinput_zero_point23 = vcvtq_f32_s32(vld1q_s32(&quantization_params[2].zero_point));
+    float32x4_t vout2x0123 = vmulq_lane_f32(vksum0123, vget_low_f32(vinput_zero_point23), 0);
+    float32x4_t vout3x0123 = vmulq_lane_f32(vksum0123, vget_high_f32(vinput_zero_point23), 0);
+    float32x4_t vout2x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point23), 0);
+    float32x4_t vout3x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point23), 0);
+    const float32x4_t vinput_zero_point45 = vcvtq_f32_s32(vld1q_s32(&quantization_params[4].zero_point));
+    float32x4_t vout4x0123 = vmulq_lane_f32(vksum0123, vget_low_f32(vinput_zero_point45), 0);
+    float32x4_t vout5x0123 = vmulq_lane_f32(vksum0123, vget_high_f32(vinput_zero_point45), 0);
+    float32x4_t vout4x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point45), 0);
+    float32x4_t vout5x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point45), 0);
+
+    for (size_t nb=0; nb < n_blocks; ++nb) {
+      int32x4_t vacc0x0123 = vdupq_n_s32(0);
+      int32x4_t vacc1x0123 = vdupq_n_s32(0);
+      int32x4_t vacc0x4567 = vdupq_n_s32(0);
+      int32x4_t vacc1x4567 = vdupq_n_s32(0);
+      int32x4_t vacc2x0123 = vdupq_n_s32(0);
+      int32x4_t vacc3x0123 = vdupq_n_s32(0);
+      int32x4_t vacc2x4567 = vdupq_n_s32(0);
+      int32x4_t vacc3x4567 = vdupq_n_s32(0);
+      int32x4_t vacc4x0123 = vdupq_n_s32(0);
+      int32x4_t vacc5x0123 = vdupq_n_s32(0);
+      int32x4_t vacc4x4567 = vdupq_n_s32(0);
+      int32x4_t vacc5x4567 = vdupq_n_s32(0);
+    // Inner accumulation loop along the 8 columns.
+    size_t k = bl;
+    // 2x partial unrolled loop to load 8 bytes at a time.
+    while (k >= 8 * sizeof(int8_t)) {
+      // Load a 6x8 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 8;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 8;
+      const int8x8_t va2x01234567 = vld1_s8(a2); a2 += 8;
+      const int8x8_t va3x01234567 = vld1_s8(a3); a3 += 8;
+      const int8x8_t va4x01234567 = vld1_s8(a4); a4 += 8;
+      const int8x8_t va5x01234567 = vld1_s8(a5); a5 += 8;
+
+      // Load a 8x8 block of weights.
+      const int8x16_t vb01234567x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb01234567x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x0123 = vshlq_n_s8(vb01234567x0123, 4);
+      const int8x16_t vb0123x4567 = vshlq_n_s8(vb01234567x4567, 4);
+      const int8x16_t vb4567x0123 = vandq_s8(vb01234567x0123, vmask);
+      const int8x16_t vb4567x4567 = vandq_s8(vb01234567x4567, vmask);
+
+      // Multiply-accumulate: 6x8 * 8x8 --> 6x8.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb0123x0123, va2x01234567, 0);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb0123x4567, va2x01234567, 0);
+      vacc3x0123 = vdotq_lane_s32(vacc3x0123, vb0123x0123, va3x01234567, 0);
+      vacc3x4567 = vdotq_lane_s32(vacc3x4567, vb0123x4567, va3x01234567, 0);
+      vacc4x0123 = vdotq_lane_s32(vacc4x0123, vb0123x0123, va4x01234567, 0);
+      vacc4x4567 = vdotq_lane_s32(vacc4x4567, vb0123x4567, va4x01234567, 0);
+      vacc5x0123 = vdotq_lane_s32(vacc5x0123, vb0123x0123, va5x01234567, 0);
+      vacc5x4567 = vdotq_lane_s32(vacc5x4567, vb0123x4567, va5x01234567, 0);
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb4567x0123, va0x01234567, 1);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb4567x4567, va0x01234567, 1);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb4567x0123, va1x01234567, 1);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb4567x4567, va1x01234567, 1);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb4567x0123, va2x01234567, 1);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb4567x4567, va2x01234567, 1);
+      vacc3x0123 = vdotq_lane_s32(vacc3x0123, vb4567x0123, va3x01234567, 1);
+      vacc3x4567 = vdotq_lane_s32(vacc3x4567, vb4567x4567, va3x01234567, 1);
+      vacc4x0123 = vdotq_lane_s32(vacc4x0123, vb4567x0123, va4x01234567, 1);
+      vacc4x4567 = vdotq_lane_s32(vacc4x4567, vb4567x4567, va4x01234567, 1);
+      vacc5x0123 = vdotq_lane_s32(vacc5x0123, vb4567x0123, va5x01234567, 1);
+      vacc5x4567 = vdotq_lane_s32(vacc5x4567, vb4567x4567, va5x01234567, 1);
+
+      k -= 8 * sizeof(int8_t);
+    }
+    // Handle up to 4 final positions of `k`
+    if XNN_UNLIKELY(k != 0) {
+      // Load a 6x4 block of activations.
+      const int8x8_t va0x01234567 = vld1_s8(a0); a0 += 4;
+      const int8x8_t va1x01234567 = vld1_s8(a1); a1 += 4;
+      const int8x8_t va2x01234567 = vld1_s8(a2); a2 += 4;
+      const int8x8_t va3x01234567 = vld1_s8(a3); a3 += 4;
+      const int8x8_t va4x01234567 = vld1_s8(a4); a4 += 4;
+      const int8x8_t va5x01234567 = vld1_s8(a5); a5 += 4;
+
+      // Load a 4x8 block of weights.
+      const int8x16_t vb0123x0123 = vld1q_s8(w); w = (const int8_t*) w + 16;
+      const int8x16_t vb0123x4567 = vld1q_s8(w); w = (const int8_t*) w + 16;
+
+      // Multiply-accumulate: 6x4 * 4x8 --> 6x8.
+      vacc0x0123 = vdotq_lane_s32(vacc0x0123, vb0123x0123, va0x01234567, 0);
+      vacc0x4567 = vdotq_lane_s32(vacc0x4567, vb0123x4567, va0x01234567, 0);
+      vacc1x0123 = vdotq_lane_s32(vacc1x0123, vb0123x0123, va1x01234567, 0);
+      vacc1x4567 = vdotq_lane_s32(vacc1x4567, vb0123x4567, va1x01234567, 0);
+      vacc2x0123 = vdotq_lane_s32(vacc2x0123, vb0123x0123, va2x01234567, 0);
+      vacc2x4567 = vdotq_lane_s32(vacc2x4567, vb0123x4567, va2x01234567, 0);
+      vacc3x0123 = vdotq_lane_s32(vacc3x0123, vb0123x0123, va3x01234567, 0);
+      vacc3x4567 = vdotq_lane_s32(vacc3x4567, vb0123x4567, va3x01234567, 0);
+      vacc4x0123 = vdotq_lane_s32(vacc4x0123, vb0123x0123, va4x01234567, 0);
+      vacc4x4567 = vdotq_lane_s32(vacc4x4567, vb0123x4567, va4x01234567, 0);
+      vacc5x0123 = vdotq_lane_s32(vacc5x0123, vb0123x0123, va5x01234567, 0);
+      vacc5x4567 = vdotq_lane_s32(vacc5x4567, vb0123x4567, va5x01234567, 0);
+    }
+    const float32x4_t vfilter_output_scale0123 = vld1q_f32(w); w = (const float*) w + 4;
+    const float32x4_t vfilter_output_scale4567 = vld1q_f32(w); w = (const float*) w + 4;
+
+    float32x4_t vf0x0123 = vcvtq_f32_s32(vacc0x0123);
+    float32x4_t vf1x0123 = vcvtq_f32_s32(vacc1x0123);
+    vout0x0123 = vfmaq_f32(vout0x0123, vf0x0123, vfilter_output_scale0123);
+    vout1x0123 = vfmaq_f32(vout1x0123, vf1x0123, vfilter_output_scale0123);
+    float32x4_t vf0x4567 = vcvtq_f32_s32(vacc0x4567);
+    float32x4_t vf1x4567 = vcvtq_f32_s32(vacc1x4567);
+    vout0x4567 = vfmaq_f32(vout0x4567, vf0x4567, vfilter_output_scale4567);
+    vout1x4567 = vfmaq_f32(vout1x4567, vf1x4567, vfilter_output_scale4567);
+    float32x4_t vf2x0123 = vcvtq_f32_s32(vacc2x0123);
+    float32x4_t vf3x0123 = vcvtq_f32_s32(vacc3x0123);
+    vout2x0123 = vfmaq_f32(vout2x0123, vf2x0123, vfilter_output_scale0123);
+    vout3x0123 = vfmaq_f32(vout3x0123, vf3x0123, vfilter_output_scale0123);
+    float32x4_t vf2x4567 = vcvtq_f32_s32(vacc2x4567);
+    float32x4_t vf3x4567 = vcvtq_f32_s32(vacc3x4567);
+    vout2x4567 = vfmaq_f32(vout2x4567, vf2x4567, vfilter_output_scale4567);
+    vout3x4567 = vfmaq_f32(vout3x4567, vf3x4567, vfilter_output_scale4567);
+    float32x4_t vf4x0123 = vcvtq_f32_s32(vacc4x0123);
+    float32x4_t vf5x0123 = vcvtq_f32_s32(vacc5x0123);
+    vout4x0123 = vfmaq_f32(vout4x0123, vf4x0123, vfilter_output_scale0123);
+    vout5x0123 = vfmaq_f32(vout5x0123, vf5x0123, vfilter_output_scale0123);
+    float32x4_t vf4x4567 = vcvtq_f32_s32(vacc4x4567);
+    float32x4_t vf5x4567 = vcvtq_f32_s32(vacc5x4567);
+    vout4x4567 = vfmaq_f32(vout4x4567, vf4x4567, vfilter_output_scale4567);
+    vout5x4567 = vfmaq_f32(vout5x4567, vf5x4567, vfilter_output_scale4567);
+    }
+
+    const float32x4_t one_sixteenth = vdupq_n_f32(1/16.0);
+    vout0x0123 = vmulq_f32(vout0x0123, one_sixteenth);
+    vout0x4567 = vmulq_f32(vout0x4567, one_sixteenth);
+    vout1x0123 = vmulq_f32(vout1x0123, one_sixteenth);
+    vout1x4567 = vmulq_f32(vout1x4567, one_sixteenth);
+    vout2x0123 = vmulq_f32(vout2x0123, one_sixteenth);
+    vout2x4567 = vmulq_f32(vout2x4567, one_sixteenth);
+    vout3x0123 = vmulq_f32(vout3x0123, one_sixteenth);
+    vout3x4567 = vmulq_f32(vout3x4567, one_sixteenth);
+    vout4x0123 = vmulq_f32(vout4x0123, one_sixteenth);
+    vout4x4567 = vmulq_f32(vout4x4567, one_sixteenth);
+    vout5x0123 = vmulq_f32(vout5x0123, one_sixteenth);
+    vout5x4567 = vmulq_f32(vout5x4567, one_sixteenth);
+    const float32x4_t vinput_scale01 = vreinterpretq_f32_s32(vld1q_s32(&quantization_params[0].zero_point));
+    vout0x0123 = vmulq_lane_f32(vout0x0123, vget_low_f32(vinput_scale01), 1);
+    vout1x0123 = vmulq_lane_f32(vout1x0123, vget_high_f32(vinput_scale01), 1);
+    vout0x4567 = vmulq_lane_f32(vout0x4567, vget_low_f32(vinput_scale01), 1);
+    vout1x4567 = vmulq_lane_f32(vout1x4567, vget_high_f32(vinput_scale01), 1);
+    const float32x4_t vinput_scale23 = vreinterpretq_f32_s32(vld1q_s32(&quantization_params[2].zero_point));
+    vout2x0123 = vmulq_lane_f32(vout2x0123, vget_low_f32(vinput_scale23), 1);
+    vout3x0123 = vmulq_lane_f32(vout3x0123, vget_high_f32(vinput_scale23), 1);
+    vout2x4567 = vmulq_lane_f32(vout2x4567, vget_low_f32(vinput_scale23), 1);
+    vout3x4567 = vmulq_lane_f32(vout3x4567, vget_high_f32(vinput_scale23), 1);
+    const float32x4_t vinput_scale45 = vreinterpretq_f32_s32(vld1q_s32(&quantization_params[4].zero_point));
+    vout4x0123 = vmulq_lane_f32(vout4x0123, vget_low_f32(vinput_scale45), 1);
+    vout5x0123 = vmulq_lane_f32(vout5x0123, vget_high_f32(vinput_scale45), 1);
+    vout4x4567 = vmulq_lane_f32(vout4x4567, vget_low_f32(vinput_scale45), 1);
+    vout5x4567 = vmulq_lane_f32(vout5x4567, vget_high_f32(vinput_scale45), 1);
+
+
+    const float32x4_t vbias0123 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x0123 = vaddq_f32(vbias0123, vout0x0123);
+    vout1x0123 = vaddq_f32(vbias0123, vout1x0123);
+    vout2x0123 = vaddq_f32(vbias0123, vout2x0123);
+    vout3x0123 = vaddq_f32(vbias0123, vout3x0123);
+    vout4x0123 = vaddq_f32(vbias0123, vout4x0123);
+    vout5x0123 = vaddq_f32(vbias0123, vout5x0123);
+    const float32x4_t vbias4567 = vld1q_f32(w); w = (const float*) w + 4;
+    vout0x4567 = vaddq_f32(vbias4567, vout0x4567);
+    vout1x4567 = vaddq_f32(vbias4567, vout1x4567);
+    vout2x4567 = vaddq_f32(vbias4567, vout2x4567);
+    vout3x4567 = vaddq_f32(vbias4567, vout3x4567);
+    vout4x4567 = vaddq_f32(vbias4567, vout4x4567);
+    vout5x4567 = vaddq_f32(vbias4567, vout5x4567);
+
+    const float32x4_t voutput_min = vld1q_dup_f32(&params->scalar.min);
+    vout0x0123 = vmaxq_f32(vout0x0123, voutput_min);
+    vout0x4567 = vmaxq_f32(vout0x4567, voutput_min);
+    vout1x0123 = vmaxq_f32(vout1x0123, voutput_min);
+    vout1x4567 = vmaxq_f32(vout1x4567, voutput_min);
+    vout2x0123 = vmaxq_f32(vout2x0123, voutput_min);
+    vout2x4567 = vmaxq_f32(vout2x4567, voutput_min);
+    vout3x0123 = vmaxq_f32(vout3x0123, voutput_min);
+    vout3x4567 = vmaxq_f32(vout3x4567, voutput_min);
+    vout4x0123 = vmaxq_f32(vout4x0123, voutput_min);
+    vout4x4567 = vmaxq_f32(vout4x4567, voutput_min);
+    vout5x0123 = vmaxq_f32(vout5x0123, voutput_min);
+    vout5x4567 = vmaxq_f32(vout5x4567, voutput_min);
+
+    const float32x4_t voutput_max = vld1q_dup_f32(&params->scalar.max);
+    vout0x0123 = vminq_f32(vout0x0123, voutput_max);
+    vout0x4567 = vminq_f32(vout0x4567, voutput_max);
+    vout1x0123 = vminq_f32(vout1x0123, voutput_max);
+    vout1x4567 = vminq_f32(vout1x4567, voutput_max);
+    vout2x0123 = vminq_f32(vout2x0123, voutput_max);
+    vout2x4567 = vminq_f32(vout2x4567, voutput_max);
+    vout3x0123 = vminq_f32(vout3x0123, voutput_max);
+    vout3x4567 = vminq_f32(vout3x4567, voutput_max);
+    vout4x0123 = vminq_f32(vout4x0123, voutput_max);
+    vout4x4567 = vminq_f32(vout4x4567, voutput_max);
+    vout5x0123 = vminq_f32(vout5x0123, voutput_max);
+    vout5x4567 = vminq_f32(vout5x4567, voutput_max);
+
+    if XNN_LIKELY(nc >= 8) {
+      vst1q_f32(c0, vout0x0123);
+      vst1q_f32(c0 + 4, vout0x4567);
+      vst1q_f32(c1, vout1x0123);
+      vst1q_f32(c1 + 4, vout1x4567);
+      vst1q_f32(c2, vout2x0123);
+      vst1q_f32(c2 + 4, vout2x4567);
+      vst1q_f32(c3, vout3x0123);
+      vst1q_f32(c3 + 4, vout3x4567);
+      vst1q_f32(c4, vout4x0123);
+      vst1q_f32(c4 + 4, vout4x4567);
+      vst1q_f32(c5, vout5x0123);
+      vst1q_f32(c5 + 4, vout5x4567);
+
+      a0 = (const int8_t*) ((uintptr_t) a0 - kc);
+      a1 = (const int8_t*) ((uintptr_t) a1 - kc);
+      a2 = (const int8_t*) ((uintptr_t) a2 - kc);
+      a3 = (const int8_t*) ((uintptr_t) a3 - kc);
+      a4 = (const int8_t*) ((uintptr_t) a4 - kc);
+      a5 = (const int8_t*) ((uintptr_t) a5 - kc);
+
+      c0 = (float*) ((uintptr_t) c0 + cn_stride);
+      c1 = (float*) ((uintptr_t) c1 + cn_stride);
+      c2 = (float*) ((uintptr_t) c2 + cn_stride);
+      c3 = (float*) ((uintptr_t) c3 + cn_stride);
+      c4 = (float*) ((uintptr_t) c4 + cn_stride);
+      c5 = (float*) ((uintptr_t) c5 + cn_stride);
+
+      nc -= 8;
+    } else {
+     if (nc & 4) {
+       vst1q_f32(c0, vout0x0123); c0 += 4;
+       vout0x0123 = vout0x4567;
+       vst1q_f32(c1, vout1x0123); c1 += 4;
+       vout1x0123 = vout1x4567;
+       vst1q_f32(c2, vout2x0123); c2 += 4;
+       vout2x0123 = vout2x4567;
+       vst1q_f32(c3, vout3x0123); c3 += 4;
+       vout3x0123 = vout3x4567;
+       vst1q_f32(c4, vout4x0123); c4 += 4;
+       vout4x0123 = vout4x4567;
+       vst1q_f32(c5, vout5x0123); c5 += 4;
+       vout5x0123 = vout5x4567;
+     }
+     float32x2_t vout0x01 = vget_low_f32(vout0x0123);
+     float32x2_t vout1x01 = vget_low_f32(vout1x0123);
+     float32x2_t vout2x01 = vget_low_f32(vout2x0123);
+     float32x2_t vout3x01 = vget_low_f32(vout3x0123);
+     float32x2_t vout4x01 = vget_low_f32(vout4x0123);
+     float32x2_t vout5x01 = vget_low_f32(vout5x0123);
+     if (nc & 2) {
+       vst1_f32(c0, vout0x01); c0 += 2;
+       vst1_f32(c1, vout1x01); c1 += 2;
+       vst1_f32(c2, vout2x01); c2 += 2;
+       vst1_f32(c3, vout3x01); c3 += 2;
+       vst1_f32(c4, vout4x01); c4 += 2;
+       vst1_f32(c5, vout5x01); c5 += 2;
+       vout0x01 = vget_high_f32(vout0x0123);
+       vout1x01 = vget_high_f32(vout1x0123);
+       vout2x01 = vget_high_f32(vout2x0123);
+       vout3x01 = vget_high_f32(vout3x0123);
+       vout4x01 = vget_high_f32(vout4x0123);
+       vout5x01 = vget_high_f32(vout5x0123);
+     }
+     if (nc & 1) {
+       vst1_lane_f32(c0, vout0x01, 0);
+       vst1_lane_f32(c1, vout1x01, 0);
+       vst1_lane_f32(c2, vout2x01, 0);
+       vst1_lane_f32(c3, vout3x01, 0);
+       vst1_lane_f32(c4, vout4x01, 0);
+       vst1_lane_f32(c5, vout5x01, 0);
+     }
+      nc = 0;
+    }
+  } while (nc != 0);
+}

--- a/src/qs8-gemm/c4-neondot.c.in
+++ b/src/qs8-gemm/c4-neondot.c.in
@@ -7,9 +7,9 @@ $ABC = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 $assert NR % 8 == 0
 $assert 8 <= NR <= 16
 $assert REQUANTIZATION in ["FP32", "RNDNU"] or not REQUANTIZATION
-$assert DATATYPE in ["QC8", "QS8", "QD8_F16", "QD8_F32", "QC4_F16", "QC4_F32"]
+$assert DATATYPE in ["QC8", "QS8", "QD8_F16", "QD8_F32", "QC4_F16", "QC4_F32", "QB4_F16", "QB4_F32"]
 $assert DATATYPE != "QC8" or REQUANTIZATION == "FP32"
-$assert not DATATYPE in ["QD8_F16", "QD8_F32", "QC4_F16", "QC4_F32"] or not REQUANTIZATION
+$assert not DATATYPE in ["QD8_F16", "QD8_F32", "QC4_F16", "QC4_F32", "QB4_F16", "QB4_F32"] or not REQUANTIZATION
 #include <assert.h>
 
 #include <arm_neon.h>
@@ -20,12 +20,13 @@ $if REQUANTIZATION == "FP32":
 #include "xnnpack/math.h"
 
 
-$DATATYPE_SPEC = {"QC8": "qs8_qc8w", "QS8": "qs8", "QD8_F16" : "qd8_f16_qc8w", "QD8_F32": "qd8_f32_qc8w", "QC4_F16": "qd8_f16_qc4w", "QC4_F32": "qd8_f32_qc4w"}[DATATYPE]
+$DATATYPE_SPEC = {"QC8": "qs8_qc8w", "QS8": "qs8", "QD8_F16" : "qd8_f16_qc8w", "QD8_F32": "qd8_f32_qc8w", "QC4_F16": "qd8_f16_qc4w", "QC4_F32": "qd8_f32_qc4w", "QB4_F16": "qd8_f16_qb4w", "QB4_F32": "qd8_f32_qb4w"}[DATATYPE]
 $REQUANTIZATION_SPEC = "_" + REQUANTIZATION.lower() if REQUANTIZATION else ""
 $PARAMS_STRUCT = REQUANTIZATION.lower() + "_" + ("neonv8" if REQUANTIZATION == "FP32" else "neon")
-$PARAMS_UNION = {"QC8": "xnn_qs8_qc8w_conv_minmax_params", "QS8": "xnn_qs8_conv_minmax_params", "QD8_F16": "xnn_f16_minmax_params", "QD8_F32": "xnn_f32_minmax_params", "QC4_F16": "xnn_f16_qc4w_minmax_params", "QC4_F32": "xnn_f32_qc4w_minmax_params"}[DATATYPE]
-$OUT_T = {"QC8": "int8_t", "QD8_F16": "void", "QD8_F32": "float", "QC4_F16": "void", "QC4_F32": "float", "QS8": "int8_t"}[DATATYPE]
-$ISA = "fp16arith" if DATATYPE in ["QC4_F16", "QD8_F16"] else ""
+$PARAMS_UNION = {"QC8": "xnn_qs8_qc8w_conv_minmax_params", "QS8": "xnn_qs8_conv_minmax_params", "QD8_F16": "xnn_f16_minmax_params", "QD8_F32": "xnn_f32_minmax_params", "QC4_F16": "xnn_f16_qc4w_minmax_params", "QC4_F32": "xnn_f32_qc4w_minmax_params", "QB4_F16": "xnn_f16_qb4w_minmax_params", "QB4_F32": "xnn_f32_qb4w_minmax_params"}[DATATYPE]
+$OUT_T = {"QC8": "int8_t", "QD8_F16": "void", "QD8_F32": "float", "QC4_F16": "void", "QC4_F32": "float", "QB4_F16": "uint16_t", "QB4_F32": "float", "QS8": "int8_t"}[DATATYPE]
+$ISA = "fp16arith" if DATATYPE in ["QC4_F16", "QD8_F16", "QB4_F16"] else ""
+$BLOCKWISE = True if DATATYPE in ["QB4_F16", "QB4_F32"] else False
 void xnn_${DATATYPE_SPEC}_gemm_minmax${REQUANTIZATION_SPEC}_ukernel_${MR}x${NR}c4__neondot${ISA}(
     size_t mr,
     size_t nc,
@@ -36,7 +37,7 @@ void xnn_${DATATYPE_SPEC}_gemm_minmax${REQUANTIZATION_SPEC}_ukernel_${MR}x${NR}c
     ${OUT_T}* restrict c,
     size_t cm_stride,
     size_t cn_stride,
-    $if DATATYPE in ["QD8_F16", "QD8_F32", "QC4_F16", "QC4_F32"]:
+    $if DATATYPE in ["QD8_F16", "QD8_F32", "QC4_F16", "QC4_F32", "QB4_F16", "QB4_F32"]:
       const union ${PARAMS_UNION} params[restrict XNN_MIN_ELEMENTS(1)],
       const struct xnn_qd8_quantization_params quantization_params[restrict XNN_MIN_ELEMENTS(1)]) XNN_OOB_READS
     $else:
@@ -53,13 +54,13 @@ void xnn_${DATATYPE_SPEC}_gemm_minmax${REQUANTIZATION_SPEC}_ukernel_${MR}x${NR}c
 
   kc = round_up_po2(kc, 4 * sizeof(int8_t));
   const int8_t* a0 = a;
-  $if DATATYPE in ["QD8_F16", "QC4_F16"]:
+  $if DATATYPE in ["QD8_F16", "QC4_F16", "QB4_F16"]:
     uint16_t* c0 = (uint16_t*) c;
   $else:
     ${OUT_T}* c0 = c;
   $for M in range(1, MR):
     const int8_t* a${M} = (const int8_t*) ((uintptr_t) a${M-1} + a_stride);
-    $if DATATYPE in ["QD8_F16", "QC4_F16"]:
+    $if DATATYPE in ["QD8_F16", "QC4_F16", "QB4_F16"]:
       uint16_t* c${M} = (uint16_t*) ((uintptr_t) c${M-1} + cm_stride);
     $else:
       ${OUT_T}* c${M} = (${OUT_T}*) ((uintptr_t) c${M-1} + cm_stride);
@@ -79,27 +80,52 @@ void xnn_${DATATYPE_SPEC}_gemm_minmax${REQUANTIZATION_SPEC}_ukernel_${MR}x${NR}c
         c${M} = c${M-1};
       }
 
-  $if DATATYPE in ["QC4_F16", "QC4_F32"]:
+  $if DATATYPE in ["QB4_F16", "QB4_F32"]:
+    $if DATATYPE == "QB4_F16":
+      size_t bl = params->fp16arith.blocksize;
+    $else:
+      size_t bl = params->scalar.blocksize;
+    assert(bl <= kc);
+    assert(bl != 0);
+    size_t n_blocks = kc / bl;
+  $if DATATYPE in ["QC4_F16", "QC4_F32", "QB4_F16", "QB4_F32"]:
     const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of ${NR} columns.
   do {
     // Initialize accumulators with bias. ${NR} bias values are loaded from the
     // weight matrix, at the start of the group of ${NR} columns.
-    $if DATATYPE in ["QD8_F16", "QD8_F32", "QC4_F16", "QC4_F32"]:
+    $if DATATYPE in ["QD8_F16", "QD8_F32", "QC4_F16", "QC4_F32", "QB4_F16", "QB4_F32"]:
       $for M in range(0, MR, 2):
         $if M + 1 == MR:
-          const int32x4_t vinput_zero_point${M} = vld1q_dup_s32(&quantization_params[${M}].zero_point);
+          $if BLOCKWISE:
+            const float32x4_t vinput_zero_point${M} = vcvtq_f32_s32(vld1q_dup_s32(&quantization_params[${M}].zero_point));
+          $else:
+            const int32x4_t vinput_zero_point${M} = vld1q_dup_s32(&quantization_params[${M}].zero_point);
           $for N in range(0, NR, 4):
-            $if M == 0:
-              const int32x4_t vksum${ABC[N:N+4]} = vld1q_s32(w); w = (const int32_t*) w + 4;
-            int32x4_t vacc${M}x${ABC[N:N+4]} = vmulq_s32(vksum${ABC[N:N+4]}, vinput_zero_point${M});
+            $if BLOCKWISE:
+              $if M == 0:
+                const float32x4_t vksum${ABC[N:N+4]} = vld1q_f32(w); w = (const float*) w + 4;
+              float32x4_t vout${M}x${ABC[N:N+4]} = vmulq_f32(vksum${ABC[N:N+4]}, vinput_zero_point${M});
+            $else:
+              $if M == 0:
+                const int32x4_t vksum${ABC[N:N+4]} = vld1q_s32(w); w = (const int32_t*) w + 4;
+              int32x4_t vacc${M}x${ABC[N:N+4]} = vmulq_s32(vksum${ABC[N:N+4]}, vinput_zero_point${M});
         $else:
-          const int32x4_t vinput_zero_point${ABC[M:M+2]} = vld1q_s32(&quantization_params[${M}].zero_point);
+          $if DATATYPE in ["QB4_F16", "QB4_F32"]:
+            const float32x4_t vinput_zero_point${ABC[M:M+2]} = vcvtq_f32_s32(vld1q_s32(&quantization_params[${M}].zero_point));
+          $else:
+            const int32x4_t vinput_zero_point${ABC[M:M+2]} = vld1q_s32(&quantization_params[${M}].zero_point);
           $for N in range(0, NR, 4):
-            $if M == 0:
-              const int32x4_t vksum${ABC[N:N+4]} = vld1q_s32(w); w = (const int32_t*) w + 4;
-            int32x4_t vacc${M}x${ABC[N:N+4]} = vmulq_lane_s32(vksum${ABC[N:N+4]}, vget_low_s32(vinput_zero_point${ABC[M:M+2]}), 0);
-            int32x4_t vacc${M+1}x${ABC[N:N+4]} = vmulq_lane_s32(vksum${ABC[N:N+4]}, vget_high_s32(vinput_zero_point${ABC[M:M+2]}), 0);
+            $if BLOCKWISE:
+              $if M == 0:
+                const float32x4_t vksum${ABC[N:N+4]} = vld1q_f32(w); w = (const float*) w + 4;
+              float32x4_t vout${M}x${ABC[N:N+4]} = vmulq_lane_f32(vksum${ABC[N:N+4]}, vget_low_f32(vinput_zero_point${ABC[M:M+2]}), 0);
+              float32x4_t vout${M+1}x${ABC[N:N+4]} = vmulq_lane_f32(vksum${ABC[N:N+4]}, vget_high_f32(vinput_zero_point${ABC[M:M+2]}), 0);
+            $else:
+              $if M == 0:
+                const int32x4_t vksum${ABC[N:N+4]} = vld1q_s32(w); w = (const int32_t*) w + 4;
+              int32x4_t vacc${M}x${ABC[N:N+4]} = vmulq_lane_s32(vksum${ABC[N:N+4]}, vget_low_s32(vinput_zero_point${ABC[M:M+2]}), 0);
+              int32x4_t vacc${M+1}x${ABC[N:N+4]} = vmulq_lane_s32(vksum${ABC[N:N+4]}, vget_high_s32(vinput_zero_point${ABC[M:M+2]}), 0);
     $else:
       $for N in range(0, NR, 4):
         int32x4_t vacc0x${ABC[N:N+4]} = vld1q_s32(w); w = (const int32_t*) w + 4;
@@ -107,8 +133,21 @@ void xnn_${DATATYPE_SPEC}_gemm_minmax${REQUANTIZATION_SPEC}_ukernel_${MR}x${NR}c
         $for N in range(0, NR, 4):
           int32x4_t vacc${M}x${ABC[N:N+4]} = vacc0x${ABC[N:N+4]};
 
+    $if BLOCKWISE:
+      for (size_t nb=0; nb < n_blocks; ++nb) {
+        $for M in range(0, MR, 2):
+          $if M + 1 == MR:
+            $for N in range(0, NR, 4):
+              int32x4_t vacc${M}x${ABC[N:N+4]} = vdupq_n_s32(0);
+          $else:
+            $for N in range(0, NR, 4):
+              int32x4_t vacc${M}x${ABC[N:N+4]} = vdupq_n_s32(0);
+              int32x4_t vacc${M+1}x${ABC[N:N+4]} = vdupq_n_s32(0);
     // Inner accumulation loop along the ${NR} columns.
-    size_t k = kc;
+    $if BLOCKWISE:
+      size_t k = bl;
+    $else:
+      size_t k = kc;
     // 2x partial unrolled loop to load 8 bytes at a time.
     while (k >= 8 * sizeof(int8_t)) {
       // Load a ${MR}x8 block of activations.
@@ -116,7 +155,7 @@ void xnn_${DATATYPE_SPEC}_gemm_minmax${REQUANTIZATION_SPEC}_ukernel_${MR}x${NR}c
         const int8x8_t va${M}x01234567 = vld1_s8(a${M}); a${M} += 8;
 
       // Load a 8x${NR} block of weights.
-      $if DATATYPE in ["QC4_F16", "QC4_F32"]:
+      $if DATATYPE in ["QC4_F16", "QC4_F32", "QB4_F16", "QB4_F32"]:
         $for K in range(0, 8, 8):
           $for N in range(0, NR, 4):
             const int8x16_t vb${ABC[K:K+8]}x${ABC[N:N+4]} = vld1q_s8(w); w = (const int8_t*) w + 16;
@@ -159,12 +198,32 @@ void xnn_${DATATYPE_SPEC}_gemm_minmax${REQUANTIZATION_SPEC}_ukernel_${MR}x${NR}c
         $for N in range(0, NR, 4):
           vacc${M}x${ABC[N:N+4]} = vdotq_lane_s32(vacc${M}x${ABC[N:N+4]}, vb0123x${ABC[N:N+4]}, va${M}x01234567, 0);
     }
+    $if BLOCKWISE:
+      $for N in range(0, NR, 4):
+        const float32x4_t vfilter_output_scale${ABC[N:N+4]} = vld1q_f32(w); w = (const float*) w + 4;
 
-    $if DATATYPE in ["QD8_F16", "QD8_F32", "QC4_F16", "QC4_F32"]:
+      $for M in range(0, MR, 2):
+          $if M + 1 == MR:
+            $for N in range(0, NR, 4):
+              float32x4_t vf${M}x${ABC[N:N+4]} = vcvtq_f32_s32(vacc${M}x${ABC[N:N+4]});
+              vout${M}x${ABC[N:N+4]} = vfmaq_f32(vout${M}x${ABC[N:N+4]}, vf${M}x${ABC[N:N+4]}, vfilter_output_scale${ABC[N:N+4]});
+          $else:
+            $for N in range(0, NR, 4):
+              float32x4_t vf${M}x${ABC[N:N+4]} = vcvtq_f32_s32(vacc${M}x${ABC[N:N+4]});
+              float32x4_t vf${M+1}x${ABC[N:N+4]} = vcvtq_f32_s32(vacc${M+1}x${ABC[N:N+4]});
+              vout${M}x${ABC[N:N+4]} = vfmaq_f32(vout${M}x${ABC[N:N+4]}, vf${M}x${ABC[N:N+4]}, vfilter_output_scale${ABC[N:N+4]});
+              vout${M+1}x${ABC[N:N+4]} = vfmaq_f32(vout${M+1}x${ABC[N:N+4]}, vf${M+1}x${ABC[N:N+4]}, vfilter_output_scale${ABC[N:N+4]});
+      }
+
+    $if DATATYPE in ["QD8_F16", "QD8_F32", "QC4_F16", "QC4_F32"] or BLOCKWISE:
+      $if BLOCKWISE:
+        const float32x4_t one_sixteenth = vdupq_n_f32(1/16.0);
       $for M in range(0, MR):
         $for N in range(0, NR, 4):
           $if DATATYPE in ["QC4_F16", "QC4_F32"]:
             float32x4_t vout${M}x${ABC[N:N+4]} = vcvtq_n_f32_s32(vacc${M}x${ABC[N:N+4]}, 4);
+          $elif BLOCKWISE:
+            vout${M}x${ABC[N:N+4]} = vmulq_f32(vout${M}x${ABC[N:N+4]}, one_sixteenth);
           $else:
             float32x4_t vout${M}x${ABC[N:N+4]} = vcvtq_f32_s32(vacc${M}x${ABC[N:N+4]});
       $for M in range(0, MR, 2):
@@ -178,20 +237,25 @@ void xnn_${DATATYPE_SPEC}_gemm_minmax${REQUANTIZATION_SPEC}_ukernel_${MR}x${NR}c
             vout${M}x${ABC[N:N+4]} = vmulq_lane_f32(vout${M}x${ABC[N:N+4]}, vget_low_f32(vinput_scale${ABC[M:M+2]}), 1);
             vout${M+1}x${ABC[N:N+4]} = vmulq_lane_f32(vout${M+1}x${ABC[N:N+4]}, vget_high_f32(vinput_scale${ABC[M:M+2]}), 1);
 
-      $for N in range(0, NR, 4):
-        const float32x4_t vfilter_output_scale${ABC[N:N+4]} = vld1q_f32(w); w = (const float*) w + 4;
+      $if not BLOCKWISE:
+        $for N in range(0, NR, 4):
+          const float32x4_t vfilter_output_scale${ABC[N:N+4]} = vld1q_f32(w); w = (const float*) w + 4;
 
       $for N in range(0, NR, 4):
         const float32x4_t vbias${ABC[N:N+4]} = vld1q_f32(w); w = (const float*) w + 4;
-        #if XNN_ARCH_ARM64
-          $for M in range(MR):
-            vout${M}x${ABC[N:N+4]} = vfmaq_f32(vbias${ABC[N:N+4]}, vout${M}x${ABC[N:N+4]}, vfilter_output_scale${ABC[N:N+4]});
-        #else
-          $for M in range(MR):
-            vout${M}x${ABC[N:N+4]} = vmlaq_f32(vbias${ABC[N:N+4]}, vout${M}x${ABC[N:N+4]}, vfilter_output_scale${ABC[N:N+4]});
-        #endif
+        $if BLOCKWISE:
+            $for M in range(MR):
+              vout${M}x${ABC[N:N+4]} = vaddq_f32(vbias${ABC[N:N+4]}, vout${M}x${ABC[N:N+4]});
+        $else:
+          #if XNN_ARCH_ARM64
+            $for M in range(MR):
+              vout${M}x${ABC[N:N+4]} = vfmaq_f32(vbias${ABC[N:N+4]}, vout${M}x${ABC[N:N+4]}, vfilter_output_scale${ABC[N:N+4]});
+          #else
+            $for M in range(MR):
+              vout${M}x${ABC[N:N+4]} = vmlaq_f32(vbias${ABC[N:N+4]}, vout${M}x${ABC[N:N+4]}, vfilter_output_scale${ABC[N:N+4]});
+          #endif
 
-      $if DATATYPE in ["QD8_F16", "QC4_F16"]:
+      $if DATATYPE in ["QD8_F16", "QC4_F16", "QB4_F16"]:
         $for M in range(0, MR):
           $for N in range(0, NR, 8):
             float16x8_t vfp16out${M}x${ABC[N:N+8]} = vcombine_f16(vcvt_f16_f32(vout${M}x${ABC[N:N+4]}), vcvt_f16_f32(vout${M}x${ABC[N+4:N+8]}));

--- a/src/xnnpack/gemm.h
+++ b/src/xnnpack/gemm.h
@@ -671,6 +671,20 @@ DECLARE_QD8_F16_QB4W_GEMM_MINMAX_UKERNEL_FUNCTION(xnn_qd8_f16_qb4w_gemm_minmax_u
 DECLARE_QD8_F16_QB4W_GEMM_MINMAX_UKERNEL_FUNCTION(xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x8__scalar)
 DECLARE_QD8_F16_QB4W_GEMM_MINMAX_UKERNEL_FUNCTION(xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x4__scalar)
 
+DECLARE_QD8_F16_QB4W_GEMM_MINMAX_UKERNEL_FUNCTION(xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x8c4__neondotfp16arith)
+DECLARE_QD8_F16_QB4W_GEMM_MINMAX_UKERNEL_FUNCTION(xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x8c4__neondotfp16arith)
+DECLARE_QD8_F16_QB4W_GEMM_MINMAX_UKERNEL_FUNCTION(xnn_qd8_f16_qb4w_gemm_minmax_ukernel_3x8c4__neondotfp16arith)
+DECLARE_QD8_F16_QB4W_GEMM_MINMAX_UKERNEL_FUNCTION(xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x8c4__neondotfp16arith)
+DECLARE_QD8_F16_QB4W_GEMM_MINMAX_UKERNEL_FUNCTION(xnn_qd8_f16_qb4w_gemm_minmax_ukernel_5x8c4__neondotfp16arith)
+DECLARE_QD8_F16_QB4W_GEMM_MINMAX_UKERNEL_FUNCTION(xnn_qd8_f16_qb4w_gemm_minmax_ukernel_6x8c4__neondotfp16arith)
+
+DECLARE_QD8_F16_QB4W_GEMM_MINMAX_UKERNEL_FUNCTION(xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x16c4__neondotfp16arith)
+DECLARE_QD8_F16_QB4W_GEMM_MINMAX_UKERNEL_FUNCTION(xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x16c4__neondotfp16arith)
+DECLARE_QD8_F16_QB4W_GEMM_MINMAX_UKERNEL_FUNCTION(xnn_qd8_f16_qb4w_gemm_minmax_ukernel_3x16c4__neondotfp16arith)
+DECLARE_QD8_F16_QB4W_GEMM_MINMAX_UKERNEL_FUNCTION(xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x16c4__neondotfp16arith)
+DECLARE_QD8_F16_QB4W_GEMM_MINMAX_UKERNEL_FUNCTION(xnn_qd8_f16_qb4w_gemm_minmax_ukernel_5x16c4__neondotfp16arith)
+DECLARE_QD8_F16_QB4W_GEMM_MINMAX_UKERNEL_FUNCTION(xnn_qd8_f16_qb4w_gemm_minmax_ukernel_6x16c4__neondotfp16arith)
+
 #define DECLARE_F32_QC8W_GEMM_UKERNEL_FUNCTION(fn_name) \
   XNN_INTERNAL void fn_name(                            \
       size_t mr,                                        \
@@ -1930,7 +1944,21 @@ DECLARE_QD8_F32_QB4W_GEMM_MINMAX_UKERNEL_FUNCTION(xnn_qd8_f32_qb4w_gemm_minmax_u
 DECLARE_QD8_F32_QB4W_GEMM_MINMAX_UKERNEL_FUNCTION(xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x4c8__sse2_ld64)
 DECLARE_QD8_F32_QB4W_GEMM_MINMAX_UKERNEL_FUNCTION(xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x4c8__sse2_ld64)
 DECLARE_QD8_F32_QB4W_GEMM_MINMAX_UKERNEL_FUNCTION(xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x4c8__sse2_ld64)
-    
+
+DECLARE_QD8_F32_QB4W_GEMM_MINMAX_UKERNEL_FUNCTION(xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x8c4__neondot)
+DECLARE_QD8_F32_QB4W_GEMM_MINMAX_UKERNEL_FUNCTION(xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x8c4__neondot)
+DECLARE_QD8_F32_QB4W_GEMM_MINMAX_UKERNEL_FUNCTION(xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x8c4__neondot)
+DECLARE_QD8_F32_QB4W_GEMM_MINMAX_UKERNEL_FUNCTION(xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x8c4__neondot)
+DECLARE_QD8_F32_QB4W_GEMM_MINMAX_UKERNEL_FUNCTION(xnn_qd8_f32_qb4w_gemm_minmax_ukernel_5x8c4__neondot)
+DECLARE_QD8_F32_QB4W_GEMM_MINMAX_UKERNEL_FUNCTION(xnn_qd8_f32_qb4w_gemm_minmax_ukernel_6x8c4__neondot)
+
+DECLARE_QD8_F32_QB4W_GEMM_MINMAX_UKERNEL_FUNCTION(xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x16c4__neondot)
+DECLARE_QD8_F32_QB4W_GEMM_MINMAX_UKERNEL_FUNCTION(xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x16c4__neondot)
+DECLARE_QD8_F32_QB4W_GEMM_MINMAX_UKERNEL_FUNCTION(xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x16c4__neondot)
+DECLARE_QD8_F32_QB4W_GEMM_MINMAX_UKERNEL_FUNCTION(xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x16c4__neondot)
+DECLARE_QD8_F32_QB4W_GEMM_MINMAX_UKERNEL_FUNCTION(xnn_qd8_f32_qb4w_gemm_minmax_ukernel_5x16c4__neondot)
+DECLARE_QD8_F32_QB4W_GEMM_MINMAX_UKERNEL_FUNCTION(xnn_qd8_f32_qb4w_gemm_minmax_ukernel_6x16c4__neondot)
+
 #define DECLARE_QP8_F32_QC4W_GEMM_MINMAX_UKERNEL_FUNCTION(fn_name) \
   XNN_INTERNAL void fn_name(                                       \
       size_t m,                                                    \

--- a/test/gemm-microkernel-tester.cc
+++ b/test/gemm-microkernel-tester.cc
@@ -76,9 +76,10 @@ TEST_P(GemmTest, Test) {
             if (params.loop_bzp_.is_set) {
               tester.b_zero_point(bzp);
             }
-            for (size_t bl = params.loop_bl_.from; bl <= params.loop_bl_.to;
-                 bl += params.loop_bl_.step) {
-              if (params.loop_bl_.is_set) {
+            for (size_t bl = params.loop_bl_.from; bl <= tester.k() / 2;
+               bl = params.loop_bl_.next(bl)) {
+              
+               if (params.loop_bl_.is_set) {
                 // Require block size to divide (padded) column size.
                 if (round_up_po2(k, params.loop_bl_.step) % bl != 0) {
                   continue;

--- a/test/qd8-f16-qb4w-gemm-minmax.cc
+++ b/test/qd8-f16-qb4w-gemm-minmax.cc
@@ -10,6 +10,11 @@
 //   Specification: test/qd8-f16-qb4w-gemm-minmax.yaml
 //   Generator: tools/generate-gemm-test.py
 
+#include <cstddef>
+#include <functional>
+#include <string>
+#include <vector>
+
 #include <gtest/gtest.h>
 #include "xnnpack/allocator.h"
 #include "xnnpack/common.h"
@@ -21,11 +26,6 @@
 #include "xnnpack/packw.h"
 #include "xnnpack/ppmm.h"
 #include "xnnpack/requantization.h"
-#include <cstddef>
-#include <functional>
-#include <string>
-#include <vector>
-
 #include "gemm-microkernel-tester.h"
 
 namespace {
@@ -226,3 +226,234 @@ INSTANTIATE_TEST_SUITE_P(
     [](const testing::TestParamInfo<GemmTest::ParamType>& info) {
       return info.param.test_name;
     });
+
+
+#if XNN_ENABLE_ARM_DOTPROD && XNN_ENABLE_ARM_FP16_VECTOR && (XNN_ARCH_ARM || XNN_ARCH_ARM64)
+  INSTANTIATE_TEST_SUITE_P(
+      QD8_F16_QB4W_GEMM_MINMAX_1X8C4__NEONDOTFP16ARITH, GemmTest,
+      testing::ValuesIn(CreateTests1(
+          /*k_block=*/8,
+          /*adj_k_block=*/8,
+          /*mr=*/1, /*nr=*/8, /*kr=*/4, /*sr=*/1,
+          /*is_igemm=*/false,
+          [](GemmMicrokernelTester& tester) {
+            tester.Test(xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x8c4__neondotfp16arith,
+                        xnn_init_f16_qb4w_minmax_scalar_params,
+                        xnn_pack_qs8_qb4w_gemm_goi_w);
+          },
+          []() {
+            TEST_REQUIRES_ARM_NEON_DOT_FP16_ARITH;
+          })),
+      [](const testing::TestParamInfo<GemmTest::ParamType>& info) {
+        return info.param.test_name;
+      });
+
+  INSTANTIATE_TEST_SUITE_P(
+      QD8_F16_QB4W_GEMM_MINMAX_1X16C4__NEONDOTFP16ARITH, GemmTest,
+      testing::ValuesIn(CreateTests1(
+          /*k_block=*/8,
+          /*adj_k_block=*/8,
+          /*mr=*/1, /*nr=*/16, /*kr=*/4, /*sr=*/1,
+          /*is_igemm=*/false,
+          [](GemmMicrokernelTester& tester) {
+            tester.Test(xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x16c4__neondotfp16arith,
+                        xnn_init_f16_qb4w_minmax_scalar_params,
+                        xnn_pack_qs8_qb4w_gemm_goi_w);
+          },
+          []() {
+            TEST_REQUIRES_ARM_NEON_DOT_FP16_ARITH;
+          })),
+      [](const testing::TestParamInfo<GemmTest::ParamType>& info) {
+        return info.param.test_name;
+      });
+
+  INSTANTIATE_TEST_SUITE_P(
+      QD8_F16_QB4W_GEMM_MINMAX_2X8C4__NEONDOTFP16ARITH, GemmTest,
+      testing::ValuesIn(CreateTests1(
+          /*k_block=*/8,
+          /*adj_k_block=*/8,
+          /*mr=*/2, /*nr=*/8, /*kr=*/4, /*sr=*/1,
+          /*is_igemm=*/false,
+          [](GemmMicrokernelTester& tester) {
+            tester.Test(xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x8c4__neondotfp16arith,
+                        xnn_init_f16_qb4w_minmax_scalar_params,
+                        xnn_pack_qs8_qb4w_gemm_goi_w);
+          },
+          []() {
+            TEST_REQUIRES_ARM_NEON_DOT_FP16_ARITH;
+          })),
+      [](const testing::TestParamInfo<GemmTest::ParamType>& info) {
+        return info.param.test_name;
+      });
+
+  INSTANTIATE_TEST_SUITE_P(
+      QD8_F16_QB4W_GEMM_MINMAX_2X16C4__NEONDOTFP16ARITH, GemmTest,
+      testing::ValuesIn(CreateTests1(
+          /*k_block=*/8,
+          /*adj_k_block=*/8,
+          /*mr=*/2, /*nr=*/16, /*kr=*/4, /*sr=*/1,
+          /*is_igemm=*/false,
+          [](GemmMicrokernelTester& tester) {
+            tester.Test(xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x16c4__neondotfp16arith,
+                        xnn_init_f16_qb4w_minmax_scalar_params,
+                        xnn_pack_qs8_qb4w_gemm_goi_w);
+          },
+          []() {
+            TEST_REQUIRES_ARM_NEON_DOT_FP16_ARITH;
+          })),
+      [](const testing::TestParamInfo<GemmTest::ParamType>& info) {
+        return info.param.test_name;
+      });
+
+  INSTANTIATE_TEST_SUITE_P(
+      QD8_F16_QB4W_GEMM_MINMAX_3X8C4__NEONDOTFP16ARITH, GemmTest,
+      testing::ValuesIn(CreateTests1(
+          /*k_block=*/8,
+          /*adj_k_block=*/8,
+          /*mr=*/3, /*nr=*/8, /*kr=*/4, /*sr=*/1,
+          /*is_igemm=*/false,
+          [](GemmMicrokernelTester& tester) {
+            tester.Test(xnn_qd8_f16_qb4w_gemm_minmax_ukernel_3x8c4__neondotfp16arith,
+                        xnn_init_f16_qb4w_minmax_scalar_params,
+                        xnn_pack_qs8_qb4w_gemm_goi_w);
+          },
+          []() {
+            TEST_REQUIRES_ARM_NEON_DOT_FP16_ARITH;
+          })),
+      [](const testing::TestParamInfo<GemmTest::ParamType>& info) {
+        return info.param.test_name;
+      });
+
+  INSTANTIATE_TEST_SUITE_P(
+      QD8_F16_QB4W_GEMM_MINMAX_3X16C4__NEONDOTFP16ARITH, GemmTest,
+      testing::ValuesIn(CreateTests1(
+          /*k_block=*/8,
+          /*adj_k_block=*/8,
+          /*mr=*/3, /*nr=*/16, /*kr=*/4, /*sr=*/1,
+          /*is_igemm=*/false,
+          [](GemmMicrokernelTester& tester) {
+            tester.Test(xnn_qd8_f16_qb4w_gemm_minmax_ukernel_3x16c4__neondotfp16arith,
+                        xnn_init_f16_qb4w_minmax_scalar_params,
+                        xnn_pack_qs8_qb4w_gemm_goi_w);
+          },
+          []() {
+            TEST_REQUIRES_ARM_NEON_DOT_FP16_ARITH;
+          })),
+      [](const testing::TestParamInfo<GemmTest::ParamType>& info) {
+        return info.param.test_name;
+      });
+
+  INSTANTIATE_TEST_SUITE_P(
+      QD8_F16_QB4W_GEMM_MINMAX_4X8C4__NEONDOTFP16ARITH, GemmTest,
+      testing::ValuesIn(CreateTests1(
+          /*k_block=*/8,
+          /*adj_k_block=*/8,
+          /*mr=*/4, /*nr=*/8, /*kr=*/4, /*sr=*/1,
+          /*is_igemm=*/false,
+          [](GemmMicrokernelTester& tester) {
+            tester.Test(xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x8c4__neondotfp16arith,
+                        xnn_init_f16_qb4w_minmax_scalar_params,
+                        xnn_pack_qs8_qb4w_gemm_goi_w);
+          },
+          []() {
+            TEST_REQUIRES_ARM_NEON_DOT_FP16_ARITH;
+          })),
+      [](const testing::TestParamInfo<GemmTest::ParamType>& info) {
+        return info.param.test_name;
+      });
+
+  INSTANTIATE_TEST_SUITE_P(
+      QD8_F16_QB4W_GEMM_MINMAX_4X16C4__NEONDOTFP16ARITH, GemmTest,
+      testing::ValuesIn(CreateTests1(
+          /*k_block=*/8,
+          /*adj_k_block=*/8,
+          /*mr=*/4, /*nr=*/16, /*kr=*/4, /*sr=*/1,
+          /*is_igemm=*/false,
+          [](GemmMicrokernelTester& tester) {
+            tester.Test(xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x16c4__neondotfp16arith,
+                        xnn_init_f16_qb4w_minmax_scalar_params,
+                        xnn_pack_qs8_qb4w_gemm_goi_w);
+          },
+          []() {
+            TEST_REQUIRES_ARM_NEON_DOT_FP16_ARITH;
+          })),
+      [](const testing::TestParamInfo<GemmTest::ParamType>& info) {
+        return info.param.test_name;
+      });
+
+  INSTANTIATE_TEST_SUITE_P(
+      QD8_F16_QB4W_GEMM_MINMAX_5X8C4__NEONDOTFP16ARITH, GemmTest,
+      testing::ValuesIn(CreateTests1(
+          /*k_block=*/8,
+          /*adj_k_block=*/8,
+          /*mr=*/5, /*nr=*/8, /*kr=*/4, /*sr=*/1,
+          /*is_igemm=*/false,
+          [](GemmMicrokernelTester& tester) {
+            tester.Test(xnn_qd8_f16_qb4w_gemm_minmax_ukernel_5x8c4__neondotfp16arith,
+                        xnn_init_f16_qb4w_minmax_scalar_params,
+                        xnn_pack_qs8_qb4w_gemm_goi_w);
+          },
+          []() {
+            TEST_REQUIRES_ARM_NEON_DOT_FP16_ARITH;
+          })),
+      [](const testing::TestParamInfo<GemmTest::ParamType>& info) {
+        return info.param.test_name;
+      });
+
+  INSTANTIATE_TEST_SUITE_P(
+      QD8_F16_QB4W_GEMM_MINMAX_5X16C4__NEONDOTFP16ARITH, GemmTest,
+      testing::ValuesIn(CreateTests1(
+          /*k_block=*/8,
+          /*adj_k_block=*/8,
+          /*mr=*/5, /*nr=*/16, /*kr=*/4, /*sr=*/1,
+          /*is_igemm=*/false,
+          [](GemmMicrokernelTester& tester) {
+            tester.Test(xnn_qd8_f16_qb4w_gemm_minmax_ukernel_5x16c4__neondotfp16arith,
+                        xnn_init_f16_qb4w_minmax_scalar_params,
+                        xnn_pack_qs8_qb4w_gemm_goi_w);
+          },
+          []() {
+            TEST_REQUIRES_ARM_NEON_DOT_FP16_ARITH;
+          })),
+      [](const testing::TestParamInfo<GemmTest::ParamType>& info) {
+        return info.param.test_name;
+      });
+
+  INSTANTIATE_TEST_SUITE_P(
+      QD8_F16_QB4W_GEMM_MINMAX_6X8C4__NEONDOTFP16ARITH, GemmTest,
+      testing::ValuesIn(CreateTests1(
+          /*k_block=*/8,
+          /*adj_k_block=*/8,
+          /*mr=*/6, /*nr=*/8, /*kr=*/4, /*sr=*/1,
+          /*is_igemm=*/false,
+          [](GemmMicrokernelTester& tester) {
+            tester.Test(xnn_qd8_f16_qb4w_gemm_minmax_ukernel_6x8c4__neondotfp16arith,
+                        xnn_init_f16_qb4w_minmax_scalar_params,
+                        xnn_pack_qs8_qb4w_gemm_goi_w);
+          },
+          []() {
+            TEST_REQUIRES_ARM_NEON_DOT_FP16_ARITH;
+          })),
+      [](const testing::TestParamInfo<GemmTest::ParamType>& info) {
+        return info.param.test_name;
+      });
+
+  INSTANTIATE_TEST_SUITE_P(
+      QD8_F16_QB4W_GEMM_MINMAX_6X16C4__NEONDOTFP16ARITH, GemmTest,
+      testing::ValuesIn(CreateTests1(
+          /*k_block=*/8,
+          /*adj_k_block=*/8,
+          /*mr=*/6, /*nr=*/16, /*kr=*/4, /*sr=*/1,
+          /*is_igemm=*/false,
+          [](GemmMicrokernelTester& tester) {
+            tester.Test(xnn_qd8_f16_qb4w_gemm_minmax_ukernel_6x16c4__neondotfp16arith,
+                        xnn_init_f16_qb4w_minmax_scalar_params,
+                        xnn_pack_qs8_qb4w_gemm_goi_w);
+          },
+          []() {
+            TEST_REQUIRES_ARM_NEON_DOT_FP16_ARITH;
+          })),
+      [](const testing::TestParamInfo<GemmTest::ParamType>& info) {
+        return info.param.test_name;
+      });
+#endif  // XNN_ENABLE_ARM_DOTPROD && XNN_ENABLE_ARM_FP16_VECTOR && (XNN_ARCH_ARM || XNN_ARCH_ARM64)

--- a/test/qd8-f16-qb4w-gemm-minmax.yaml
+++ b/test/qd8-f16-qb4w-gemm-minmax.yaml
@@ -38,3 +38,53 @@
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
   k-block: 2
+
+# ARM NEONDOT
+- name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x8c4__neondotfp16arith
+  init: xnn_init_f16_qb4w_minmax_scalar_params
+  pack: xnn_pack_qs8_qb4w_gemm_goi_w
+  k-block: 8
+- name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x16c4__neondotfp16arith
+  init: xnn_init_f16_qb4w_minmax_scalar_params
+  pack: xnn_pack_qs8_qb4w_gemm_goi_w
+  k-block: 8
+- name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x8c4__neondotfp16arith
+  init: xnn_init_f16_qb4w_minmax_scalar_params
+  pack: xnn_pack_qs8_qb4w_gemm_goi_w
+  k-block: 8
+- name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x16c4__neondotfp16arith
+  init: xnn_init_f16_qb4w_minmax_scalar_params
+  pack: xnn_pack_qs8_qb4w_gemm_goi_w
+  k-block: 8
+- name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_3x8c4__neondotfp16arith
+  init: xnn_init_f16_qb4w_minmax_scalar_params
+  pack: xnn_pack_qs8_qb4w_gemm_goi_w
+  k-block: 8
+- name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_3x16c4__neondotfp16arith
+  init: xnn_init_f16_qb4w_minmax_scalar_params
+  pack: xnn_pack_qs8_qb4w_gemm_goi_w
+  k-block: 8
+- name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x8c4__neondotfp16arith
+  init: xnn_init_f16_qb4w_minmax_scalar_params
+  pack: xnn_pack_qs8_qb4w_gemm_goi_w
+  k-block: 8
+- name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x16c4__neondotfp16arith
+  init: xnn_init_f16_qb4w_minmax_scalar_params
+  pack: xnn_pack_qs8_qb4w_gemm_goi_w
+  k-block: 8
+- name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_5x8c4__neondotfp16arith
+  init: xnn_init_f16_qb4w_minmax_scalar_params
+  pack: xnn_pack_qs8_qb4w_gemm_goi_w
+  k-block: 8
+- name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_5x16c4__neondotfp16arith
+  init: xnn_init_f16_qb4w_minmax_scalar_params
+  pack: xnn_pack_qs8_qb4w_gemm_goi_w
+  k-block: 8
+- name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_6x8c4__neondotfp16arith
+  init: xnn_init_f16_qb4w_minmax_scalar_params
+  pack: xnn_pack_qs8_qb4w_gemm_goi_w
+  k-block: 8
+- name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_6x16c4__neondotfp16arith
+  init: xnn_init_f16_qb4w_minmax_scalar_params
+  pack: xnn_pack_qs8_qb4w_gemm_goi_w
+  k-block: 8

--- a/test/qd8-f32-qb4w-gemm-minmax.cc
+++ b/test/qd8-f32-qb4w-gemm-minmax.cc
@@ -685,3 +685,234 @@ INSTANTIATE_TEST_SUITE_P(
         return info.param.test_name;
       });
 #endif  // XNN_ARCH_X86 || XNN_ARCH_X86_64
+
+
+#if XNN_ENABLE_ARM_DOTPROD && (XNN_ARCH_ARM || XNN_ARCH_ARM64)
+  INSTANTIATE_TEST_SUITE_P(
+      QD8_F32_QB4W_GEMM_MINMAX_1X8C4__NEONDOT, GemmTest,
+      testing::ValuesIn(CreateTests1(
+          /*k_block=*/8,
+          /*adj_k_block=*/8,
+          /*mr=*/1, /*nr=*/8, /*kr=*/4, /*sr=*/1,
+          /*is_igemm=*/false,
+          [](GemmMicrokernelTester& tester) {
+            tester.Test(xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x8c4__neondot,
+                        xnn_init_f32_qb4w_minmax_scalar_params,
+                        xnn_pack_qs8_qb4w_gemm_goi_w);
+          },
+          []() {
+            TEST_REQUIRES_ARM_NEON_DOT;
+          })),
+      [](const testing::TestParamInfo<GemmTest::ParamType>& info) {
+        return info.param.test_name;
+      });
+
+  INSTANTIATE_TEST_SUITE_P(
+      QD8_F32_QB4W_GEMM_MINMAX_1X16C4__NEONDOT, GemmTest,
+      testing::ValuesIn(CreateTests1(
+          /*k_block=*/8,
+          /*adj_k_block=*/8,
+          /*mr=*/1, /*nr=*/16, /*kr=*/4, /*sr=*/1,
+          /*is_igemm=*/false,
+          [](GemmMicrokernelTester& tester) {
+            tester.Test(xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x16c4__neondot,
+                        xnn_init_f32_qb4w_minmax_scalar_params,
+                        xnn_pack_qs8_qb4w_gemm_goi_w);
+          },
+          []() {
+            TEST_REQUIRES_ARM_NEON_DOT;
+          })),
+      [](const testing::TestParamInfo<GemmTest::ParamType>& info) {
+        return info.param.test_name;
+      });
+
+  INSTANTIATE_TEST_SUITE_P(
+      QD8_F32_QB4W_GEMM_MINMAX_2X8C4__NEONDOT, GemmTest,
+      testing::ValuesIn(CreateTests1(
+          /*k_block=*/8,
+          /*adj_k_block=*/8,
+          /*mr=*/2, /*nr=*/8, /*kr=*/4, /*sr=*/1,
+          /*is_igemm=*/false,
+          [](GemmMicrokernelTester& tester) {
+            tester.Test(xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x8c4__neondot,
+                        xnn_init_f32_qb4w_minmax_scalar_params,
+                        xnn_pack_qs8_qb4w_gemm_goi_w);
+          },
+          []() {
+            TEST_REQUIRES_ARM_NEON_DOT;
+          })),
+      [](const testing::TestParamInfo<GemmTest::ParamType>& info) {
+        return info.param.test_name;
+      });
+
+  INSTANTIATE_TEST_SUITE_P(
+      QD8_F32_QB4W_GEMM_MINMAX_2X16C4__NEONDOT, GemmTest,
+      testing::ValuesIn(CreateTests1(
+          /*k_block=*/8,
+          /*adj_k_block=*/8,
+          /*mr=*/2, /*nr=*/16, /*kr=*/4, /*sr=*/1,
+          /*is_igemm=*/false,
+          [](GemmMicrokernelTester& tester) {
+            tester.Test(xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x16c4__neondot,
+                        xnn_init_f32_qb4w_minmax_scalar_params,
+                        xnn_pack_qs8_qb4w_gemm_goi_w);
+          },
+          []() {
+            TEST_REQUIRES_ARM_NEON_DOT;
+          })),
+      [](const testing::TestParamInfo<GemmTest::ParamType>& info) {
+        return info.param.test_name;
+      });
+
+  INSTANTIATE_TEST_SUITE_P(
+      QD8_F32_QB4W_GEMM_MINMAX_3X8C4__NEONDOT, GemmTest,
+      testing::ValuesIn(CreateTests1(
+          /*k_block=*/8,
+          /*adj_k_block=*/8,
+          /*mr=*/3, /*nr=*/8, /*kr=*/4, /*sr=*/1,
+          /*is_igemm=*/false,
+          [](GemmMicrokernelTester& tester) {
+            tester.Test(xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x8c4__neondot,
+                        xnn_init_f32_qb4w_minmax_scalar_params,
+                        xnn_pack_qs8_qb4w_gemm_goi_w);
+          },
+          []() {
+            TEST_REQUIRES_ARM_NEON_DOT;
+          })),
+      [](const testing::TestParamInfo<GemmTest::ParamType>& info) {
+        return info.param.test_name;
+      });
+
+  INSTANTIATE_TEST_SUITE_P(
+      QD8_F32_QB4W_GEMM_MINMAX_3X16C4__NEONDOT, GemmTest,
+      testing::ValuesIn(CreateTests1(
+          /*k_block=*/8,
+          /*adj_k_block=*/8,
+          /*mr=*/3, /*nr=*/16, /*kr=*/4, /*sr=*/1,
+          /*is_igemm=*/false,
+          [](GemmMicrokernelTester& tester) {
+            tester.Test(xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x16c4__neondot,
+                        xnn_init_f32_qb4w_minmax_scalar_params,
+                        xnn_pack_qs8_qb4w_gemm_goi_w);
+          },
+          []() {
+            TEST_REQUIRES_ARM_NEON_DOT;
+          })),
+      [](const testing::TestParamInfo<GemmTest::ParamType>& info) {
+        return info.param.test_name;
+      });
+
+  INSTANTIATE_TEST_SUITE_P(
+      QD8_F32_QB4W_GEMM_MINMAX_4X8C4__NEONDOT, GemmTest,
+      testing::ValuesIn(CreateTests1(
+          /*k_block=*/8,
+          /*adj_k_block=*/8,
+          /*mr=*/4, /*nr=*/8, /*kr=*/4, /*sr=*/1,
+          /*is_igemm=*/false,
+          [](GemmMicrokernelTester& tester) {
+            tester.Test(xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x8c4__neondot,
+                        xnn_init_f32_qb4w_minmax_scalar_params,
+                        xnn_pack_qs8_qb4w_gemm_goi_w);
+          },
+          []() {
+            TEST_REQUIRES_ARM_NEON_DOT;
+          })),
+      [](const testing::TestParamInfo<GemmTest::ParamType>& info) {
+        return info.param.test_name;
+      });
+
+  INSTANTIATE_TEST_SUITE_P(
+      QD8_F32_QB4W_GEMM_MINMAX_4X16C4__NEONDOT, GemmTest,
+      testing::ValuesIn(CreateTests1(
+          /*k_block=*/8,
+          /*adj_k_block=*/8,
+          /*mr=*/4, /*nr=*/16, /*kr=*/4, /*sr=*/1,
+          /*is_igemm=*/false,
+          [](GemmMicrokernelTester& tester) {
+            tester.Test(xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x16c4__neondot,
+                        xnn_init_f32_qb4w_minmax_scalar_params,
+                        xnn_pack_qs8_qb4w_gemm_goi_w);
+          },
+          []() {
+            TEST_REQUIRES_ARM_NEON_DOT;
+          })),
+      [](const testing::TestParamInfo<GemmTest::ParamType>& info) {
+        return info.param.test_name;
+      });
+
+  INSTANTIATE_TEST_SUITE_P(
+      QD8_F32_QB4W_GEMM_MINMAX_5X8C4__NEONDOT, GemmTest,
+      testing::ValuesIn(CreateTests1(
+          /*k_block=*/8,
+          /*adj_k_block=*/8,
+          /*mr=*/5, /*nr=*/8, /*kr=*/4, /*sr=*/1,
+          /*is_igemm=*/false,
+          [](GemmMicrokernelTester& tester) {
+            tester.Test(xnn_qd8_f32_qb4w_gemm_minmax_ukernel_5x8c4__neondot,
+                        xnn_init_f32_qb4w_minmax_scalar_params,
+                        xnn_pack_qs8_qb4w_gemm_goi_w);
+          },
+          []() {
+            TEST_REQUIRES_ARM_NEON_DOT;
+          })),
+      [](const testing::TestParamInfo<GemmTest::ParamType>& info) {
+        return info.param.test_name;
+      });
+
+  INSTANTIATE_TEST_SUITE_P(
+      QD8_F32_QB4W_GEMM_MINMAX_5X16C4__NEONDOT, GemmTest,
+      testing::ValuesIn(CreateTests1(
+          /*k_block=*/8,
+          /*adj_k_block=*/8,
+          /*mr=*/5, /*nr=*/16, /*kr=*/4, /*sr=*/1,
+          /*is_igemm=*/false,
+          [](GemmMicrokernelTester& tester) {
+            tester.Test(xnn_qd8_f32_qb4w_gemm_minmax_ukernel_5x16c4__neondot,
+                        xnn_init_f32_qb4w_minmax_scalar_params,
+                        xnn_pack_qs8_qb4w_gemm_goi_w);
+          },
+          []() {
+            TEST_REQUIRES_ARM_NEON_DOT;
+          })),
+      [](const testing::TestParamInfo<GemmTest::ParamType>& info) {
+        return info.param.test_name;
+      });
+
+  INSTANTIATE_TEST_SUITE_P(
+      QD8_F32_QB4W_GEMM_MINMAX_6X8C4__NEONDOT, GemmTest,
+      testing::ValuesIn(CreateTests1(
+          /*k_block=*/8,
+          /*adj_k_block=*/8,
+          /*mr=*/6, /*nr=*/8, /*kr=*/4, /*sr=*/1,
+          /*is_igemm=*/false,
+          [](GemmMicrokernelTester& tester) {
+            tester.Test(xnn_qd8_f32_qb4w_gemm_minmax_ukernel_6x8c4__neondot,
+                        xnn_init_f32_qb4w_minmax_scalar_params,
+                        xnn_pack_qs8_qb4w_gemm_goi_w);
+          },
+          []() {
+            TEST_REQUIRES_ARM_NEON_DOT;
+          })),
+      [](const testing::TestParamInfo<GemmTest::ParamType>& info) {
+        return info.param.test_name;
+      });
+
+  INSTANTIATE_TEST_SUITE_P(
+      QD8_F32_QB4W_GEMM_MINMAX_6X16C4__NEONDOT, GemmTest,
+      testing::ValuesIn(CreateTests1(
+          /*k_block=*/8,
+          /*adj_k_block=*/8,
+          /*mr=*/6, /*nr=*/16, /*kr=*/4, /*sr=*/1,
+          /*is_igemm=*/false,
+          [](GemmMicrokernelTester& tester) {
+            tester.Test(xnn_qd8_f32_qb4w_gemm_minmax_ukernel_6x16c4__neondot,
+                        xnn_init_f32_qb4w_minmax_scalar_params,
+                        xnn_pack_qs8_qb4w_gemm_goi_w);
+          },
+          []() {
+            TEST_REQUIRES_ARM_NEON_DOT;
+          })),
+      [](const testing::TestParamInfo<GemmTest::ParamType>& info) {
+        return info.param.test_name;
+      });
+#endif  // XNN_ENABLE_ARM_DOTPROD && (XNN_ARCH_ARM || XNN_ARCH_ARM64)

--- a/test/qd8-f32-qb4w-gemm-minmax.yaml
+++ b/test/qd8-f32-qb4w-gemm-minmax.yaml
@@ -161,3 +161,53 @@
   init: xnn_init_f32_qb4w_minmax_sse_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
   k-block: 16
+
+  # ARM NEONDOT
+- name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x8c4__neondot
+  init: xnn_init_f32_qb4w_minmax_scalar_params
+  pack: xnn_pack_qs8_qb4w_gemm_goi_w
+  k-block: 8
+- name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x16c4__neondot
+  init: xnn_init_f32_qb4w_minmax_scalar_params
+  pack: xnn_pack_qs8_qb4w_gemm_goi_w
+  k-block: 8
+- name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x8c4__neondot
+  init: xnn_init_f32_qb4w_minmax_scalar_params
+  pack: xnn_pack_qs8_qb4w_gemm_goi_w
+  k-block: 8
+- name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x16c4__neondot
+  init: xnn_init_f32_qb4w_minmax_scalar_params
+  pack: xnn_pack_qs8_qb4w_gemm_goi_w
+  k-block: 8
+- name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x8c4__neondot
+  init: xnn_init_f32_qb4w_minmax_scalar_params
+  pack: xnn_pack_qs8_qb4w_gemm_goi_w
+  k-block: 8
+- name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x16c4__neondot
+  init: xnn_init_f32_qb4w_minmax_scalar_params
+  pack: xnn_pack_qs8_qb4w_gemm_goi_w
+  k-block: 8
+- name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x8c4__neondot
+  init: xnn_init_f32_qb4w_minmax_scalar_params
+  pack: xnn_pack_qs8_qb4w_gemm_goi_w
+  k-block: 8
+- name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x16c4__neondot
+  init: xnn_init_f32_qb4w_minmax_scalar_params
+  pack: xnn_pack_qs8_qb4w_gemm_goi_w
+  k-block: 8
+- name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_5x8c4__neondot
+  init: xnn_init_f32_qb4w_minmax_scalar_params
+  pack: xnn_pack_qs8_qb4w_gemm_goi_w
+  k-block: 8
+- name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_5x16c4__neondot
+  init: xnn_init_f32_qb4w_minmax_scalar_params
+  pack: xnn_pack_qs8_qb4w_gemm_goi_w
+  k-block: 8
+- name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_6x8c4__neondot
+  init: xnn_init_f32_qb4w_minmax_scalar_params
+  pack: xnn_pack_qs8_qb4w_gemm_goi_w
+  k-block: 8
+- name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_6x16c4__neondot
+  init: xnn_init_f32_qb4w_minmax_scalar_params
+  pack: xnn_pack_qs8_qb4w_gemm_goi_w
+  k-block: 8


### PR DESCRIPTION
Add QB4W `{1,2,3,4,5,6}x{8,16}c4__neondot` gemm kernels for F16 and F32. Performance is as we discussed, using QC4W as a baseline, compared two block sizes {32, 256} for small and large use cases. For smaller blocks there is ~20% overhead while the large blocks setup keeps up with QC4W.

Here is a graph:
![image](https://github.com/google/XNNPACK/assets/368720/7f57d95b-ac74-4d5b-8615-3ce234080675)

Here are some numbers:
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:////Users/digantdesai/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip.htm">
<link rel=File-List
href="file:////Users/digantdesai/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip_filelist.xml">

<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:12.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:"Aptos Narrow", sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{mso-number-format:"0\.0";}
-->

</head>

<body link="#467886" vlink="#96607D">


GOPS (mean) | M | N | K | qd8_f32_qb4w, bl=32 | qd8_f32_qb4w, bl=256 | qd8_f32_qc4w
-- | -- | -- | -- | -- | -- | --
1x16c4 | 128 | 16 | 1024 | 128.0 | 154.6 | 150.1
  |   | 128 | 1024 | 127.9 | 155.5 | 151.2
  |   | 4096 | 1024 | 122.3 | 149.1 | 149.7
  |   | 11008 | 4096 | 97.4 | 117.7 | 120.0
  |   | 32000 | 4096 | 97.2 | 118.2 | 121.0
1x8c4 | 128 | 16 | 1024 | 120.5 | 128.7 | 118.9
  |   | 128 | 1024 | 117.7 | 127.3 | 118.1
  |   | 4096 | 1024 | 109.5 | 116.3 | 112.1
  |   | 11008 | 4096 | 95.9 | 108.9 | 105.9
  |   | 32000 | 4096 | 95.7 | 108.4 | 103.9
2x16c4 | 128 | 16 | 1024 | 164.5 | 204.7 | 207.9
  |   | 128 | 1024 | 165.3 | 205.0 | 205.0
  |   | 4096 | 1024 | 163.8 | 201.9 | 206.3
  |   | 11008 | 4096 | 138.3 | 182.8 | 190.7
  |   | 32000 | 4096 | 138.8 | 188.8 | 190.3
2x8c4 | 128 | 16 | 1024 | 157.3 | 171.8 | 165.6
  |   | 128 | 1024 | 151.3 | 172.3 | 166.5
  |   | 4096 | 1024 | 152.5 | 168.8 | 167.7
  |   | 11008 | 4096 | 144.1 | 158.8 | 157.7
  |   | 32000 | 4096 | 145.5 | 161.4 | 159.0
4x16c4 | 128 | 16 | 1024 | 178.4 | 238.9 | 247.6
  |   | 128 | 1024 | 181.1 | 246.1 | 251.6
  |   | 4096 | 1024 | 181.2 | 246.3 | 255.4
  |   | 11008 | 4096 | 163.2 | 214.3 | 225.5
  |   | 32000 | 4096 | 167.3 | 220.3 | 225.0
4x8c4 | 128 | 16 | 1024 | 182.9 | 228.8 | 236.1
  |   | 128 | 1024 | 180.6 | 229.9 | 240.2
  |   | 4096 | 1024 | 179.6 | 222.5 | 229.3
  |   | 11008 | 4096 | 171.6 | 212.5 | 221.9
  |   | 32000 | 4096 | 172.6 | 215.3 | 222.7
</body>
</html>
