### PR TITLE
Cleanup/Simplify HVX `f32-vbinary/f32-vbinaryc` implementations

### DIFF
--- a/src/f32-vbinary/gen/f32-vadd-minmax-hvx-u128.c
+++ b/src/f32-vbinary/gen/f32-vadd-minmax-hvx-u128.c
@@ -5,12 +5,8 @@
 
 #include <assert.h>
 
-#include <hvx_hexagon_protos.h>
-#include <hexagon_protos.h>
-#include <hexagon_types.h>
+#include "xnnpack/simd/f32-hvx.h"
 
-#include "xnnpack/common.h"
-#include "xnnpack/intrinsics-polyfill.h"
 #include "xnnpack/math.h"
 #include "xnnpack/vbinary.h"
 
@@ -27,61 +23,64 @@ void xnn_f32_vadd_minmax_ukernel__hvx_u128(
   assert(input_b != NULL);
   assert(output != NULL);
 
-  const HVX_Vector voutput_min = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.min));
-  const HVX_Vector voutput_max = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.max));
-
-  const HVX_UVector *vptr_a = (const HVX_UVector *) input_a;
-  const HVX_UVector *vptr_b = (const HVX_UVector *) input_b;
-  HVX_UVector *vptr_o = (HVX_UVector*) output;
+  const HVX_Vector voutput_min = xnn_set1_f32(params->scalar.min);
+  const HVX_Vector voutput_max = xnn_set1_f32(params->scalar.max);
 
   for (; batch >= 128 * sizeof(float); batch -= 128 * sizeof(float)) {
-    HVX_Vector va0 = *vptr_a++;
-    HVX_Vector va1 = *vptr_a++;
-    HVX_Vector va2 = *vptr_a++;
-    HVX_Vector va3 = *vptr_a++;
-    HVX_Vector vb0 = *vptr_b++;
-    HVX_Vector vb1 = *vptr_b++;
-    HVX_Vector vb2 = *vptr_b++;
-    HVX_Vector vb3 = *vptr_b++;
+    HVX_Vector va0 = xnn_loadu_f32(input_a);
+    HVX_Vector va1 = xnn_loadu_f32(input_a + 32);
+    HVX_Vector va2 = xnn_loadu_f32(input_a + 64);
+    HVX_Vector va3 = xnn_loadu_f32(input_a + 96);
+    HVX_Vector vb0 = xnn_loadu_f32(input_b);
+    HVX_Vector vb1 = xnn_loadu_f32(input_b + 32);
+    HVX_Vector vb2 = xnn_loadu_f32(input_b + 64);
+    HVX_Vector vb3 = xnn_loadu_f32(input_b + 96);
+    input_a += 128;
+    input_b += 128;
 
-    HVX_Vector vacc0 = Q6_Vsf_vadd_VsfVsf(va0, vb0);
-    HVX_Vector vacc1 = Q6_Vsf_vadd_VsfVsf(va1, vb1);
-    HVX_Vector vacc2 = Q6_Vsf_vadd_VsfVsf(va2, vb2);
-    HVX_Vector vacc3 = Q6_Vsf_vadd_VsfVsf(va3, vb3);
+    HVX_Vector vacc0 = xnn_add_f32(va0, vb0);
+    HVX_Vector vacc1 = xnn_add_f32(va1, vb1);
+    HVX_Vector vacc2 = xnn_add_f32(va2, vb2);
+    HVX_Vector vacc3 = xnn_add_f32(va3, vb3);
 
-    vacc0 = Q6_Vsf_vmax_VsfVsf(vacc0, voutput_min);
-    vacc1 = Q6_Vsf_vmax_VsfVsf(vacc1, voutput_min);
-    vacc2 = Q6_Vsf_vmax_VsfVsf(vacc2, voutput_min);
-    vacc3 = Q6_Vsf_vmax_VsfVsf(vacc3, voutput_min);
 
-    vacc0 = Q6_Vsf_vmin_VsfVsf(vacc0, voutput_max);
-    vacc1 = Q6_Vsf_vmin_VsfVsf(vacc1, voutput_max);
-    vacc2 = Q6_Vsf_vmin_VsfVsf(vacc2, voutput_max);
-    vacc3 = Q6_Vsf_vmin_VsfVsf(vacc3, voutput_max);
+    vacc0 = xnn_max_f32(vacc0, voutput_min);
+    vacc1 = xnn_max_f32(vacc1, voutput_min);
+    vacc2 = xnn_max_f32(vacc2, voutput_min);
+    vacc3 = xnn_max_f32(vacc3, voutput_min);
 
-    *vptr_o++ = vacc0;
-    *vptr_o++ = vacc1;
-    *vptr_o++ = vacc2;
-    *vptr_o++ = vacc3;
+    vacc0 = xnn_min_f32(vacc0, voutput_max);
+    vacc1 = xnn_min_f32(vacc1, voutput_max);
+    vacc2 = xnn_min_f32(vacc2, voutput_max);
+    vacc3 = xnn_min_f32(vacc3, voutput_max);
+
+    xnn_storeu_f32(output, vacc0);
+    xnn_storeu_f32(output + 32, vacc1);
+    xnn_storeu_f32(output + 64, vacc2);
+    xnn_storeu_f32(output + 96, vacc3);
+    output += 128;
   }
   for (; batch >= 32 * sizeof(float); batch -= 32 * sizeof(float)) {
-    HVX_Vector va = *vptr_a++;
-    HVX_Vector vb = *vptr_b++;
+    HVX_Vector va = xnn_loadu_f32(input_a);
+    HVX_Vector vb = xnn_loadu_f32(input_b);
+    input_a += 32;
+    input_b += 32;
 
-    HVX_Vector vacc = Q6_Vsf_vadd_VsfVsf(va, vb);
-    vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-    vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+    HVX_Vector vacc = xnn_add_f32(va, vb);
+    vacc = xnn_max_f32(vacc, voutput_min);
+    vacc = xnn_min_f32(vacc, voutput_max);
 
-    *vptr_o++ = vacc;
+    xnn_storeu_f32(output, vacc);
+    output += 32;
   }
   if XNN_UNLIKELY(batch != 0) {
-     HVX_Vector va = *vptr_a;
-     HVX_Vector vb = *vptr_b;
+     HVX_Vector va = xnn_loadu_f32(input_a);
+     HVX_Vector vb = xnn_loadu_f32(input_b);
 
-     HVX_Vector vacc = Q6_Vsf_vadd_VsfVsf(va, vb);
-     vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-     vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+     HVX_Vector vacc = xnn_add_f32(va, vb);
+     vacc = xnn_max_f32(vacc, voutput_min);
+     vacc = xnn_min_f32(vacc, voutput_max);
      
-     Q6_V_vstu_variable(vptr_o, batch, vacc);
+     Q6_V_vstu_variable(output, batch, vacc);
   }
 }

--- a/src/f32-vbinary/gen/f32-vadd-minmax-hvx-u32.c
+++ b/src/f32-vbinary/gen/f32-vadd-minmax-hvx-u32.c
@@ -5,12 +5,8 @@
 
 #include <assert.h>
 
-#include <hvx_hexagon_protos.h>
-#include <hexagon_protos.h>
-#include <hexagon_types.h>
+#include "xnnpack/simd/f32-hvx.h"
 
-#include "xnnpack/common.h"
-#include "xnnpack/intrinsics-polyfill.h"
 #include "xnnpack/math.h"
 #include "xnnpack/vbinary.h"
 
@@ -27,31 +23,30 @@ void xnn_f32_vadd_minmax_ukernel__hvx_u32(
   assert(input_b != NULL);
   assert(output != NULL);
 
-  const HVX_Vector voutput_min = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.min));
-  const HVX_Vector voutput_max = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.max));
-
-  const HVX_UVector *vptr_a = (const HVX_UVector *) input_a;
-  const HVX_UVector *vptr_b = (const HVX_UVector *) input_b;
-  HVX_UVector *vptr_o = (HVX_UVector*) output;
+  const HVX_Vector voutput_min = xnn_set1_f32(params->scalar.min);
+  const HVX_Vector voutput_max = xnn_set1_f32(params->scalar.max);
 
   for (; batch >= 32 * sizeof(float); batch -= 32 * sizeof(float)) {
-    HVX_Vector va = *vptr_a++;
-    HVX_Vector vb = *vptr_b++;
+    HVX_Vector va = xnn_loadu_f32(input_a);
+    HVX_Vector vb = xnn_loadu_f32(input_b);
+    input_a += 32;
+    input_b += 32;
 
-    HVX_Vector vacc = Q6_Vsf_vadd_VsfVsf(va, vb);
-    vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-    vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+    HVX_Vector vacc = xnn_add_f32(va, vb);
+    vacc = xnn_max_f32(vacc, voutput_min);
+    vacc = xnn_min_f32(vacc, voutput_max);
 
-    *vptr_o++ = vacc;
+    xnn_storeu_f32(output, vacc);
+    output += 32;
   }
   if XNN_UNLIKELY(batch != 0) {
-     HVX_Vector va = *vptr_a;
-     HVX_Vector vb = *vptr_b;
+     HVX_Vector va = xnn_loadu_f32(input_a);
+     HVX_Vector vb = xnn_loadu_f32(input_b);
 
-     HVX_Vector vacc = Q6_Vsf_vadd_VsfVsf(va, vb);
-     vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-     vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+     HVX_Vector vacc = xnn_add_f32(va, vb);
+     vacc = xnn_max_f32(vacc, voutput_min);
+     vacc = xnn_min_f32(vacc, voutput_max);
      
-     Q6_V_vstu_variable(vptr_o, batch, vacc);
+     Q6_V_vstu_variable(output, batch, vacc);
   }
 }

--- a/src/f32-vbinary/gen/f32-vadd-minmax-hvx-u64.c
+++ b/src/f32-vbinary/gen/f32-vadd-minmax-hvx-u64.c
@@ -5,12 +5,8 @@
 
 #include <assert.h>
 
-#include <hvx_hexagon_protos.h>
-#include <hexagon_protos.h>
-#include <hexagon_types.h>
+#include "xnnpack/simd/f32-hvx.h"
 
-#include "xnnpack/common.h"
-#include "xnnpack/intrinsics-polyfill.h"
 #include "xnnpack/math.h"
 #include "xnnpack/vbinary.h"
 
@@ -27,49 +23,52 @@ void xnn_f32_vadd_minmax_ukernel__hvx_u64(
   assert(input_b != NULL);
   assert(output != NULL);
 
-  const HVX_Vector voutput_min = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.min));
-  const HVX_Vector voutput_max = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.max));
-
-  const HVX_UVector *vptr_a = (const HVX_UVector *) input_a;
-  const HVX_UVector *vptr_b = (const HVX_UVector *) input_b;
-  HVX_UVector *vptr_o = (HVX_UVector*) output;
+  const HVX_Vector voutput_min = xnn_set1_f32(params->scalar.min);
+  const HVX_Vector voutput_max = xnn_set1_f32(params->scalar.max);
 
   for (; batch >= 64 * sizeof(float); batch -= 64 * sizeof(float)) {
-    HVX_Vector va0 = *vptr_a++;
-    HVX_Vector va1 = *vptr_a++;
-    HVX_Vector vb0 = *vptr_b++;
-    HVX_Vector vb1 = *vptr_b++;
+    HVX_Vector va0 = xnn_loadu_f32(input_a);
+    HVX_Vector va1 = xnn_loadu_f32(input_a + 32);
+    HVX_Vector vb0 = xnn_loadu_f32(input_b);
+    HVX_Vector vb1 = xnn_loadu_f32(input_b + 32);
+    input_a += 64;
+    input_b += 64;
 
-    HVX_Vector vacc0 = Q6_Vsf_vadd_VsfVsf(va0, vb0);
-    HVX_Vector vacc1 = Q6_Vsf_vadd_VsfVsf(va1, vb1);
+    HVX_Vector vacc0 = xnn_add_f32(va0, vb0);
+    HVX_Vector vacc1 = xnn_add_f32(va1, vb1);
 
-    vacc0 = Q6_Vsf_vmax_VsfVsf(vacc0, voutput_min);
-    vacc1 = Q6_Vsf_vmax_VsfVsf(vacc1, voutput_min);
 
-    vacc0 = Q6_Vsf_vmin_VsfVsf(vacc0, voutput_max);
-    vacc1 = Q6_Vsf_vmin_VsfVsf(vacc1, voutput_max);
+    vacc0 = xnn_max_f32(vacc0, voutput_min);
+    vacc1 = xnn_max_f32(vacc1, voutput_min);
 
-    *vptr_o++ = vacc0;
-    *vptr_o++ = vacc1;
+    vacc0 = xnn_min_f32(vacc0, voutput_max);
+    vacc1 = xnn_min_f32(vacc1, voutput_max);
+
+    xnn_storeu_f32(output, vacc0);
+    xnn_storeu_f32(output + 32, vacc1);
+    output += 64;
   }
   for (; batch >= 32 * sizeof(float); batch -= 32 * sizeof(float)) {
-    HVX_Vector va = *vptr_a++;
-    HVX_Vector vb = *vptr_b++;
+    HVX_Vector va = xnn_loadu_f32(input_a);
+    HVX_Vector vb = xnn_loadu_f32(input_b);
+    input_a += 32;
+    input_b += 32;
 
-    HVX_Vector vacc = Q6_Vsf_vadd_VsfVsf(va, vb);
-    vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-    vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+    HVX_Vector vacc = xnn_add_f32(va, vb);
+    vacc = xnn_max_f32(vacc, voutput_min);
+    vacc = xnn_min_f32(vacc, voutput_max);
 
-    *vptr_o++ = vacc;
+    xnn_storeu_f32(output, vacc);
+    output += 32;
   }
   if XNN_UNLIKELY(batch != 0) {
-     HVX_Vector va = *vptr_a;
-     HVX_Vector vb = *vptr_b;
+     HVX_Vector va = xnn_loadu_f32(input_a);
+     HVX_Vector vb = xnn_loadu_f32(input_b);
 
-     HVX_Vector vacc = Q6_Vsf_vadd_VsfVsf(va, vb);
-     vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-     vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+     HVX_Vector vacc = xnn_add_f32(va, vb);
+     vacc = xnn_max_f32(vacc, voutput_min);
+     vacc = xnn_min_f32(vacc, voutput_max);
      
-     Q6_V_vstu_variable(vptr_o, batch, vacc);
+     Q6_V_vstu_variable(output, batch, vacc);
   }
 }

--- a/src/f32-vbinary/gen/f32-vaddc-minmax-hvx-u128.c
+++ b/src/f32-vbinary/gen/f32-vaddc-minmax-hvx-u128.c
@@ -5,12 +5,8 @@
 
 #include <assert.h>
 
-#include <hvx_hexagon_protos.h>
-#include <hexagon_protos.h>
-#include <hexagon_types.h>
+#include "xnnpack/simd/f32-hvx.h"
 
-#include "xnnpack/common.h"
-#include "xnnpack/intrinsics-polyfill.h"
 #include "xnnpack/math.h"
 #include "xnnpack/vbinary.h"
 
@@ -27,56 +23,56 @@ void xnn_f32_vaddc_minmax_ukernel__hvx_u128(
   assert(input_b != NULL);
   assert(output != NULL);
 
-  const HVX_Vector voutput_min = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.min));
-  const HVX_Vector voutput_max = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.max));
-  HVX_Vector vb = Q6_V_vsplat_R(*((int32_t*) input_b));
+  const HVX_Vector voutput_min = xnn_set1_f32(params->scalar.min);
+  const HVX_Vector voutput_max = xnn_set1_f32(params->scalar.max);
+  HVX_Vector vb = xnn_set1_f32(*input_b);
 
   for (; batch >= 128 * sizeof(float); batch -= 128 * sizeof(float)) {
-    HVX_Vector va0 = *((HVX_UVector*) input_a);
-    HVX_Vector va1 = *((HVX_UVector*)(input_a + 32));
-    HVX_Vector va2 = *((HVX_UVector*)(input_a + 64));
-    HVX_Vector va3 = *((HVX_UVector*)(input_a + 96));
+    HVX_Vector va0 = xnn_loadu_f32(input_a);
+    HVX_Vector va1 = xnn_loadu_f32(input_a + 32);
+    HVX_Vector va2 = xnn_loadu_f32(input_a + 64);
+    HVX_Vector va3 = xnn_loadu_f32(input_a + 96);
     input_a += 128;
 
-    HVX_Vector vacc0 = Q6_Vsf_vadd_VsfVsf(va0, vb);
-    HVX_Vector vacc1 = Q6_Vsf_vadd_VsfVsf(va1, vb);
-    HVX_Vector vacc2 = Q6_Vsf_vadd_VsfVsf(va2, vb);
-    HVX_Vector vacc3 = Q6_Vsf_vadd_VsfVsf(va3, vb);
+    HVX_Vector vacc0 = xnn_add_f32(va0, vb);
+    HVX_Vector vacc1 = xnn_add_f32(va1, vb);
+    HVX_Vector vacc2 = xnn_add_f32(va2, vb);
+    HVX_Vector vacc3 = xnn_add_f32(va3, vb);
 
 
-    vacc0 = Q6_Vsf_vmax_VsfVsf(vacc0, voutput_min);
-    vacc1 = Q6_Vsf_vmax_VsfVsf(vacc1, voutput_min);
-    vacc2 = Q6_Vsf_vmax_VsfVsf(vacc2, voutput_min);
-    vacc3 = Q6_Vsf_vmax_VsfVsf(vacc3, voutput_min);
+    vacc0 = xnn_max_f32(vacc0, voutput_min);
+    vacc1 = xnn_max_f32(vacc1, voutput_min);
+    vacc2 = xnn_max_f32(vacc2, voutput_min);
+    vacc3 = xnn_max_f32(vacc3, voutput_min);
 
-    vacc0 = Q6_Vsf_vmin_VsfVsf(vacc0, voutput_max);
-    vacc1 = Q6_Vsf_vmin_VsfVsf(vacc1, voutput_max);
-    vacc2 = Q6_Vsf_vmin_VsfVsf(vacc2, voutput_max);
-    vacc3 = Q6_Vsf_vmin_VsfVsf(vacc3, voutput_max);
+    vacc0 = xnn_min_f32(vacc0, voutput_max);
+    vacc1 = xnn_min_f32(vacc1, voutput_max);
+    vacc2 = xnn_min_f32(vacc2, voutput_max);
+    vacc3 = xnn_min_f32(vacc3, voutput_max);
 
-    *((HVX_UVector *) output) = vacc0;
-    *((HVX_UVector *)(output + 32)) = vacc1;
-    *((HVX_UVector *)(output + 64)) = vacc2;
-    *((HVX_UVector *)(output + 96)) = vacc3;
+   xnn_storeu_f32(output, vacc0);
+    xnn_storeu_f32(output + 32, vacc1);
+    xnn_storeu_f32(output + 64, vacc2);
+    xnn_storeu_f32(output + 96, vacc3);
     output += 128;
   }
   for (; batch >= 32 * sizeof(float); batch -= 32 * sizeof(float)) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
     input_a += 32;
 
-    HVX_Vector vacc = Q6_Vsf_vadd_VsfVsf(va, vb);
-    vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-    vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+    HVX_Vector vacc = xnn_add_f32(va, vb);
+    vacc = xnn_max_f32(vacc, voutput_min);
+    vacc = xnn_min_f32(vacc, voutput_max);
 
-    *((HVX_UVector *) output) = vacc;
+    xnn_storeu_f32(output, vacc);
     output+= 32;
   }
   if XNN_UNLIKELY(batch != 0) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
 
-    HVX_Vector vacc = Q6_Vsf_vadd_VsfVsf(va, vb);
-    vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-    vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+    HVX_Vector vacc = xnn_add_f32(va, vb);
+    vacc = xnn_max_f32(vacc, voutput_min);
+    vacc = xnn_min_f32(vacc, voutput_max);
 
     Q6_V_vstu_variable(output, batch, vacc);
   }

--- a/src/f32-vbinary/gen/f32-vaddc-minmax-hvx-u32.c
+++ b/src/f32-vbinary/gen/f32-vaddc-minmax-hvx-u32.c
@@ -5,12 +5,8 @@
 
 #include <assert.h>
 
-#include <hvx_hexagon_protos.h>
-#include <hexagon_protos.h>
-#include <hexagon_types.h>
+#include "xnnpack/simd/f32-hvx.h"
 
-#include "xnnpack/common.h"
-#include "xnnpack/intrinsics-polyfill.h"
 #include "xnnpack/math.h"
 #include "xnnpack/vbinary.h"
 
@@ -27,27 +23,27 @@ void xnn_f32_vaddc_minmax_ukernel__hvx_u32(
   assert(input_b != NULL);
   assert(output != NULL);
 
-  const HVX_Vector voutput_min = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.min));
-  const HVX_Vector voutput_max = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.max));
-  HVX_Vector vb = Q6_V_vsplat_R(*((int32_t*) input_b));
+  const HVX_Vector voutput_min = xnn_set1_f32(params->scalar.min);
+  const HVX_Vector voutput_max = xnn_set1_f32(params->scalar.max);
+  HVX_Vector vb = xnn_set1_f32(*input_b);
 
   for (; batch >= 32 * sizeof(float); batch -= 32 * sizeof(float)) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
     input_a += 32;
 
-    HVX_Vector vacc = Q6_Vsf_vadd_VsfVsf(va, vb);
-    vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-    vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+    HVX_Vector vacc = xnn_add_f32(va, vb);
+    vacc = xnn_max_f32(vacc, voutput_min);
+    vacc = xnn_min_f32(vacc, voutput_max);
 
-    *((HVX_UVector *) output) = vacc;
+    xnn_storeu_f32(output, vacc);
     output+= 32;
   }
   if XNN_UNLIKELY(batch != 0) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
 
-    HVX_Vector vacc = Q6_Vsf_vadd_VsfVsf(va, vb);
-    vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-    vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+    HVX_Vector vacc = xnn_add_f32(va, vb);
+    vacc = xnn_max_f32(vacc, voutput_min);
+    vacc = xnn_min_f32(vacc, voutput_max);
 
     Q6_V_vstu_variable(output, batch, vacc);
   }

--- a/src/f32-vbinary/gen/f32-vaddc-minmax-hvx-u64.c
+++ b/src/f32-vbinary/gen/f32-vaddc-minmax-hvx-u64.c
@@ -5,12 +5,8 @@
 
 #include <assert.h>
 
-#include <hvx_hexagon_protos.h>
-#include <hexagon_protos.h>
-#include <hexagon_types.h>
+#include "xnnpack/simd/f32-hvx.h"
 
-#include "xnnpack/common.h"
-#include "xnnpack/intrinsics-polyfill.h"
 #include "xnnpack/math.h"
 #include "xnnpack/vbinary.h"
 
@@ -27,46 +23,46 @@ void xnn_f32_vaddc_minmax_ukernel__hvx_u64(
   assert(input_b != NULL);
   assert(output != NULL);
 
-  const HVX_Vector voutput_min = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.min));
-  const HVX_Vector voutput_max = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.max));
-  HVX_Vector vb = Q6_V_vsplat_R(*((int32_t*) input_b));
+  const HVX_Vector voutput_min = xnn_set1_f32(params->scalar.min);
+  const HVX_Vector voutput_max = xnn_set1_f32(params->scalar.max);
+  HVX_Vector vb = xnn_set1_f32(*input_b);
 
   for (; batch >= 64 * sizeof(float); batch -= 64 * sizeof(float)) {
-    HVX_Vector va0 = *((HVX_UVector*) input_a);
-    HVX_Vector va1 = *((HVX_UVector*)(input_a + 32));
+    HVX_Vector va0 = xnn_loadu_f32(input_a);
+    HVX_Vector va1 = xnn_loadu_f32(input_a + 32);
     input_a += 64;
 
-    HVX_Vector vacc0 = Q6_Vsf_vadd_VsfVsf(va0, vb);
-    HVX_Vector vacc1 = Q6_Vsf_vadd_VsfVsf(va1, vb);
+    HVX_Vector vacc0 = xnn_add_f32(va0, vb);
+    HVX_Vector vacc1 = xnn_add_f32(va1, vb);
 
 
-    vacc0 = Q6_Vsf_vmax_VsfVsf(vacc0, voutput_min);
-    vacc1 = Q6_Vsf_vmax_VsfVsf(vacc1, voutput_min);
+    vacc0 = xnn_max_f32(vacc0, voutput_min);
+    vacc1 = xnn_max_f32(vacc1, voutput_min);
 
-    vacc0 = Q6_Vsf_vmin_VsfVsf(vacc0, voutput_max);
-    vacc1 = Q6_Vsf_vmin_VsfVsf(vacc1, voutput_max);
+    vacc0 = xnn_min_f32(vacc0, voutput_max);
+    vacc1 = xnn_min_f32(vacc1, voutput_max);
 
-    *((HVX_UVector *) output) = vacc0;
-    *((HVX_UVector *)(output + 32)) = vacc1;
+   xnn_storeu_f32(output, vacc0);
+    xnn_storeu_f32(output + 32, vacc1);
     output += 64;
   }
   for (; batch >= 32 * sizeof(float); batch -= 32 * sizeof(float)) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
     input_a += 32;
 
-    HVX_Vector vacc = Q6_Vsf_vadd_VsfVsf(va, vb);
-    vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-    vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+    HVX_Vector vacc = xnn_add_f32(va, vb);
+    vacc = xnn_max_f32(vacc, voutput_min);
+    vacc = xnn_min_f32(vacc, voutput_max);
 
-    *((HVX_UVector *) output) = vacc;
+    xnn_storeu_f32(output, vacc);
     output+= 32;
   }
   if XNN_UNLIKELY(batch != 0) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
 
-    HVX_Vector vacc = Q6_Vsf_vadd_VsfVsf(va, vb);
-    vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-    vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+    HVX_Vector vacc = xnn_add_f32(va, vb);
+    vacc = xnn_max_f32(vacc, voutput_min);
+    vacc = xnn_min_f32(vacc, voutput_max);
 
     Q6_V_vstu_variable(output, batch, vacc);
   }

--- a/src/f32-vbinary/gen/f32-vmax-hvx-u128.c
+++ b/src/f32-vbinary/gen/f32-vmax-hvx-u128.c
@@ -5,12 +5,8 @@
 
 #include <assert.h>
 
-#include <hvx_hexagon_protos.h>
-#include <hexagon_protos.h>
-#include <hexagon_types.h>
+#include "xnnpack/simd/f32-hvx.h"
 
-#include "xnnpack/common.h"
-#include "xnnpack/intrinsics-polyfill.h"
 #include "xnnpack/math.h"
 #include "xnnpack/vbinary.h"
 
@@ -28,45 +24,48 @@ void xnn_f32_vmax_ukernel__hvx_u128(
   assert(output != NULL);
 
 
-  const HVX_UVector *vptr_a = (const HVX_UVector *) input_a;
-  const HVX_UVector *vptr_b = (const HVX_UVector *) input_b;
-  HVX_UVector *vptr_o = (HVX_UVector*) output;
-
   for (; batch >= 128 * sizeof(float); batch -= 128 * sizeof(float)) {
-    HVX_Vector va0 = *vptr_a++;
-    HVX_Vector va1 = *vptr_a++;
-    HVX_Vector va2 = *vptr_a++;
-    HVX_Vector va3 = *vptr_a++;
-    HVX_Vector vb0 = *vptr_b++;
-    HVX_Vector vb1 = *vptr_b++;
-    HVX_Vector vb2 = *vptr_b++;
-    HVX_Vector vb3 = *vptr_b++;
+    HVX_Vector va0 = xnn_loadu_f32(input_a);
+    HVX_Vector va1 = xnn_loadu_f32(input_a + 32);
+    HVX_Vector va2 = xnn_loadu_f32(input_a + 64);
+    HVX_Vector va3 = xnn_loadu_f32(input_a + 96);
+    HVX_Vector vb0 = xnn_loadu_f32(input_b);
+    HVX_Vector vb1 = xnn_loadu_f32(input_b + 32);
+    HVX_Vector vb2 = xnn_loadu_f32(input_b + 64);
+    HVX_Vector vb3 = xnn_loadu_f32(input_b + 96);
+    input_a += 128;
+    input_b += 128;
 
-    HVX_Vector vacc0 = Q6_Vsf_vmax_VsfVsf(va0, vb0);
-    HVX_Vector vacc1 = Q6_Vsf_vmax_VsfVsf(va1, vb1);
-    HVX_Vector vacc2 = Q6_Vsf_vmax_VsfVsf(va2, vb2);
-    HVX_Vector vacc3 = Q6_Vsf_vmax_VsfVsf(va3, vb3);
+    HVX_Vector vacc0 = xnn_max_f32(va0, vb0);
+    HVX_Vector vacc1 = xnn_max_f32(va1, vb1);
+    HVX_Vector vacc2 = xnn_max_f32(va2, vb2);
+    HVX_Vector vacc3 = xnn_max_f32(va3, vb3);
 
 
-    *vptr_o++ = vacc0;
-    *vptr_o++ = vacc1;
-    *vptr_o++ = vacc2;
-    *vptr_o++ = vacc3;
+
+    xnn_storeu_f32(output, vacc0);
+    xnn_storeu_f32(output + 32, vacc1);
+    xnn_storeu_f32(output + 64, vacc2);
+    xnn_storeu_f32(output + 96, vacc3);
+    output += 128;
   }
   for (; batch >= 32 * sizeof(float); batch -= 32 * sizeof(float)) {
-    HVX_Vector va = *vptr_a++;
-    HVX_Vector vb = *vptr_b++;
+    HVX_Vector va = xnn_loadu_f32(input_a);
+    HVX_Vector vb = xnn_loadu_f32(input_b);
+    input_a += 32;
+    input_b += 32;
 
-    HVX_Vector vacc = Q6_Vsf_vmax_VsfVsf(va, vb);
+    HVX_Vector vacc = xnn_max_f32(va, vb);
 
-    *vptr_o++ = vacc;
+    xnn_storeu_f32(output, vacc);
+    output += 32;
   }
   if XNN_UNLIKELY(batch != 0) {
-     HVX_Vector va = *vptr_a;
-     HVX_Vector vb = *vptr_b;
+     HVX_Vector va = xnn_loadu_f32(input_a);
+     HVX_Vector vb = xnn_loadu_f32(input_b);
 
-     HVX_Vector vacc = Q6_Vsf_vmax_VsfVsf(va, vb);
+     HVX_Vector vacc = xnn_max_f32(va, vb);
      
-     Q6_V_vstu_variable(vptr_o, batch, vacc);
+     Q6_V_vstu_variable(output, batch, vacc);
   }
 }

--- a/src/f32-vbinary/gen/f32-vmax-hvx-u32.c
+++ b/src/f32-vbinary/gen/f32-vmax-hvx-u32.c
@@ -5,12 +5,8 @@
 
 #include <assert.h>
 
-#include <hvx_hexagon_protos.h>
-#include <hexagon_protos.h>
-#include <hexagon_types.h>
+#include "xnnpack/simd/f32-hvx.h"
 
-#include "xnnpack/common.h"
-#include "xnnpack/intrinsics-polyfill.h"
 #include "xnnpack/math.h"
 #include "xnnpack/vbinary.h"
 
@@ -28,24 +24,23 @@ void xnn_f32_vmax_ukernel__hvx_u32(
   assert(output != NULL);
 
 
-  const HVX_UVector *vptr_a = (const HVX_UVector *) input_a;
-  const HVX_UVector *vptr_b = (const HVX_UVector *) input_b;
-  HVX_UVector *vptr_o = (HVX_UVector*) output;
-
   for (; batch >= 32 * sizeof(float); batch -= 32 * sizeof(float)) {
-    HVX_Vector va = *vptr_a++;
-    HVX_Vector vb = *vptr_b++;
+    HVX_Vector va = xnn_loadu_f32(input_a);
+    HVX_Vector vb = xnn_loadu_f32(input_b);
+    input_a += 32;
+    input_b += 32;
 
-    HVX_Vector vacc = Q6_Vsf_vmax_VsfVsf(va, vb);
+    HVX_Vector vacc = xnn_max_f32(va, vb);
 
-    *vptr_o++ = vacc;
+    xnn_storeu_f32(output, vacc);
+    output += 32;
   }
   if XNN_UNLIKELY(batch != 0) {
-     HVX_Vector va = *vptr_a;
-     HVX_Vector vb = *vptr_b;
+     HVX_Vector va = xnn_loadu_f32(input_a);
+     HVX_Vector vb = xnn_loadu_f32(input_b);
 
-     HVX_Vector vacc = Q6_Vsf_vmax_VsfVsf(va, vb);
+     HVX_Vector vacc = xnn_max_f32(va, vb);
      
-     Q6_V_vstu_variable(vptr_o, batch, vacc);
+     Q6_V_vstu_variable(output, batch, vacc);
   }
 }

--- a/src/f32-vbinary/gen/f32-vmax-hvx-u64.c
+++ b/src/f32-vbinary/gen/f32-vmax-hvx-u64.c
@@ -5,12 +5,8 @@
 
 #include <assert.h>
 
-#include <hvx_hexagon_protos.h>
-#include <hexagon_protos.h>
-#include <hexagon_types.h>
+#include "xnnpack/simd/f32-hvx.h"
 
-#include "xnnpack/common.h"
-#include "xnnpack/intrinsics-polyfill.h"
 #include "xnnpack/math.h"
 #include "xnnpack/vbinary.h"
 
@@ -28,37 +24,40 @@ void xnn_f32_vmax_ukernel__hvx_u64(
   assert(output != NULL);
 
 
-  const HVX_UVector *vptr_a = (const HVX_UVector *) input_a;
-  const HVX_UVector *vptr_b = (const HVX_UVector *) input_b;
-  HVX_UVector *vptr_o = (HVX_UVector*) output;
-
   for (; batch >= 64 * sizeof(float); batch -= 64 * sizeof(float)) {
-    HVX_Vector va0 = *vptr_a++;
-    HVX_Vector va1 = *vptr_a++;
-    HVX_Vector vb0 = *vptr_b++;
-    HVX_Vector vb1 = *vptr_b++;
+    HVX_Vector va0 = xnn_loadu_f32(input_a);
+    HVX_Vector va1 = xnn_loadu_f32(input_a + 32);
+    HVX_Vector vb0 = xnn_loadu_f32(input_b);
+    HVX_Vector vb1 = xnn_loadu_f32(input_b + 32);
+    input_a += 64;
+    input_b += 64;
 
-    HVX_Vector vacc0 = Q6_Vsf_vmax_VsfVsf(va0, vb0);
-    HVX_Vector vacc1 = Q6_Vsf_vmax_VsfVsf(va1, vb1);
+    HVX_Vector vacc0 = xnn_max_f32(va0, vb0);
+    HVX_Vector vacc1 = xnn_max_f32(va1, vb1);
 
 
-    *vptr_o++ = vacc0;
-    *vptr_o++ = vacc1;
+
+    xnn_storeu_f32(output, vacc0);
+    xnn_storeu_f32(output + 32, vacc1);
+    output += 64;
   }
   for (; batch >= 32 * sizeof(float); batch -= 32 * sizeof(float)) {
-    HVX_Vector va = *vptr_a++;
-    HVX_Vector vb = *vptr_b++;
+    HVX_Vector va = xnn_loadu_f32(input_a);
+    HVX_Vector vb = xnn_loadu_f32(input_b);
+    input_a += 32;
+    input_b += 32;
 
-    HVX_Vector vacc = Q6_Vsf_vmax_VsfVsf(va, vb);
+    HVX_Vector vacc = xnn_max_f32(va, vb);
 
-    *vptr_o++ = vacc;
+    xnn_storeu_f32(output, vacc);
+    output += 32;
   }
   if XNN_UNLIKELY(batch != 0) {
-     HVX_Vector va = *vptr_a;
-     HVX_Vector vb = *vptr_b;
+     HVX_Vector va = xnn_loadu_f32(input_a);
+     HVX_Vector vb = xnn_loadu_f32(input_b);
 
-     HVX_Vector vacc = Q6_Vsf_vmax_VsfVsf(va, vb);
+     HVX_Vector vacc = xnn_max_f32(va, vb);
      
-     Q6_V_vstu_variable(vptr_o, batch, vacc);
+     Q6_V_vstu_variable(output, batch, vacc);
   }
 }

--- a/src/f32-vbinary/gen/f32-vmaxc-hvx-u128.c
+++ b/src/f32-vbinary/gen/f32-vmaxc-hvx-u128.c
@@ -5,12 +5,8 @@
 
 #include <assert.h>
 
-#include <hvx_hexagon_protos.h>
-#include <hexagon_protos.h>
-#include <hexagon_types.h>
+#include "xnnpack/simd/f32-hvx.h"
 
-#include "xnnpack/common.h"
-#include "xnnpack/intrinsics-polyfill.h"
 #include "xnnpack/math.h"
 #include "xnnpack/vbinary.h"
 
@@ -27,41 +23,41 @@ void xnn_f32_vmaxc_ukernel__hvx_u128(
   assert(input_b != NULL);
   assert(output != NULL);
 
-  HVX_Vector vb = Q6_V_vsplat_R(*((int32_t*) input_b));
+  HVX_Vector vb = xnn_set1_f32(*input_b);
 
   for (; batch >= 128 * sizeof(float); batch -= 128 * sizeof(float)) {
-    HVX_Vector va0 = *((HVX_UVector*) input_a);
-    HVX_Vector va1 = *((HVX_UVector*)(input_a + 32));
-    HVX_Vector va2 = *((HVX_UVector*)(input_a + 64));
-    HVX_Vector va3 = *((HVX_UVector*)(input_a + 96));
+    HVX_Vector va0 = xnn_loadu_f32(input_a);
+    HVX_Vector va1 = xnn_loadu_f32(input_a + 32);
+    HVX_Vector va2 = xnn_loadu_f32(input_a + 64);
+    HVX_Vector va3 = xnn_loadu_f32(input_a + 96);
     input_a += 128;
 
-    HVX_Vector vacc0 = Q6_Vsf_vmax_VsfVsf(va0, vb);
-    HVX_Vector vacc1 = Q6_Vsf_vmax_VsfVsf(va1, vb);
-    HVX_Vector vacc2 = Q6_Vsf_vmax_VsfVsf(va2, vb);
-    HVX_Vector vacc3 = Q6_Vsf_vmax_VsfVsf(va3, vb);
+    HVX_Vector vacc0 = xnn_max_f32(va0, vb);
+    HVX_Vector vacc1 = xnn_max_f32(va1, vb);
+    HVX_Vector vacc2 = xnn_max_f32(va2, vb);
+    HVX_Vector vacc3 = xnn_max_f32(va3, vb);
 
 
 
-    *((HVX_UVector *) output) = vacc0;
-    *((HVX_UVector *)(output + 32)) = vacc1;
-    *((HVX_UVector *)(output + 64)) = vacc2;
-    *((HVX_UVector *)(output + 96)) = vacc3;
+   xnn_storeu_f32(output, vacc0);
+    xnn_storeu_f32(output + 32, vacc1);
+    xnn_storeu_f32(output + 64, vacc2);
+    xnn_storeu_f32(output + 96, vacc3);
     output += 128;
   }
   for (; batch >= 32 * sizeof(float); batch -= 32 * sizeof(float)) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
     input_a += 32;
 
-    HVX_Vector vacc = Q6_Vsf_vmax_VsfVsf(va, vb);
+    HVX_Vector vacc = xnn_max_f32(va, vb);
 
-    *((HVX_UVector *) output) = vacc;
+    xnn_storeu_f32(output, vacc);
     output+= 32;
   }
   if XNN_UNLIKELY(batch != 0) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
 
-    HVX_Vector vacc = Q6_Vsf_vmax_VsfVsf(va, vb);
+    HVX_Vector vacc = xnn_max_f32(va, vb);
 
     Q6_V_vstu_variable(output, batch, vacc);
   }

--- a/src/f32-vbinary/gen/f32-vmaxc-hvx-u64.c
+++ b/src/f32-vbinary/gen/f32-vmaxc-hvx-u64.c
@@ -5,12 +5,8 @@
 
 #include <assert.h>
 
-#include <hvx_hexagon_protos.h>
-#include <hexagon_protos.h>
-#include <hexagon_types.h>
+#include "xnnpack/simd/f32-hvx.h"
 
-#include "xnnpack/common.h"
-#include "xnnpack/intrinsics-polyfill.h"
 #include "xnnpack/math.h"
 #include "xnnpack/vbinary.h"
 
@@ -27,35 +23,35 @@ void xnn_f32_vmaxc_ukernel__hvx_u64(
   assert(input_b != NULL);
   assert(output != NULL);
 
-  HVX_Vector vb = Q6_V_vsplat_R(*((int32_t*) input_b));
+  HVX_Vector vb = xnn_set1_f32(*input_b);
 
   for (; batch >= 64 * sizeof(float); batch -= 64 * sizeof(float)) {
-    HVX_Vector va0 = *((HVX_UVector*) input_a);
-    HVX_Vector va1 = *((HVX_UVector*)(input_a + 32));
+    HVX_Vector va0 = xnn_loadu_f32(input_a);
+    HVX_Vector va1 = xnn_loadu_f32(input_a + 32);
     input_a += 64;
 
-    HVX_Vector vacc0 = Q6_Vsf_vmax_VsfVsf(va0, vb);
-    HVX_Vector vacc1 = Q6_Vsf_vmax_VsfVsf(va1, vb);
+    HVX_Vector vacc0 = xnn_max_f32(va0, vb);
+    HVX_Vector vacc1 = xnn_max_f32(va1, vb);
 
 
 
-    *((HVX_UVector *) output) = vacc0;
-    *((HVX_UVector *)(output + 32)) = vacc1;
+   xnn_storeu_f32(output, vacc0);
+    xnn_storeu_f32(output + 32, vacc1);
     output += 64;
   }
   for (; batch >= 32 * sizeof(float); batch -= 32 * sizeof(float)) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
     input_a += 32;
 
-    HVX_Vector vacc = Q6_Vsf_vmax_VsfVsf(va, vb);
+    HVX_Vector vacc = xnn_max_f32(va, vb);
 
-    *((HVX_UVector *) output) = vacc;
+    xnn_storeu_f32(output, vacc);
     output+= 32;
   }
   if XNN_UNLIKELY(batch != 0) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
 
-    HVX_Vector vacc = Q6_Vsf_vmax_VsfVsf(va, vb);
+    HVX_Vector vacc = xnn_max_f32(va, vb);
 
     Q6_V_vstu_variable(output, batch, vacc);
   }

--- a/src/f32-vbinary/gen/f32-vmin-hvx-u128.c
+++ b/src/f32-vbinary/gen/f32-vmin-hvx-u128.c
@@ -5,12 +5,8 @@
 
 #include <assert.h>
 
-#include <hvx_hexagon_protos.h>
-#include <hexagon_protos.h>
-#include <hexagon_types.h>
+#include "xnnpack/simd/f32-hvx.h"
 
-#include "xnnpack/common.h"
-#include "xnnpack/intrinsics-polyfill.h"
 #include "xnnpack/math.h"
 #include "xnnpack/vbinary.h"
 
@@ -28,45 +24,48 @@ void xnn_f32_vmin_ukernel__hvx_u128(
   assert(output != NULL);
 
 
-  const HVX_UVector *vptr_a = (const HVX_UVector *) input_a;
-  const HVX_UVector *vptr_b = (const HVX_UVector *) input_b;
-  HVX_UVector *vptr_o = (HVX_UVector*) output;
-
   for (; batch >= 128 * sizeof(float); batch -= 128 * sizeof(float)) {
-    HVX_Vector va0 = *vptr_a++;
-    HVX_Vector va1 = *vptr_a++;
-    HVX_Vector va2 = *vptr_a++;
-    HVX_Vector va3 = *vptr_a++;
-    HVX_Vector vb0 = *vptr_b++;
-    HVX_Vector vb1 = *vptr_b++;
-    HVX_Vector vb2 = *vptr_b++;
-    HVX_Vector vb3 = *vptr_b++;
+    HVX_Vector va0 = xnn_loadu_f32(input_a);
+    HVX_Vector va1 = xnn_loadu_f32(input_a + 32);
+    HVX_Vector va2 = xnn_loadu_f32(input_a + 64);
+    HVX_Vector va3 = xnn_loadu_f32(input_a + 96);
+    HVX_Vector vb0 = xnn_loadu_f32(input_b);
+    HVX_Vector vb1 = xnn_loadu_f32(input_b + 32);
+    HVX_Vector vb2 = xnn_loadu_f32(input_b + 64);
+    HVX_Vector vb3 = xnn_loadu_f32(input_b + 96);
+    input_a += 128;
+    input_b += 128;
 
-    HVX_Vector vacc0 = Q6_Vsf_vmin_VsfVsf(va0, vb0);
-    HVX_Vector vacc1 = Q6_Vsf_vmin_VsfVsf(va1, vb1);
-    HVX_Vector vacc2 = Q6_Vsf_vmin_VsfVsf(va2, vb2);
-    HVX_Vector vacc3 = Q6_Vsf_vmin_VsfVsf(va3, vb3);
+    HVX_Vector vacc0 = xnn_min_f32(va0, vb0);
+    HVX_Vector vacc1 = xnn_min_f32(va1, vb1);
+    HVX_Vector vacc2 = xnn_min_f32(va2, vb2);
+    HVX_Vector vacc3 = xnn_min_f32(va3, vb3);
 
 
-    *vptr_o++ = vacc0;
-    *vptr_o++ = vacc1;
-    *vptr_o++ = vacc2;
-    *vptr_o++ = vacc3;
+
+    xnn_storeu_f32(output, vacc0);
+    xnn_storeu_f32(output + 32, vacc1);
+    xnn_storeu_f32(output + 64, vacc2);
+    xnn_storeu_f32(output + 96, vacc3);
+    output += 128;
   }
   for (; batch >= 32 * sizeof(float); batch -= 32 * sizeof(float)) {
-    HVX_Vector va = *vptr_a++;
-    HVX_Vector vb = *vptr_b++;
+    HVX_Vector va = xnn_loadu_f32(input_a);
+    HVX_Vector vb = xnn_loadu_f32(input_b);
+    input_a += 32;
+    input_b += 32;
 
-    HVX_Vector vacc = Q6_Vsf_vmin_VsfVsf(va, vb);
+    HVX_Vector vacc = xnn_min_f32(va, vb);
 
-    *vptr_o++ = vacc;
+    xnn_storeu_f32(output, vacc);
+    output += 32;
   }
   if XNN_UNLIKELY(batch != 0) {
-     HVX_Vector va = *vptr_a;
-     HVX_Vector vb = *vptr_b;
+     HVX_Vector va = xnn_loadu_f32(input_a);
+     HVX_Vector vb = xnn_loadu_f32(input_b);
 
-     HVX_Vector vacc = Q6_Vsf_vmin_VsfVsf(va, vb);
+     HVX_Vector vacc = xnn_min_f32(va, vb);
      
-     Q6_V_vstu_variable(vptr_o, batch, vacc);
+     Q6_V_vstu_variable(output, batch, vacc);
   }
 }

--- a/src/f32-vbinary/gen/f32-vminc-hvx-u128.c
+++ b/src/f32-vbinary/gen/f32-vminc-hvx-u128.c
@@ -5,12 +5,8 @@
 
 #include <assert.h>
 
-#include <hvx_hexagon_protos.h>
-#include <hexagon_protos.h>
-#include <hexagon_types.h>
+#include "xnnpack/simd/f32-hvx.h"
 
-#include "xnnpack/common.h"
-#include "xnnpack/intrinsics-polyfill.h"
 #include "xnnpack/math.h"
 #include "xnnpack/vbinary.h"
 
@@ -27,41 +23,41 @@ void xnn_f32_vminc_ukernel__hvx_u128(
   assert(input_b != NULL);
   assert(output != NULL);
 
-  HVX_Vector vb = Q6_V_vsplat_R(*((int32_t*) input_b));
+  HVX_Vector vb = xnn_set1_f32(*input_b);
 
   for (; batch >= 128 * sizeof(float); batch -= 128 * sizeof(float)) {
-    HVX_Vector va0 = *((HVX_UVector*) input_a);
-    HVX_Vector va1 = *((HVX_UVector*)(input_a + 32));
-    HVX_Vector va2 = *((HVX_UVector*)(input_a + 64));
-    HVX_Vector va3 = *((HVX_UVector*)(input_a + 96));
+    HVX_Vector va0 = xnn_loadu_f32(input_a);
+    HVX_Vector va1 = xnn_loadu_f32(input_a + 32);
+    HVX_Vector va2 = xnn_loadu_f32(input_a + 64);
+    HVX_Vector va3 = xnn_loadu_f32(input_a + 96);
     input_a += 128;
 
-    HVX_Vector vacc0 = Q6_Vsf_vmin_VsfVsf(va0, vb);
-    HVX_Vector vacc1 = Q6_Vsf_vmin_VsfVsf(va1, vb);
-    HVX_Vector vacc2 = Q6_Vsf_vmin_VsfVsf(va2, vb);
-    HVX_Vector vacc3 = Q6_Vsf_vmin_VsfVsf(va3, vb);
+    HVX_Vector vacc0 = xnn_min_f32(va0, vb);
+    HVX_Vector vacc1 = xnn_min_f32(va1, vb);
+    HVX_Vector vacc2 = xnn_min_f32(va2, vb);
+    HVX_Vector vacc3 = xnn_min_f32(va3, vb);
 
 
 
-    *((HVX_UVector *) output) = vacc0;
-    *((HVX_UVector *)(output + 32)) = vacc1;
-    *((HVX_UVector *)(output + 64)) = vacc2;
-    *((HVX_UVector *)(output + 96)) = vacc3;
+   xnn_storeu_f32(output, vacc0);
+    xnn_storeu_f32(output + 32, vacc1);
+    xnn_storeu_f32(output + 64, vacc2);
+    xnn_storeu_f32(output + 96, vacc3);
     output += 128;
   }
   for (; batch >= 32 * sizeof(float); batch -= 32 * sizeof(float)) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
     input_a += 32;
 
-    HVX_Vector vacc = Q6_Vsf_vmin_VsfVsf(va, vb);
+    HVX_Vector vacc = xnn_min_f32(va, vb);
 
-    *((HVX_UVector *) output) = vacc;
+    xnn_storeu_f32(output, vacc);
     output+= 32;
   }
   if XNN_UNLIKELY(batch != 0) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
 
-    HVX_Vector vacc = Q6_Vsf_vmin_VsfVsf(va, vb);
+    HVX_Vector vacc = xnn_min_f32(va, vb);
 
     Q6_V_vstu_variable(output, batch, vacc);
   }

--- a/src/f32-vbinary/gen/f32-vminc-hvx-u32.c
+++ b/src/f32-vbinary/gen/f32-vminc-hvx-u32.c
@@ -5,12 +5,8 @@
 
 #include <assert.h>
 
-#include <hvx_hexagon_protos.h>
-#include <hexagon_protos.h>
-#include <hexagon_types.h>
+#include "xnnpack/simd/f32-hvx.h"
 
-#include "xnnpack/common.h"
-#include "xnnpack/intrinsics-polyfill.h"
 #include "xnnpack/math.h"
 #include "xnnpack/vbinary.h"
 
@@ -27,21 +23,21 @@ void xnn_f32_vminc_ukernel__hvx_u32(
   assert(input_b != NULL);
   assert(output != NULL);
 
-  HVX_Vector vb = Q6_V_vsplat_R(*((int32_t*) input_b));
+  HVX_Vector vb = xnn_set1_f32(*input_b);
 
   for (; batch >= 32 * sizeof(float); batch -= 32 * sizeof(float)) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
     input_a += 32;
 
-    HVX_Vector vacc = Q6_Vsf_vmin_VsfVsf(va, vb);
+    HVX_Vector vacc = xnn_min_f32(va, vb);
 
-    *((HVX_UVector *) output) = vacc;
+    xnn_storeu_f32(output, vacc);
     output+= 32;
   }
   if XNN_UNLIKELY(batch != 0) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
 
-    HVX_Vector vacc = Q6_Vsf_vmin_VsfVsf(va, vb);
+    HVX_Vector vacc = xnn_min_f32(va, vb);
 
     Q6_V_vstu_variable(output, batch, vacc);
   }

--- a/src/f32-vbinary/gen/f32-vminc-hvx-u64.c
+++ b/src/f32-vbinary/gen/f32-vminc-hvx-u64.c
@@ -5,12 +5,8 @@
 
 #include <assert.h>
 
-#include <hvx_hexagon_protos.h>
-#include <hexagon_protos.h>
-#include <hexagon_types.h>
+#include "xnnpack/simd/f32-hvx.h"
 
-#include "xnnpack/common.h"
-#include "xnnpack/intrinsics-polyfill.h"
 #include "xnnpack/math.h"
 #include "xnnpack/vbinary.h"
 
@@ -27,35 +23,35 @@ void xnn_f32_vminc_ukernel__hvx_u64(
   assert(input_b != NULL);
   assert(output != NULL);
 
-  HVX_Vector vb = Q6_V_vsplat_R(*((int32_t*) input_b));
+  HVX_Vector vb = xnn_set1_f32(*input_b);
 
   for (; batch >= 64 * sizeof(float); batch -= 64 * sizeof(float)) {
-    HVX_Vector va0 = *((HVX_UVector*) input_a);
-    HVX_Vector va1 = *((HVX_UVector*)(input_a + 32));
+    HVX_Vector va0 = xnn_loadu_f32(input_a);
+    HVX_Vector va1 = xnn_loadu_f32(input_a + 32);
     input_a += 64;
 
-    HVX_Vector vacc0 = Q6_Vsf_vmin_VsfVsf(va0, vb);
-    HVX_Vector vacc1 = Q6_Vsf_vmin_VsfVsf(va1, vb);
+    HVX_Vector vacc0 = xnn_min_f32(va0, vb);
+    HVX_Vector vacc1 = xnn_min_f32(va1, vb);
 
 
 
-    *((HVX_UVector *) output) = vacc0;
-    *((HVX_UVector *)(output + 32)) = vacc1;
+   xnn_storeu_f32(output, vacc0);
+    xnn_storeu_f32(output + 32, vacc1);
     output += 64;
   }
   for (; batch >= 32 * sizeof(float); batch -= 32 * sizeof(float)) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
     input_a += 32;
 
-    HVX_Vector vacc = Q6_Vsf_vmin_VsfVsf(va, vb);
+    HVX_Vector vacc = xnn_min_f32(va, vb);
 
-    *((HVX_UVector *) output) = vacc;
+    xnn_storeu_f32(output, vacc);
     output+= 32;
   }
   if XNN_UNLIKELY(batch != 0) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
 
-    HVX_Vector vacc = Q6_Vsf_vmin_VsfVsf(va, vb);
+    HVX_Vector vacc = xnn_min_f32(va, vb);
 
     Q6_V_vstu_variable(output, batch, vacc);
   }

--- a/src/f32-vbinary/gen/f32-vmul-minmax-hvx-u128.c
+++ b/src/f32-vbinary/gen/f32-vmul-minmax-hvx-u128.c
@@ -5,12 +5,8 @@
 
 #include <assert.h>
 
-#include <hvx_hexagon_protos.h>
-#include <hexagon_protos.h>
-#include <hexagon_types.h>
+#include "xnnpack/simd/f32-hvx.h"
 
-#include "xnnpack/common.h"
-#include "xnnpack/intrinsics-polyfill.h"
 #include "xnnpack/math.h"
 #include "xnnpack/vbinary.h"
 
@@ -27,61 +23,64 @@ void xnn_f32_vmul_minmax_ukernel__hvx_u128(
   assert(input_b != NULL);
   assert(output != NULL);
 
-  const HVX_Vector voutput_min = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.min));
-  const HVX_Vector voutput_max = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.max));
-
-  const HVX_UVector *vptr_a = (const HVX_UVector *) input_a;
-  const HVX_UVector *vptr_b = (const HVX_UVector *) input_b;
-  HVX_UVector *vptr_o = (HVX_UVector*) output;
+  const HVX_Vector voutput_min = xnn_set1_f32(params->scalar.min);
+  const HVX_Vector voutput_max = xnn_set1_f32(params->scalar.max);
 
   for (; batch >= 128 * sizeof(float); batch -= 128 * sizeof(float)) {
-    HVX_Vector va0 = *vptr_a++;
-    HVX_Vector va1 = *vptr_a++;
-    HVX_Vector va2 = *vptr_a++;
-    HVX_Vector va3 = *vptr_a++;
-    HVX_Vector vb0 = *vptr_b++;
-    HVX_Vector vb1 = *vptr_b++;
-    HVX_Vector vb2 = *vptr_b++;
-    HVX_Vector vb3 = *vptr_b++;
+    HVX_Vector va0 = xnn_loadu_f32(input_a);
+    HVX_Vector va1 = xnn_loadu_f32(input_a + 32);
+    HVX_Vector va2 = xnn_loadu_f32(input_a + 64);
+    HVX_Vector va3 = xnn_loadu_f32(input_a + 96);
+    HVX_Vector vb0 = xnn_loadu_f32(input_b);
+    HVX_Vector vb1 = xnn_loadu_f32(input_b + 32);
+    HVX_Vector vb2 = xnn_loadu_f32(input_b + 64);
+    HVX_Vector vb3 = xnn_loadu_f32(input_b + 96);
+    input_a += 128;
+    input_b += 128;
 
-    HVX_Vector vacc0 = Q6_Vsf_vmpy_VsfVsf(va0, vb0);
-    HVX_Vector vacc1 = Q6_Vsf_vmpy_VsfVsf(va1, vb1);
-    HVX_Vector vacc2 = Q6_Vsf_vmpy_VsfVsf(va2, vb2);
-    HVX_Vector vacc3 = Q6_Vsf_vmpy_VsfVsf(va3, vb3);
+    HVX_Vector vacc0 = xnn_mul_f32(va0, vb0);
+    HVX_Vector vacc1 = xnn_mul_f32(va1, vb1);
+    HVX_Vector vacc2 = xnn_mul_f32(va2, vb2);
+    HVX_Vector vacc3 = xnn_mul_f32(va3, vb3);
 
-    vacc0 = Q6_Vsf_vmax_VsfVsf(vacc0, voutput_min);
-    vacc1 = Q6_Vsf_vmax_VsfVsf(vacc1, voutput_min);
-    vacc2 = Q6_Vsf_vmax_VsfVsf(vacc2, voutput_min);
-    vacc3 = Q6_Vsf_vmax_VsfVsf(vacc3, voutput_min);
 
-    vacc0 = Q6_Vsf_vmin_VsfVsf(vacc0, voutput_max);
-    vacc1 = Q6_Vsf_vmin_VsfVsf(vacc1, voutput_max);
-    vacc2 = Q6_Vsf_vmin_VsfVsf(vacc2, voutput_max);
-    vacc3 = Q6_Vsf_vmin_VsfVsf(vacc3, voutput_max);
+    vacc0 = xnn_max_f32(vacc0, voutput_min);
+    vacc1 = xnn_max_f32(vacc1, voutput_min);
+    vacc2 = xnn_max_f32(vacc2, voutput_min);
+    vacc3 = xnn_max_f32(vacc3, voutput_min);
 
-    *vptr_o++ = vacc0;
-    *vptr_o++ = vacc1;
-    *vptr_o++ = vacc2;
-    *vptr_o++ = vacc3;
+    vacc0 = xnn_min_f32(vacc0, voutput_max);
+    vacc1 = xnn_min_f32(vacc1, voutput_max);
+    vacc2 = xnn_min_f32(vacc2, voutput_max);
+    vacc3 = xnn_min_f32(vacc3, voutput_max);
+
+    xnn_storeu_f32(output, vacc0);
+    xnn_storeu_f32(output + 32, vacc1);
+    xnn_storeu_f32(output + 64, vacc2);
+    xnn_storeu_f32(output + 96, vacc3);
+    output += 128;
   }
   for (; batch >= 32 * sizeof(float); batch -= 32 * sizeof(float)) {
-    HVX_Vector va = *vptr_a++;
-    HVX_Vector vb = *vptr_b++;
+    HVX_Vector va = xnn_loadu_f32(input_a);
+    HVX_Vector vb = xnn_loadu_f32(input_b);
+    input_a += 32;
+    input_b += 32;
 
-    HVX_Vector vacc = Q6_Vsf_vmpy_VsfVsf(va, vb);
-    vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-    vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+    HVX_Vector vacc = xnn_mul_f32(va, vb);
+    vacc = xnn_max_f32(vacc, voutput_min);
+    vacc = xnn_min_f32(vacc, voutput_max);
 
-    *vptr_o++ = vacc;
+    xnn_storeu_f32(output, vacc);
+    output += 32;
   }
   if XNN_UNLIKELY(batch != 0) {
-     HVX_Vector va = *vptr_a;
-     HVX_Vector vb = *vptr_b;
+     HVX_Vector va = xnn_loadu_f32(input_a);
+     HVX_Vector vb = xnn_loadu_f32(input_b);
 
-     HVX_Vector vacc = Q6_Vsf_vmpy_VsfVsf(va, vb);
-     vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-     vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+     HVX_Vector vacc = xnn_mul_f32(va, vb);
+     vacc = xnn_max_f32(vacc, voutput_min);
+     vacc = xnn_min_f32(vacc, voutput_max);
      
-     Q6_V_vstu_variable(vptr_o, batch, vacc);
+     Q6_V_vstu_variable(output, batch, vacc);
   }
 }

--- a/src/f32-vbinary/gen/f32-vmul-minmax-hvx-u64.c
+++ b/src/f32-vbinary/gen/f32-vmul-minmax-hvx-u64.c
@@ -5,12 +5,8 @@
 
 #include <assert.h>
 
-#include <hvx_hexagon_protos.h>
-#include <hexagon_protos.h>
-#include <hexagon_types.h>
+#include "xnnpack/simd/f32-hvx.h"
 
-#include "xnnpack/common.h"
-#include "xnnpack/intrinsics-polyfill.h"
 #include "xnnpack/math.h"
 #include "xnnpack/vbinary.h"
 
@@ -27,49 +23,52 @@ void xnn_f32_vmul_minmax_ukernel__hvx_u64(
   assert(input_b != NULL);
   assert(output != NULL);
 
-  const HVX_Vector voutput_min = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.min));
-  const HVX_Vector voutput_max = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.max));
-
-  const HVX_UVector *vptr_a = (const HVX_UVector *) input_a;
-  const HVX_UVector *vptr_b = (const HVX_UVector *) input_b;
-  HVX_UVector *vptr_o = (HVX_UVector*) output;
+  const HVX_Vector voutput_min = xnn_set1_f32(params->scalar.min);
+  const HVX_Vector voutput_max = xnn_set1_f32(params->scalar.max);
 
   for (; batch >= 64 * sizeof(float); batch -= 64 * sizeof(float)) {
-    HVX_Vector va0 = *vptr_a++;
-    HVX_Vector va1 = *vptr_a++;
-    HVX_Vector vb0 = *vptr_b++;
-    HVX_Vector vb1 = *vptr_b++;
+    HVX_Vector va0 = xnn_loadu_f32(input_a);
+    HVX_Vector va1 = xnn_loadu_f32(input_a + 32);
+    HVX_Vector vb0 = xnn_loadu_f32(input_b);
+    HVX_Vector vb1 = xnn_loadu_f32(input_b + 32);
+    input_a += 64;
+    input_b += 64;
 
-    HVX_Vector vacc0 = Q6_Vsf_vmpy_VsfVsf(va0, vb0);
-    HVX_Vector vacc1 = Q6_Vsf_vmpy_VsfVsf(va1, vb1);
+    HVX_Vector vacc0 = xnn_mul_f32(va0, vb0);
+    HVX_Vector vacc1 = xnn_mul_f32(va1, vb1);
 
-    vacc0 = Q6_Vsf_vmax_VsfVsf(vacc0, voutput_min);
-    vacc1 = Q6_Vsf_vmax_VsfVsf(vacc1, voutput_min);
 
-    vacc0 = Q6_Vsf_vmin_VsfVsf(vacc0, voutput_max);
-    vacc1 = Q6_Vsf_vmin_VsfVsf(vacc1, voutput_max);
+    vacc0 = xnn_max_f32(vacc0, voutput_min);
+    vacc1 = xnn_max_f32(vacc1, voutput_min);
 
-    *vptr_o++ = vacc0;
-    *vptr_o++ = vacc1;
+    vacc0 = xnn_min_f32(vacc0, voutput_max);
+    vacc1 = xnn_min_f32(vacc1, voutput_max);
+
+    xnn_storeu_f32(output, vacc0);
+    xnn_storeu_f32(output + 32, vacc1);
+    output += 64;
   }
   for (; batch >= 32 * sizeof(float); batch -= 32 * sizeof(float)) {
-    HVX_Vector va = *vptr_a++;
-    HVX_Vector vb = *vptr_b++;
+    HVX_Vector va = xnn_loadu_f32(input_a);
+    HVX_Vector vb = xnn_loadu_f32(input_b);
+    input_a += 32;
+    input_b += 32;
 
-    HVX_Vector vacc = Q6_Vsf_vmpy_VsfVsf(va, vb);
-    vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-    vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+    HVX_Vector vacc = xnn_mul_f32(va, vb);
+    vacc = xnn_max_f32(vacc, voutput_min);
+    vacc = xnn_min_f32(vacc, voutput_max);
 
-    *vptr_o++ = vacc;
+    xnn_storeu_f32(output, vacc);
+    output += 32;
   }
   if XNN_UNLIKELY(batch != 0) {
-     HVX_Vector va = *vptr_a;
-     HVX_Vector vb = *vptr_b;
+     HVX_Vector va = xnn_loadu_f32(input_a);
+     HVX_Vector vb = xnn_loadu_f32(input_b);
 
-     HVX_Vector vacc = Q6_Vsf_vmpy_VsfVsf(va, vb);
-     vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-     vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+     HVX_Vector vacc = xnn_mul_f32(va, vb);
+     vacc = xnn_max_f32(vacc, voutput_min);
+     vacc = xnn_min_f32(vacc, voutput_max);
      
-     Q6_V_vstu_variable(vptr_o, batch, vacc);
+     Q6_V_vstu_variable(output, batch, vacc);
   }
 }

--- a/src/f32-vbinary/gen/f32-vmulc-minmax-hvx-u128.c
+++ b/src/f32-vbinary/gen/f32-vmulc-minmax-hvx-u128.c
@@ -5,12 +5,8 @@
 
 #include <assert.h>
 
-#include <hvx_hexagon_protos.h>
-#include <hexagon_protos.h>
-#include <hexagon_types.h>
+#include "xnnpack/simd/f32-hvx.h"
 
-#include "xnnpack/common.h"
-#include "xnnpack/intrinsics-polyfill.h"
 #include "xnnpack/math.h"
 #include "xnnpack/vbinary.h"
 
@@ -27,56 +23,56 @@ void xnn_f32_vmulc_minmax_ukernel__hvx_u128(
   assert(input_b != NULL);
   assert(output != NULL);
 
-  const HVX_Vector voutput_min = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.min));
-  const HVX_Vector voutput_max = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.max));
-  HVX_Vector vb = Q6_V_vsplat_R(*((int32_t*) input_b));
+  const HVX_Vector voutput_min = xnn_set1_f32(params->scalar.min);
+  const HVX_Vector voutput_max = xnn_set1_f32(params->scalar.max);
+  HVX_Vector vb = xnn_set1_f32(*input_b);
 
   for (; batch >= 128 * sizeof(float); batch -= 128 * sizeof(float)) {
-    HVX_Vector va0 = *((HVX_UVector*) input_a);
-    HVX_Vector va1 = *((HVX_UVector*)(input_a + 32));
-    HVX_Vector va2 = *((HVX_UVector*)(input_a + 64));
-    HVX_Vector va3 = *((HVX_UVector*)(input_a + 96));
+    HVX_Vector va0 = xnn_loadu_f32(input_a);
+    HVX_Vector va1 = xnn_loadu_f32(input_a + 32);
+    HVX_Vector va2 = xnn_loadu_f32(input_a + 64);
+    HVX_Vector va3 = xnn_loadu_f32(input_a + 96);
     input_a += 128;
 
-    HVX_Vector vacc0 = Q6_Vsf_vmpy_VsfVsf(va0, vb);
-    HVX_Vector vacc1 = Q6_Vsf_vmpy_VsfVsf(va1, vb);
-    HVX_Vector vacc2 = Q6_Vsf_vmpy_VsfVsf(va2, vb);
-    HVX_Vector vacc3 = Q6_Vsf_vmpy_VsfVsf(va3, vb);
+    HVX_Vector vacc0 = xnn_mul_f32(va0, vb);
+    HVX_Vector vacc1 = xnn_mul_f32(va1, vb);
+    HVX_Vector vacc2 = xnn_mul_f32(va2, vb);
+    HVX_Vector vacc3 = xnn_mul_f32(va3, vb);
 
 
-    vacc0 = Q6_Vsf_vmax_VsfVsf(vacc0, voutput_min);
-    vacc1 = Q6_Vsf_vmax_VsfVsf(vacc1, voutput_min);
-    vacc2 = Q6_Vsf_vmax_VsfVsf(vacc2, voutput_min);
-    vacc3 = Q6_Vsf_vmax_VsfVsf(vacc3, voutput_min);
+    vacc0 = xnn_max_f32(vacc0, voutput_min);
+    vacc1 = xnn_max_f32(vacc1, voutput_min);
+    vacc2 = xnn_max_f32(vacc2, voutput_min);
+    vacc3 = xnn_max_f32(vacc3, voutput_min);
 
-    vacc0 = Q6_Vsf_vmin_VsfVsf(vacc0, voutput_max);
-    vacc1 = Q6_Vsf_vmin_VsfVsf(vacc1, voutput_max);
-    vacc2 = Q6_Vsf_vmin_VsfVsf(vacc2, voutput_max);
-    vacc3 = Q6_Vsf_vmin_VsfVsf(vacc3, voutput_max);
+    vacc0 = xnn_min_f32(vacc0, voutput_max);
+    vacc1 = xnn_min_f32(vacc1, voutput_max);
+    vacc2 = xnn_min_f32(vacc2, voutput_max);
+    vacc3 = xnn_min_f32(vacc3, voutput_max);
 
-    *((HVX_UVector *) output) = vacc0;
-    *((HVX_UVector *)(output + 32)) = vacc1;
-    *((HVX_UVector *)(output + 64)) = vacc2;
-    *((HVX_UVector *)(output + 96)) = vacc3;
+   xnn_storeu_f32(output, vacc0);
+    xnn_storeu_f32(output + 32, vacc1);
+    xnn_storeu_f32(output + 64, vacc2);
+    xnn_storeu_f32(output + 96, vacc3);
     output += 128;
   }
   for (; batch >= 32 * sizeof(float); batch -= 32 * sizeof(float)) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
     input_a += 32;
 
-    HVX_Vector vacc = Q6_Vsf_vmpy_VsfVsf(va, vb);
-    vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-    vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+    HVX_Vector vacc = xnn_mul_f32(va, vb);
+    vacc = xnn_max_f32(vacc, voutput_min);
+    vacc = xnn_min_f32(vacc, voutput_max);
 
-    *((HVX_UVector *) output) = vacc;
+    xnn_storeu_f32(output, vacc);
     output+= 32;
   }
   if XNN_UNLIKELY(batch != 0) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
 
-    HVX_Vector vacc = Q6_Vsf_vmpy_VsfVsf(va, vb);
-    vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-    vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+    HVX_Vector vacc = xnn_mul_f32(va, vb);
+    vacc = xnn_max_f32(vacc, voutput_min);
+    vacc = xnn_min_f32(vacc, voutput_max);
 
     Q6_V_vstu_variable(output, batch, vacc);
   }

--- a/src/f32-vbinary/gen/f32-vmulc-minmax-hvx-u32.c
+++ b/src/f32-vbinary/gen/f32-vmulc-minmax-hvx-u32.c
@@ -5,12 +5,8 @@
 
 #include <assert.h>
 
-#include <hvx_hexagon_protos.h>
-#include <hexagon_protos.h>
-#include <hexagon_types.h>
+#include "xnnpack/simd/f32-hvx.h"
 
-#include "xnnpack/common.h"
-#include "xnnpack/intrinsics-polyfill.h"
 #include "xnnpack/math.h"
 #include "xnnpack/vbinary.h"
 
@@ -27,27 +23,27 @@ void xnn_f32_vmulc_minmax_ukernel__hvx_u32(
   assert(input_b != NULL);
   assert(output != NULL);
 
-  const HVX_Vector voutput_min = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.min));
-  const HVX_Vector voutput_max = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.max));
-  HVX_Vector vb = Q6_V_vsplat_R(*((int32_t*) input_b));
+  const HVX_Vector voutput_min = xnn_set1_f32(params->scalar.min);
+  const HVX_Vector voutput_max = xnn_set1_f32(params->scalar.max);
+  HVX_Vector vb = xnn_set1_f32(*input_b);
 
   for (; batch >= 32 * sizeof(float); batch -= 32 * sizeof(float)) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
     input_a += 32;
 
-    HVX_Vector vacc = Q6_Vsf_vmpy_VsfVsf(va, vb);
-    vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-    vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+    HVX_Vector vacc = xnn_mul_f32(va, vb);
+    vacc = xnn_max_f32(vacc, voutput_min);
+    vacc = xnn_min_f32(vacc, voutput_max);
 
-    *((HVX_UVector *) output) = vacc;
+    xnn_storeu_f32(output, vacc);
     output+= 32;
   }
   if XNN_UNLIKELY(batch != 0) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
 
-    HVX_Vector vacc = Q6_Vsf_vmpy_VsfVsf(va, vb);
-    vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-    vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+    HVX_Vector vacc = xnn_mul_f32(va, vb);
+    vacc = xnn_max_f32(vacc, voutput_min);
+    vacc = xnn_min_f32(vacc, voutput_max);
 
     Q6_V_vstu_variable(output, batch, vacc);
   }

--- a/src/f32-vbinary/gen/f32-vmulc-minmax-hvx-u64.c
+++ b/src/f32-vbinary/gen/f32-vmulc-minmax-hvx-u64.c
@@ -5,12 +5,8 @@
 
 #include <assert.h>
 
-#include <hvx_hexagon_protos.h>
-#include <hexagon_protos.h>
-#include <hexagon_types.h>
+#include "xnnpack/simd/f32-hvx.h"
 
-#include "xnnpack/common.h"
-#include "xnnpack/intrinsics-polyfill.h"
 #include "xnnpack/math.h"
 #include "xnnpack/vbinary.h"
 
@@ -27,46 +23,46 @@ void xnn_f32_vmulc_minmax_ukernel__hvx_u64(
   assert(input_b != NULL);
   assert(output != NULL);
 
-  const HVX_Vector voutput_min = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.min));
-  const HVX_Vector voutput_max = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.max));
-  HVX_Vector vb = Q6_V_vsplat_R(*((int32_t*) input_b));
+  const HVX_Vector voutput_min = xnn_set1_f32(params->scalar.min);
+  const HVX_Vector voutput_max = xnn_set1_f32(params->scalar.max);
+  HVX_Vector vb = xnn_set1_f32(*input_b);
 
   for (; batch >= 64 * sizeof(float); batch -= 64 * sizeof(float)) {
-    HVX_Vector va0 = *((HVX_UVector*) input_a);
-    HVX_Vector va1 = *((HVX_UVector*)(input_a + 32));
+    HVX_Vector va0 = xnn_loadu_f32(input_a);
+    HVX_Vector va1 = xnn_loadu_f32(input_a + 32);
     input_a += 64;
 
-    HVX_Vector vacc0 = Q6_Vsf_vmpy_VsfVsf(va0, vb);
-    HVX_Vector vacc1 = Q6_Vsf_vmpy_VsfVsf(va1, vb);
+    HVX_Vector vacc0 = xnn_mul_f32(va0, vb);
+    HVX_Vector vacc1 = xnn_mul_f32(va1, vb);
 
 
-    vacc0 = Q6_Vsf_vmax_VsfVsf(vacc0, voutput_min);
-    vacc1 = Q6_Vsf_vmax_VsfVsf(vacc1, voutput_min);
+    vacc0 = xnn_max_f32(vacc0, voutput_min);
+    vacc1 = xnn_max_f32(vacc1, voutput_min);
 
-    vacc0 = Q6_Vsf_vmin_VsfVsf(vacc0, voutput_max);
-    vacc1 = Q6_Vsf_vmin_VsfVsf(vacc1, voutput_max);
+    vacc0 = xnn_min_f32(vacc0, voutput_max);
+    vacc1 = xnn_min_f32(vacc1, voutput_max);
 
-    *((HVX_UVector *) output) = vacc0;
-    *((HVX_UVector *)(output + 32)) = vacc1;
+   xnn_storeu_f32(output, vacc0);
+    xnn_storeu_f32(output + 32, vacc1);
     output += 64;
   }
   for (; batch >= 32 * sizeof(float); batch -= 32 * sizeof(float)) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
     input_a += 32;
 
-    HVX_Vector vacc = Q6_Vsf_vmpy_VsfVsf(va, vb);
-    vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-    vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+    HVX_Vector vacc = xnn_mul_f32(va, vb);
+    vacc = xnn_max_f32(vacc, voutput_min);
+    vacc = xnn_min_f32(vacc, voutput_max);
 
-    *((HVX_UVector *) output) = vacc;
+    xnn_storeu_f32(output, vacc);
     output+= 32;
   }
   if XNN_UNLIKELY(batch != 0) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
 
-    HVX_Vector vacc = Q6_Vsf_vmpy_VsfVsf(va, vb);
-    vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-    vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+    HVX_Vector vacc = xnn_mul_f32(va, vb);
+    vacc = xnn_max_f32(vacc, voutput_min);
+    vacc = xnn_min_f32(vacc, voutput_max);
 
     Q6_V_vstu_variable(output, batch, vacc);
   }

--- a/src/f32-vbinary/gen/f32-vrsubc-minmax-hvx-u128.c
+++ b/src/f32-vbinary/gen/f32-vrsubc-minmax-hvx-u128.c
@@ -5,12 +5,8 @@
 
 #include <assert.h>
 
-#include <hvx_hexagon_protos.h>
-#include <hexagon_protos.h>
-#include <hexagon_types.h>
+#include "xnnpack/simd/f32-hvx.h"
 
-#include "xnnpack/common.h"
-#include "xnnpack/intrinsics-polyfill.h"
 #include "xnnpack/math.h"
 #include "xnnpack/vbinary.h"
 
@@ -27,56 +23,56 @@ void xnn_f32_vrsubc_minmax_ukernel__hvx_u128(
   assert(input_b != NULL);
   assert(output != NULL);
 
-  const HVX_Vector voutput_min = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.min));
-  const HVX_Vector voutput_max = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.max));
-  HVX_Vector vb = Q6_V_vsplat_R(*((int32_t*) input_b));
+  const HVX_Vector voutput_min = xnn_set1_f32(params->scalar.min);
+  const HVX_Vector voutput_max = xnn_set1_f32(params->scalar.max);
+  HVX_Vector vb = xnn_set1_f32(*input_b);
 
   for (; batch >= 128 * sizeof(float); batch -= 128 * sizeof(float)) {
-    HVX_Vector va0 = *((HVX_UVector*) input_a);
-    HVX_Vector va1 = *((HVX_UVector*)(input_a + 32));
-    HVX_Vector va2 = *((HVX_UVector*)(input_a + 64));
-    HVX_Vector va3 = *((HVX_UVector*)(input_a + 96));
+    HVX_Vector va0 = xnn_loadu_f32(input_a);
+    HVX_Vector va1 = xnn_loadu_f32(input_a + 32);
+    HVX_Vector va2 = xnn_loadu_f32(input_a + 64);
+    HVX_Vector va3 = xnn_loadu_f32(input_a + 96);
     input_a += 128;
 
-    HVX_Vector vacc0 = Q6_Vsf_vsub_VsfVsf(vb, va0);
-    HVX_Vector vacc1 = Q6_Vsf_vsub_VsfVsf(vb, va1);
-    HVX_Vector vacc2 = Q6_Vsf_vsub_VsfVsf(vb, va2);
-    HVX_Vector vacc3 = Q6_Vsf_vsub_VsfVsf(vb, va3);
+    HVX_Vector vacc0 = xnn_sub_f32(vb, va0);
+    HVX_Vector vacc1 = xnn_sub_f32(vb, va1);
+    HVX_Vector vacc2 = xnn_sub_f32(vb, va2);
+    HVX_Vector vacc3 = xnn_sub_f32(vb, va3);
 
 
-    vacc0 = Q6_Vsf_vmax_VsfVsf(vacc0, voutput_min);
-    vacc1 = Q6_Vsf_vmax_VsfVsf(vacc1, voutput_min);
-    vacc2 = Q6_Vsf_vmax_VsfVsf(vacc2, voutput_min);
-    vacc3 = Q6_Vsf_vmax_VsfVsf(vacc3, voutput_min);
+    vacc0 = xnn_max_f32(vacc0, voutput_min);
+    vacc1 = xnn_max_f32(vacc1, voutput_min);
+    vacc2 = xnn_max_f32(vacc2, voutput_min);
+    vacc3 = xnn_max_f32(vacc3, voutput_min);
 
-    vacc0 = Q6_Vsf_vmin_VsfVsf(vacc0, voutput_max);
-    vacc1 = Q6_Vsf_vmin_VsfVsf(vacc1, voutput_max);
-    vacc2 = Q6_Vsf_vmin_VsfVsf(vacc2, voutput_max);
-    vacc3 = Q6_Vsf_vmin_VsfVsf(vacc3, voutput_max);
+    vacc0 = xnn_min_f32(vacc0, voutput_max);
+    vacc1 = xnn_min_f32(vacc1, voutput_max);
+    vacc2 = xnn_min_f32(vacc2, voutput_max);
+    vacc3 = xnn_min_f32(vacc3, voutput_max);
 
-    *((HVX_UVector *) output) = vacc0;
-    *((HVX_UVector *)(output + 32)) = vacc1;
-    *((HVX_UVector *)(output + 64)) = vacc2;
-    *((HVX_UVector *)(output + 96)) = vacc3;
+   xnn_storeu_f32(output, vacc0);
+    xnn_storeu_f32(output + 32, vacc1);
+    xnn_storeu_f32(output + 64, vacc2);
+    xnn_storeu_f32(output + 96, vacc3);
     output += 128;
   }
   for (; batch >= 32 * sizeof(float); batch -= 32 * sizeof(float)) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
     input_a += 32;
 
-    HVX_Vector vacc = Q6_Vsf_vsub_VsfVsf(vb, va);
-    vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-    vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+    HVX_Vector vacc = xnn_sub_f32(vb, va);
+    vacc = xnn_max_f32(vacc, voutput_min);
+    vacc = xnn_min_f32(vacc, voutput_max);
 
-    *((HVX_UVector *) output) = vacc;
+    xnn_storeu_f32(output, vacc);
     output+= 32;
   }
   if XNN_UNLIKELY(batch != 0) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
 
-    HVX_Vector vacc = Q6_Vsf_vsub_VsfVsf(vb, va);
-    vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-    vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+    HVX_Vector vacc = xnn_sub_f32(vb, va);
+    vacc = xnn_max_f32(vacc, voutput_min);
+    vacc = xnn_min_f32(vacc, voutput_max);
 
     Q6_V_vstu_variable(output, batch, vacc);
   }

--- a/src/f32-vbinary/gen/f32-vrsubc-minmax-hvx-u32.c
+++ b/src/f32-vbinary/gen/f32-vrsubc-minmax-hvx-u32.c
@@ -5,12 +5,8 @@
 
 #include <assert.h>
 
-#include <hvx_hexagon_protos.h>
-#include <hexagon_protos.h>
-#include <hexagon_types.h>
+#include "xnnpack/simd/f32-hvx.h"
 
-#include "xnnpack/common.h"
-#include "xnnpack/intrinsics-polyfill.h"
 #include "xnnpack/math.h"
 #include "xnnpack/vbinary.h"
 
@@ -27,27 +23,27 @@ void xnn_f32_vrsubc_minmax_ukernel__hvx_u32(
   assert(input_b != NULL);
   assert(output != NULL);
 
-  const HVX_Vector voutput_min = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.min));
-  const HVX_Vector voutput_max = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.max));
-  HVX_Vector vb = Q6_V_vsplat_R(*((int32_t*) input_b));
+  const HVX_Vector voutput_min = xnn_set1_f32(params->scalar.min);
+  const HVX_Vector voutput_max = xnn_set1_f32(params->scalar.max);
+  HVX_Vector vb = xnn_set1_f32(*input_b);
 
   for (; batch >= 32 * sizeof(float); batch -= 32 * sizeof(float)) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
     input_a += 32;
 
-    HVX_Vector vacc = Q6_Vsf_vsub_VsfVsf(vb, va);
-    vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-    vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+    HVX_Vector vacc = xnn_sub_f32(vb, va);
+    vacc = xnn_max_f32(vacc, voutput_min);
+    vacc = xnn_min_f32(vacc, voutput_max);
 
-    *((HVX_UVector *) output) = vacc;
+    xnn_storeu_f32(output, vacc);
     output+= 32;
   }
   if XNN_UNLIKELY(batch != 0) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
 
-    HVX_Vector vacc = Q6_Vsf_vsub_VsfVsf(vb, va);
-    vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-    vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+    HVX_Vector vacc = xnn_sub_f32(vb, va);
+    vacc = xnn_max_f32(vacc, voutput_min);
+    vacc = xnn_min_f32(vacc, voutput_max);
 
     Q6_V_vstu_variable(output, batch, vacc);
   }

--- a/src/f32-vbinary/gen/f32-vrsubc-minmax-hvx-u64.c
+++ b/src/f32-vbinary/gen/f32-vrsubc-minmax-hvx-u64.c
@@ -5,12 +5,8 @@
 
 #include <assert.h>
 
-#include <hvx_hexagon_protos.h>
-#include <hexagon_protos.h>
-#include <hexagon_types.h>
+#include "xnnpack/simd/f32-hvx.h"
 
-#include "xnnpack/common.h"
-#include "xnnpack/intrinsics-polyfill.h"
 #include "xnnpack/math.h"
 #include "xnnpack/vbinary.h"
 
@@ -27,46 +23,46 @@ void xnn_f32_vrsubc_minmax_ukernel__hvx_u64(
   assert(input_b != NULL);
   assert(output != NULL);
 
-  const HVX_Vector voutput_min = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.min));
-  const HVX_Vector voutput_max = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.max));
-  HVX_Vector vb = Q6_V_vsplat_R(*((int32_t*) input_b));
+  const HVX_Vector voutput_min = xnn_set1_f32(params->scalar.min);
+  const HVX_Vector voutput_max = xnn_set1_f32(params->scalar.max);
+  HVX_Vector vb = xnn_set1_f32(*input_b);
 
   for (; batch >= 64 * sizeof(float); batch -= 64 * sizeof(float)) {
-    HVX_Vector va0 = *((HVX_UVector*) input_a);
-    HVX_Vector va1 = *((HVX_UVector*)(input_a + 32));
+    HVX_Vector va0 = xnn_loadu_f32(input_a);
+    HVX_Vector va1 = xnn_loadu_f32(input_a + 32);
     input_a += 64;
 
-    HVX_Vector vacc0 = Q6_Vsf_vsub_VsfVsf(vb, va0);
-    HVX_Vector vacc1 = Q6_Vsf_vsub_VsfVsf(vb, va1);
+    HVX_Vector vacc0 = xnn_sub_f32(vb, va0);
+    HVX_Vector vacc1 = xnn_sub_f32(vb, va1);
 
 
-    vacc0 = Q6_Vsf_vmax_VsfVsf(vacc0, voutput_min);
-    vacc1 = Q6_Vsf_vmax_VsfVsf(vacc1, voutput_min);
+    vacc0 = xnn_max_f32(vacc0, voutput_min);
+    vacc1 = xnn_max_f32(vacc1, voutput_min);
 
-    vacc0 = Q6_Vsf_vmin_VsfVsf(vacc0, voutput_max);
-    vacc1 = Q6_Vsf_vmin_VsfVsf(vacc1, voutput_max);
+    vacc0 = xnn_min_f32(vacc0, voutput_max);
+    vacc1 = xnn_min_f32(vacc1, voutput_max);
 
-    *((HVX_UVector *) output) = vacc0;
-    *((HVX_UVector *)(output + 32)) = vacc1;
+   xnn_storeu_f32(output, vacc0);
+    xnn_storeu_f32(output + 32, vacc1);
     output += 64;
   }
   for (; batch >= 32 * sizeof(float); batch -= 32 * sizeof(float)) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
     input_a += 32;
 
-    HVX_Vector vacc = Q6_Vsf_vsub_VsfVsf(vb, va);
-    vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-    vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+    HVX_Vector vacc = xnn_sub_f32(vb, va);
+    vacc = xnn_max_f32(vacc, voutput_min);
+    vacc = xnn_min_f32(vacc, voutput_max);
 
-    *((HVX_UVector *) output) = vacc;
+    xnn_storeu_f32(output, vacc);
     output+= 32;
   }
   if XNN_UNLIKELY(batch != 0) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
 
-    HVX_Vector vacc = Q6_Vsf_vsub_VsfVsf(vb, va);
-    vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-    vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+    HVX_Vector vacc = xnn_sub_f32(vb, va);
+    vacc = xnn_max_f32(vacc, voutput_min);
+    vacc = xnn_min_f32(vacc, voutput_max);
 
     Q6_V_vstu_variable(output, batch, vacc);
   }

--- a/src/f32-vbinary/gen/f32-vsqrdiff-hvx-u32.c
+++ b/src/f32-vbinary/gen/f32-vsqrdiff-hvx-u32.c
@@ -5,12 +5,8 @@
 
 #include <assert.h>
 
-#include <hvx_hexagon_protos.h>
-#include <hexagon_protos.h>
-#include <hexagon_types.h>
+#include "xnnpack/simd/f32-hvx.h"
 
-#include "xnnpack/common.h"
-#include "xnnpack/intrinsics-polyfill.h"
 #include "xnnpack/math.h"
 #include "xnnpack/vbinary.h"
 
@@ -28,26 +24,25 @@ void xnn_f32_vsqrdiff_ukernel__hvx_u32(
   assert(output != NULL);
 
 
-  const HVX_UVector *vptr_a = (const HVX_UVector *) input_a;
-  const HVX_UVector *vptr_b = (const HVX_UVector *) input_b;
-  HVX_UVector *vptr_o = (HVX_UVector*) output;
-
   for (; batch >= 32 * sizeof(float); batch -= 32 * sizeof(float)) {
-    HVX_Vector va = *vptr_a++;
-    HVX_Vector vb = *vptr_b++;
+    HVX_Vector va = xnn_loadu_f32(input_a);
+    HVX_Vector vb = xnn_loadu_f32(input_b);
+    input_a += 32;
+    input_b += 32;
 
-    HVX_Vector vacc = Q6_Vsf_vsub_VsfVsf(va, vb);
-    vacc = Q6_Vsf_vmpy_VsfVsf(vacc, vacc);
+    HVX_Vector vacc = xnn_sub_f32(va, vb);
+    vacc = xnn_mul_f32(vacc, vacc);
 
-    *vptr_o++ = vacc;
+    xnn_storeu_f32(output, vacc);
+    output += 32;
   }
   if XNN_UNLIKELY(batch != 0) {
-     HVX_Vector va = *vptr_a;
-     HVX_Vector vb = *vptr_b;
+     HVX_Vector va = xnn_loadu_f32(input_a);
+     HVX_Vector vb = xnn_loadu_f32(input_b);
 
-     HVX_Vector vacc = Q6_Vsf_vsub_VsfVsf(va, vb);
-     vacc = Q6_Vsf_vmpy_VsfVsf(vacc, vacc);
+     HVX_Vector vacc = xnn_sub_f32(va, vb);
+     vacc = xnn_mul_f32(vacc, vacc);
      
-     Q6_V_vstu_variable(vptr_o, batch, vacc);
+     Q6_V_vstu_variable(output, batch, vacc);
   }
 }

--- a/src/f32-vbinary/gen/f32-vsqrdiff-hvx-u64.c
+++ b/src/f32-vbinary/gen/f32-vsqrdiff-hvx-u64.c
@@ -5,12 +5,8 @@
 
 #include <assert.h>
 
-#include <hvx_hexagon_protos.h>
-#include <hexagon_protos.h>
-#include <hexagon_types.h>
+#include "xnnpack/simd/f32-hvx.h"
 
-#include "xnnpack/common.h"
-#include "xnnpack/intrinsics-polyfill.h"
 #include "xnnpack/math.h"
 #include "xnnpack/vbinary.h"
 
@@ -28,41 +24,44 @@ void xnn_f32_vsqrdiff_ukernel__hvx_u64(
   assert(output != NULL);
 
 
-  const HVX_UVector *vptr_a = (const HVX_UVector *) input_a;
-  const HVX_UVector *vptr_b = (const HVX_UVector *) input_b;
-  HVX_UVector *vptr_o = (HVX_UVector*) output;
-
   for (; batch >= 64 * sizeof(float); batch -= 64 * sizeof(float)) {
-    HVX_Vector va0 = *vptr_a++;
-    HVX_Vector va1 = *vptr_a++;
-    HVX_Vector vb0 = *vptr_b++;
-    HVX_Vector vb1 = *vptr_b++;
+    HVX_Vector va0 = xnn_loadu_f32(input_a);
+    HVX_Vector va1 = xnn_loadu_f32(input_a + 32);
+    HVX_Vector vb0 = xnn_loadu_f32(input_b);
+    HVX_Vector vb1 = xnn_loadu_f32(input_b + 32);
+    input_a += 64;
+    input_b += 64;
 
-    HVX_Vector vacc0 = Q6_Vsf_vsub_VsfVsf(va0, vb0);
-    HVX_Vector vacc1 = Q6_Vsf_vsub_VsfVsf(va1, vb1);
+    HVX_Vector vacc0 = xnn_sub_f32(va0, vb0);
+    HVX_Vector vacc1 = xnn_sub_f32(va1, vb1);
 
-    vacc0 = Q6_Vsf_vmpy_VsfVsf(vacc0, vacc0);
-    vacc1 = Q6_Vsf_vmpy_VsfVsf(vacc1, vacc1);
+    vacc0 = xnn_mul_f32(vacc0, vacc0);
+    vacc1 = xnn_mul_f32(vacc1, vacc1);
 
-    *vptr_o++ = vacc0;
-    *vptr_o++ = vacc1;
+
+    xnn_storeu_f32(output, vacc0);
+    xnn_storeu_f32(output + 32, vacc1);
+    output += 64;
   }
   for (; batch >= 32 * sizeof(float); batch -= 32 * sizeof(float)) {
-    HVX_Vector va = *vptr_a++;
-    HVX_Vector vb = *vptr_b++;
+    HVX_Vector va = xnn_loadu_f32(input_a);
+    HVX_Vector vb = xnn_loadu_f32(input_b);
+    input_a += 32;
+    input_b += 32;
 
-    HVX_Vector vacc = Q6_Vsf_vsub_VsfVsf(va, vb);
-    vacc = Q6_Vsf_vmpy_VsfVsf(vacc, vacc);
+    HVX_Vector vacc = xnn_sub_f32(va, vb);
+    vacc = xnn_mul_f32(vacc, vacc);
 
-    *vptr_o++ = vacc;
+    xnn_storeu_f32(output, vacc);
+    output += 32;
   }
   if XNN_UNLIKELY(batch != 0) {
-     HVX_Vector va = *vptr_a;
-     HVX_Vector vb = *vptr_b;
+     HVX_Vector va = xnn_loadu_f32(input_a);
+     HVX_Vector vb = xnn_loadu_f32(input_b);
 
-     HVX_Vector vacc = Q6_Vsf_vsub_VsfVsf(va, vb);
-     vacc = Q6_Vsf_vmpy_VsfVsf(vacc, vacc);
+     HVX_Vector vacc = xnn_sub_f32(va, vb);
+     vacc = xnn_mul_f32(vacc, vacc);
      
-     Q6_V_vstu_variable(vptr_o, batch, vacc);
+     Q6_V_vstu_variable(output, batch, vacc);
   }
 }

--- a/src/f32-vbinary/gen/f32-vsqrdiffc-hvx-u128.c
+++ b/src/f32-vbinary/gen/f32-vsqrdiffc-hvx-u128.c
@@ -5,12 +5,8 @@
 
 #include <assert.h>
 
-#include <hvx_hexagon_protos.h>
-#include <hexagon_protos.h>
-#include <hexagon_types.h>
+#include "xnnpack/simd/f32-hvx.h"
 
-#include "xnnpack/common.h"
-#include "xnnpack/intrinsics-polyfill.h"
 #include "xnnpack/math.h"
 #include "xnnpack/vbinary.h"
 
@@ -27,47 +23,47 @@ void xnn_f32_vsqrdiffc_ukernel__hvx_u128(
   assert(input_b != NULL);
   assert(output != NULL);
 
-  HVX_Vector vb = Q6_V_vsplat_R(*((int32_t*) input_b));
+  HVX_Vector vb = xnn_set1_f32(*input_b);
 
   for (; batch >= 128 * sizeof(float); batch -= 128 * sizeof(float)) {
-    HVX_Vector va0 = *((HVX_UVector*) input_a);
-    HVX_Vector va1 = *((HVX_UVector*)(input_a + 32));
-    HVX_Vector va2 = *((HVX_UVector*)(input_a + 64));
-    HVX_Vector va3 = *((HVX_UVector*)(input_a + 96));
+    HVX_Vector va0 = xnn_loadu_f32(input_a);
+    HVX_Vector va1 = xnn_loadu_f32(input_a + 32);
+    HVX_Vector va2 = xnn_loadu_f32(input_a + 64);
+    HVX_Vector va3 = xnn_loadu_f32(input_a + 96);
     input_a += 128;
 
-    HVX_Vector vacc0 = Q6_Vsf_vsub_VsfVsf(va0, vb);
-    HVX_Vector vacc1 = Q6_Vsf_vsub_VsfVsf(va1, vb);
-    HVX_Vector vacc2 = Q6_Vsf_vsub_VsfVsf(va2, vb);
-    HVX_Vector vacc3 = Q6_Vsf_vsub_VsfVsf(va3, vb);
+    HVX_Vector vacc0 = xnn_sub_f32(va0, vb);
+    HVX_Vector vacc1 = xnn_sub_f32(va1, vb);
+    HVX_Vector vacc2 = xnn_sub_f32(va2, vb);
+    HVX_Vector vacc3 = xnn_sub_f32(va3, vb);
 
-    vacc0 = Q6_Vsf_vmpy_VsfVsf(vacc0, vacc0);
-    vacc1 = Q6_Vsf_vmpy_VsfVsf(vacc1, vacc1);
-    vacc2 = Q6_Vsf_vmpy_VsfVsf(vacc2, vacc2);
-    vacc3 = Q6_Vsf_vmpy_VsfVsf(vacc3, vacc3);
+    vacc0 = xnn_mul_f32(vacc0, vacc0);
+    vacc1 = xnn_mul_f32(vacc1, vacc1);
+    vacc2 = xnn_mul_f32(vacc2, vacc2);
+    vacc3 = xnn_mul_f32(vacc3, vacc3);
 
 
-    *((HVX_UVector *) output) = vacc0;
-    *((HVX_UVector *)(output + 32)) = vacc1;
-    *((HVX_UVector *)(output + 64)) = vacc2;
-    *((HVX_UVector *)(output + 96)) = vacc3;
+   xnn_storeu_f32(output, vacc0);
+    xnn_storeu_f32(output + 32, vacc1);
+    xnn_storeu_f32(output + 64, vacc2);
+    xnn_storeu_f32(output + 96, vacc3);
     output += 128;
   }
   for (; batch >= 32 * sizeof(float); batch -= 32 * sizeof(float)) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
     input_a += 32;
 
-    HVX_Vector vacc = Q6_Vsf_vsub_VsfVsf(va, vb);
-    vacc = Q6_Vsf_vmpy_VsfVsf(vacc, vacc);
+    HVX_Vector vacc = xnn_sub_f32(va, vb);
+    vacc = xnn_mul_f32(vacc, vacc);
 
-    *((HVX_UVector *) output) = vacc;
+    xnn_storeu_f32(output, vacc);
     output+= 32;
   }
   if XNN_UNLIKELY(batch != 0) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
 
-    HVX_Vector vacc = Q6_Vsf_vsub_VsfVsf(va, vb);
-    vacc = Q6_Vsf_vmpy_VsfVsf(vacc, vacc);
+    HVX_Vector vacc = xnn_sub_f32(va, vb);
+    vacc = xnn_mul_f32(vacc, vacc);
 
     Q6_V_vstu_variable(output, batch, vacc);
   }

--- a/src/f32-vbinary/gen/f32-vsqrdiffc-hvx-u64.c
+++ b/src/f32-vbinary/gen/f32-vsqrdiffc-hvx-u64.c
@@ -5,12 +5,8 @@
 
 #include <assert.h>
 
-#include <hvx_hexagon_protos.h>
-#include <hexagon_protos.h>
-#include <hexagon_types.h>
+#include "xnnpack/simd/f32-hvx.h"
 
-#include "xnnpack/common.h"
-#include "xnnpack/intrinsics-polyfill.h"
 #include "xnnpack/math.h"
 #include "xnnpack/vbinary.h"
 
@@ -27,39 +23,39 @@ void xnn_f32_vsqrdiffc_ukernel__hvx_u64(
   assert(input_b != NULL);
   assert(output != NULL);
 
-  HVX_Vector vb = Q6_V_vsplat_R(*((int32_t*) input_b));
+  HVX_Vector vb = xnn_set1_f32(*input_b);
 
   for (; batch >= 64 * sizeof(float); batch -= 64 * sizeof(float)) {
-    HVX_Vector va0 = *((HVX_UVector*) input_a);
-    HVX_Vector va1 = *((HVX_UVector*)(input_a + 32));
+    HVX_Vector va0 = xnn_loadu_f32(input_a);
+    HVX_Vector va1 = xnn_loadu_f32(input_a + 32);
     input_a += 64;
 
-    HVX_Vector vacc0 = Q6_Vsf_vsub_VsfVsf(va0, vb);
-    HVX_Vector vacc1 = Q6_Vsf_vsub_VsfVsf(va1, vb);
+    HVX_Vector vacc0 = xnn_sub_f32(va0, vb);
+    HVX_Vector vacc1 = xnn_sub_f32(va1, vb);
 
-    vacc0 = Q6_Vsf_vmpy_VsfVsf(vacc0, vacc0);
-    vacc1 = Q6_Vsf_vmpy_VsfVsf(vacc1, vacc1);
+    vacc0 = xnn_mul_f32(vacc0, vacc0);
+    vacc1 = xnn_mul_f32(vacc1, vacc1);
 
 
-    *((HVX_UVector *) output) = vacc0;
-    *((HVX_UVector *)(output + 32)) = vacc1;
+   xnn_storeu_f32(output, vacc0);
+    xnn_storeu_f32(output + 32, vacc1);
     output += 64;
   }
   for (; batch >= 32 * sizeof(float); batch -= 32 * sizeof(float)) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
     input_a += 32;
 
-    HVX_Vector vacc = Q6_Vsf_vsub_VsfVsf(va, vb);
-    vacc = Q6_Vsf_vmpy_VsfVsf(vacc, vacc);
+    HVX_Vector vacc = xnn_sub_f32(va, vb);
+    vacc = xnn_mul_f32(vacc, vacc);
 
-    *((HVX_UVector *) output) = vacc;
+    xnn_storeu_f32(output, vacc);
     output+= 32;
   }
   if XNN_UNLIKELY(batch != 0) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
 
-    HVX_Vector vacc = Q6_Vsf_vsub_VsfVsf(va, vb);
-    vacc = Q6_Vsf_vmpy_VsfVsf(vacc, vacc);
+    HVX_Vector vacc = xnn_sub_f32(va, vb);
+    vacc = xnn_mul_f32(vacc, vacc);
 
     Q6_V_vstu_variable(output, batch, vacc);
   }

--- a/src/f32-vbinary/gen/f32-vsub-minmax-hvx-u128.c
+++ b/src/f32-vbinary/gen/f32-vsub-minmax-hvx-u128.c
@@ -5,12 +5,8 @@
 
 #include <assert.h>
 
-#include <hvx_hexagon_protos.h>
-#include <hexagon_protos.h>
-#include <hexagon_types.h>
+#include "xnnpack/simd/f32-hvx.h"
 
-#include "xnnpack/common.h"
-#include "xnnpack/intrinsics-polyfill.h"
 #include "xnnpack/math.h"
 #include "xnnpack/vbinary.h"
 
@@ -27,61 +23,64 @@ void xnn_f32_vsub_minmax_ukernel__hvx_u128(
   assert(input_b != NULL);
   assert(output != NULL);
 
-  const HVX_Vector voutput_min = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.min));
-  const HVX_Vector voutput_max = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.max));
-
-  const HVX_UVector *vptr_a = (const HVX_UVector *) input_a;
-  const HVX_UVector *vptr_b = (const HVX_UVector *) input_b;
-  HVX_UVector *vptr_o = (HVX_UVector*) output;
+  const HVX_Vector voutput_min = xnn_set1_f32(params->scalar.min);
+  const HVX_Vector voutput_max = xnn_set1_f32(params->scalar.max);
 
   for (; batch >= 128 * sizeof(float); batch -= 128 * sizeof(float)) {
-    HVX_Vector va0 = *vptr_a++;
-    HVX_Vector va1 = *vptr_a++;
-    HVX_Vector va2 = *vptr_a++;
-    HVX_Vector va3 = *vptr_a++;
-    HVX_Vector vb0 = *vptr_b++;
-    HVX_Vector vb1 = *vptr_b++;
-    HVX_Vector vb2 = *vptr_b++;
-    HVX_Vector vb3 = *vptr_b++;
+    HVX_Vector va0 = xnn_loadu_f32(input_a);
+    HVX_Vector va1 = xnn_loadu_f32(input_a + 32);
+    HVX_Vector va2 = xnn_loadu_f32(input_a + 64);
+    HVX_Vector va3 = xnn_loadu_f32(input_a + 96);
+    HVX_Vector vb0 = xnn_loadu_f32(input_b);
+    HVX_Vector vb1 = xnn_loadu_f32(input_b + 32);
+    HVX_Vector vb2 = xnn_loadu_f32(input_b + 64);
+    HVX_Vector vb3 = xnn_loadu_f32(input_b + 96);
+    input_a += 128;
+    input_b += 128;
 
-    HVX_Vector vacc0 = Q6_Vsf_vsub_VsfVsf(va0, vb0);
-    HVX_Vector vacc1 = Q6_Vsf_vsub_VsfVsf(va1, vb1);
-    HVX_Vector vacc2 = Q6_Vsf_vsub_VsfVsf(va2, vb2);
-    HVX_Vector vacc3 = Q6_Vsf_vsub_VsfVsf(va3, vb3);
+    HVX_Vector vacc0 = xnn_sub_f32(va0, vb0);
+    HVX_Vector vacc1 = xnn_sub_f32(va1, vb1);
+    HVX_Vector vacc2 = xnn_sub_f32(va2, vb2);
+    HVX_Vector vacc3 = xnn_sub_f32(va3, vb3);
 
-    vacc0 = Q6_Vsf_vmax_VsfVsf(vacc0, voutput_min);
-    vacc1 = Q6_Vsf_vmax_VsfVsf(vacc1, voutput_min);
-    vacc2 = Q6_Vsf_vmax_VsfVsf(vacc2, voutput_min);
-    vacc3 = Q6_Vsf_vmax_VsfVsf(vacc3, voutput_min);
 
-    vacc0 = Q6_Vsf_vmin_VsfVsf(vacc0, voutput_max);
-    vacc1 = Q6_Vsf_vmin_VsfVsf(vacc1, voutput_max);
-    vacc2 = Q6_Vsf_vmin_VsfVsf(vacc2, voutput_max);
-    vacc3 = Q6_Vsf_vmin_VsfVsf(vacc3, voutput_max);
+    vacc0 = xnn_max_f32(vacc0, voutput_min);
+    vacc1 = xnn_max_f32(vacc1, voutput_min);
+    vacc2 = xnn_max_f32(vacc2, voutput_min);
+    vacc3 = xnn_max_f32(vacc3, voutput_min);
 
-    *vptr_o++ = vacc0;
-    *vptr_o++ = vacc1;
-    *vptr_o++ = vacc2;
-    *vptr_o++ = vacc3;
+    vacc0 = xnn_min_f32(vacc0, voutput_max);
+    vacc1 = xnn_min_f32(vacc1, voutput_max);
+    vacc2 = xnn_min_f32(vacc2, voutput_max);
+    vacc3 = xnn_min_f32(vacc3, voutput_max);
+
+    xnn_storeu_f32(output, vacc0);
+    xnn_storeu_f32(output + 32, vacc1);
+    xnn_storeu_f32(output + 64, vacc2);
+    xnn_storeu_f32(output + 96, vacc3);
+    output += 128;
   }
   for (; batch >= 32 * sizeof(float); batch -= 32 * sizeof(float)) {
-    HVX_Vector va = *vptr_a++;
-    HVX_Vector vb = *vptr_b++;
+    HVX_Vector va = xnn_loadu_f32(input_a);
+    HVX_Vector vb = xnn_loadu_f32(input_b);
+    input_a += 32;
+    input_b += 32;
 
-    HVX_Vector vacc = Q6_Vsf_vsub_VsfVsf(va, vb);
-    vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-    vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+    HVX_Vector vacc = xnn_sub_f32(va, vb);
+    vacc = xnn_max_f32(vacc, voutput_min);
+    vacc = xnn_min_f32(vacc, voutput_max);
 
-    *vptr_o++ = vacc;
+    xnn_storeu_f32(output, vacc);
+    output += 32;
   }
   if XNN_UNLIKELY(batch != 0) {
-     HVX_Vector va = *vptr_a;
-     HVX_Vector vb = *vptr_b;
+     HVX_Vector va = xnn_loadu_f32(input_a);
+     HVX_Vector vb = xnn_loadu_f32(input_b);
 
-     HVX_Vector vacc = Q6_Vsf_vsub_VsfVsf(va, vb);
-     vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-     vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+     HVX_Vector vacc = xnn_sub_f32(va, vb);
+     vacc = xnn_max_f32(vacc, voutput_min);
+     vacc = xnn_min_f32(vacc, voutput_max);
      
-     Q6_V_vstu_variable(vptr_o, batch, vacc);
+     Q6_V_vstu_variable(output, batch, vacc);
   }
 }

--- a/src/f32-vbinary/gen/f32-vsub-minmax-hvx-u32.c
+++ b/src/f32-vbinary/gen/f32-vsub-minmax-hvx-u32.c
@@ -5,12 +5,8 @@
 
 #include <assert.h>
 
-#include <hvx_hexagon_protos.h>
-#include <hexagon_protos.h>
-#include <hexagon_types.h>
+#include "xnnpack/simd/f32-hvx.h"
 
-#include "xnnpack/common.h"
-#include "xnnpack/intrinsics-polyfill.h"
 #include "xnnpack/math.h"
 #include "xnnpack/vbinary.h"
 
@@ -27,31 +23,30 @@ void xnn_f32_vsub_minmax_ukernel__hvx_u32(
   assert(input_b != NULL);
   assert(output != NULL);
 
-  const HVX_Vector voutput_min = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.min));
-  const HVX_Vector voutput_max = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.max));
-
-  const HVX_UVector *vptr_a = (const HVX_UVector *) input_a;
-  const HVX_UVector *vptr_b = (const HVX_UVector *) input_b;
-  HVX_UVector *vptr_o = (HVX_UVector*) output;
+  const HVX_Vector voutput_min = xnn_set1_f32(params->scalar.min);
+  const HVX_Vector voutput_max = xnn_set1_f32(params->scalar.max);
 
   for (; batch >= 32 * sizeof(float); batch -= 32 * sizeof(float)) {
-    HVX_Vector va = *vptr_a++;
-    HVX_Vector vb = *vptr_b++;
+    HVX_Vector va = xnn_loadu_f32(input_a);
+    HVX_Vector vb = xnn_loadu_f32(input_b);
+    input_a += 32;
+    input_b += 32;
 
-    HVX_Vector vacc = Q6_Vsf_vsub_VsfVsf(va, vb);
-    vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-    vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+    HVX_Vector vacc = xnn_sub_f32(va, vb);
+    vacc = xnn_max_f32(vacc, voutput_min);
+    vacc = xnn_min_f32(vacc, voutput_max);
 
-    *vptr_o++ = vacc;
+    xnn_storeu_f32(output, vacc);
+    output += 32;
   }
   if XNN_UNLIKELY(batch != 0) {
-     HVX_Vector va = *vptr_a;
-     HVX_Vector vb = *vptr_b;
+     HVX_Vector va = xnn_loadu_f32(input_a);
+     HVX_Vector vb = xnn_loadu_f32(input_b);
 
-     HVX_Vector vacc = Q6_Vsf_vsub_VsfVsf(va, vb);
-     vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-     vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+     HVX_Vector vacc = xnn_sub_f32(va, vb);
+     vacc = xnn_max_f32(vacc, voutput_min);
+     vacc = xnn_min_f32(vacc, voutput_max);
      
-     Q6_V_vstu_variable(vptr_o, batch, vacc);
+     Q6_V_vstu_variable(output, batch, vacc);
   }
 }

--- a/src/f32-vbinary/gen/f32-vsub-minmax-hvx-u64.c
+++ b/src/f32-vbinary/gen/f32-vsub-minmax-hvx-u64.c
@@ -5,12 +5,8 @@
 
 #include <assert.h>
 
-#include <hvx_hexagon_protos.h>
-#include <hexagon_protos.h>
-#include <hexagon_types.h>
+#include "xnnpack/simd/f32-hvx.h"
 
-#include "xnnpack/common.h"
-#include "xnnpack/intrinsics-polyfill.h"
 #include "xnnpack/math.h"
 #include "xnnpack/vbinary.h"
 
@@ -27,49 +23,52 @@ void xnn_f32_vsub_minmax_ukernel__hvx_u64(
   assert(input_b != NULL);
   assert(output != NULL);
 
-  const HVX_Vector voutput_min = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.min));
-  const HVX_Vector voutput_max = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.max));
-
-  const HVX_UVector *vptr_a = (const HVX_UVector *) input_a;
-  const HVX_UVector *vptr_b = (const HVX_UVector *) input_b;
-  HVX_UVector *vptr_o = (HVX_UVector*) output;
+  const HVX_Vector voutput_min = xnn_set1_f32(params->scalar.min);
+  const HVX_Vector voutput_max = xnn_set1_f32(params->scalar.max);
 
   for (; batch >= 64 * sizeof(float); batch -= 64 * sizeof(float)) {
-    HVX_Vector va0 = *vptr_a++;
-    HVX_Vector va1 = *vptr_a++;
-    HVX_Vector vb0 = *vptr_b++;
-    HVX_Vector vb1 = *vptr_b++;
+    HVX_Vector va0 = xnn_loadu_f32(input_a);
+    HVX_Vector va1 = xnn_loadu_f32(input_a + 32);
+    HVX_Vector vb0 = xnn_loadu_f32(input_b);
+    HVX_Vector vb1 = xnn_loadu_f32(input_b + 32);
+    input_a += 64;
+    input_b += 64;
 
-    HVX_Vector vacc0 = Q6_Vsf_vsub_VsfVsf(va0, vb0);
-    HVX_Vector vacc1 = Q6_Vsf_vsub_VsfVsf(va1, vb1);
+    HVX_Vector vacc0 = xnn_sub_f32(va0, vb0);
+    HVX_Vector vacc1 = xnn_sub_f32(va1, vb1);
 
-    vacc0 = Q6_Vsf_vmax_VsfVsf(vacc0, voutput_min);
-    vacc1 = Q6_Vsf_vmax_VsfVsf(vacc1, voutput_min);
 
-    vacc0 = Q6_Vsf_vmin_VsfVsf(vacc0, voutput_max);
-    vacc1 = Q6_Vsf_vmin_VsfVsf(vacc1, voutput_max);
+    vacc0 = xnn_max_f32(vacc0, voutput_min);
+    vacc1 = xnn_max_f32(vacc1, voutput_min);
 
-    *vptr_o++ = vacc0;
-    *vptr_o++ = vacc1;
+    vacc0 = xnn_min_f32(vacc0, voutput_max);
+    vacc1 = xnn_min_f32(vacc1, voutput_max);
+
+    xnn_storeu_f32(output, vacc0);
+    xnn_storeu_f32(output + 32, vacc1);
+    output += 64;
   }
   for (; batch >= 32 * sizeof(float); batch -= 32 * sizeof(float)) {
-    HVX_Vector va = *vptr_a++;
-    HVX_Vector vb = *vptr_b++;
+    HVX_Vector va = xnn_loadu_f32(input_a);
+    HVX_Vector vb = xnn_loadu_f32(input_b);
+    input_a += 32;
+    input_b += 32;
 
-    HVX_Vector vacc = Q6_Vsf_vsub_VsfVsf(va, vb);
-    vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-    vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+    HVX_Vector vacc = xnn_sub_f32(va, vb);
+    vacc = xnn_max_f32(vacc, voutput_min);
+    vacc = xnn_min_f32(vacc, voutput_max);
 
-    *vptr_o++ = vacc;
+    xnn_storeu_f32(output, vacc);
+    output += 32;
   }
   if XNN_UNLIKELY(batch != 0) {
-     HVX_Vector va = *vptr_a;
-     HVX_Vector vb = *vptr_b;
+     HVX_Vector va = xnn_loadu_f32(input_a);
+     HVX_Vector vb = xnn_loadu_f32(input_b);
 
-     HVX_Vector vacc = Q6_Vsf_vsub_VsfVsf(va, vb);
-     vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-     vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+     HVX_Vector vacc = xnn_sub_f32(va, vb);
+     vacc = xnn_max_f32(vacc, voutput_min);
+     vacc = xnn_min_f32(vacc, voutput_max);
      
-     Q6_V_vstu_variable(vptr_o, batch, vacc);
+     Q6_V_vstu_variable(output, batch, vacc);
   }
 }

--- a/src/f32-vbinary/gen/f32-vsubc-minmax-hvx-u128.c
+++ b/src/f32-vbinary/gen/f32-vsubc-minmax-hvx-u128.c
@@ -5,12 +5,8 @@
 
 #include <assert.h>
 
-#include <hvx_hexagon_protos.h>
-#include <hexagon_protos.h>
-#include <hexagon_types.h>
+#include "xnnpack/simd/f32-hvx.h"
 
-#include "xnnpack/common.h"
-#include "xnnpack/intrinsics-polyfill.h"
 #include "xnnpack/math.h"
 #include "xnnpack/vbinary.h"
 
@@ -27,56 +23,56 @@ void xnn_f32_vsubc_minmax_ukernel__hvx_u128(
   assert(input_b != NULL);
   assert(output != NULL);
 
-  const HVX_Vector voutput_min = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.min));
-  const HVX_Vector voutput_max = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.max));
-  HVX_Vector vb = Q6_V_vsplat_R(*((int32_t*) input_b));
+  const HVX_Vector voutput_min = xnn_set1_f32(params->scalar.min);
+  const HVX_Vector voutput_max = xnn_set1_f32(params->scalar.max);
+  HVX_Vector vb = xnn_set1_f32(*input_b);
 
   for (; batch >= 128 * sizeof(float); batch -= 128 * sizeof(float)) {
-    HVX_Vector va0 = *((HVX_UVector*) input_a);
-    HVX_Vector va1 = *((HVX_UVector*)(input_a + 32));
-    HVX_Vector va2 = *((HVX_UVector*)(input_a + 64));
-    HVX_Vector va3 = *((HVX_UVector*)(input_a + 96));
+    HVX_Vector va0 = xnn_loadu_f32(input_a);
+    HVX_Vector va1 = xnn_loadu_f32(input_a + 32);
+    HVX_Vector va2 = xnn_loadu_f32(input_a + 64);
+    HVX_Vector va3 = xnn_loadu_f32(input_a + 96);
     input_a += 128;
 
-    HVX_Vector vacc0 = Q6_Vsf_vsub_VsfVsf(va0, vb);
-    HVX_Vector vacc1 = Q6_Vsf_vsub_VsfVsf(va1, vb);
-    HVX_Vector vacc2 = Q6_Vsf_vsub_VsfVsf(va2, vb);
-    HVX_Vector vacc3 = Q6_Vsf_vsub_VsfVsf(va3, vb);
+    HVX_Vector vacc0 = xnn_sub_f32(va0, vb);
+    HVX_Vector vacc1 = xnn_sub_f32(va1, vb);
+    HVX_Vector vacc2 = xnn_sub_f32(va2, vb);
+    HVX_Vector vacc3 = xnn_sub_f32(va3, vb);
 
 
-    vacc0 = Q6_Vsf_vmax_VsfVsf(vacc0, voutput_min);
-    vacc1 = Q6_Vsf_vmax_VsfVsf(vacc1, voutput_min);
-    vacc2 = Q6_Vsf_vmax_VsfVsf(vacc2, voutput_min);
-    vacc3 = Q6_Vsf_vmax_VsfVsf(vacc3, voutput_min);
+    vacc0 = xnn_max_f32(vacc0, voutput_min);
+    vacc1 = xnn_max_f32(vacc1, voutput_min);
+    vacc2 = xnn_max_f32(vacc2, voutput_min);
+    vacc3 = xnn_max_f32(vacc3, voutput_min);
 
-    vacc0 = Q6_Vsf_vmin_VsfVsf(vacc0, voutput_max);
-    vacc1 = Q6_Vsf_vmin_VsfVsf(vacc1, voutput_max);
-    vacc2 = Q6_Vsf_vmin_VsfVsf(vacc2, voutput_max);
-    vacc3 = Q6_Vsf_vmin_VsfVsf(vacc3, voutput_max);
+    vacc0 = xnn_min_f32(vacc0, voutput_max);
+    vacc1 = xnn_min_f32(vacc1, voutput_max);
+    vacc2 = xnn_min_f32(vacc2, voutput_max);
+    vacc3 = xnn_min_f32(vacc3, voutput_max);
 
-    *((HVX_UVector *) output) = vacc0;
-    *((HVX_UVector *)(output + 32)) = vacc1;
-    *((HVX_UVector *)(output + 64)) = vacc2;
-    *((HVX_UVector *)(output + 96)) = vacc3;
+   xnn_storeu_f32(output, vacc0);
+    xnn_storeu_f32(output + 32, vacc1);
+    xnn_storeu_f32(output + 64, vacc2);
+    xnn_storeu_f32(output + 96, vacc3);
     output += 128;
   }
   for (; batch >= 32 * sizeof(float); batch -= 32 * sizeof(float)) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
     input_a += 32;
 
-    HVX_Vector vacc = Q6_Vsf_vsub_VsfVsf(va, vb);
-    vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-    vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+    HVX_Vector vacc = xnn_sub_f32(va, vb);
+    vacc = xnn_max_f32(vacc, voutput_min);
+    vacc = xnn_min_f32(vacc, voutput_max);
 
-    *((HVX_UVector *) output) = vacc;
+    xnn_storeu_f32(output, vacc);
     output+= 32;
   }
   if XNN_UNLIKELY(batch != 0) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
 
-    HVX_Vector vacc = Q6_Vsf_vsub_VsfVsf(va, vb);
-    vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-    vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+    HVX_Vector vacc = xnn_sub_f32(va, vb);
+    vacc = xnn_max_f32(vacc, voutput_min);
+    vacc = xnn_min_f32(vacc, voutput_max);
 
     Q6_V_vstu_variable(output, batch, vacc);
   }

--- a/src/f32-vbinary/gen/f32-vsubc-minmax-hvx-u32.c
+++ b/src/f32-vbinary/gen/f32-vsubc-minmax-hvx-u32.c
@@ -5,12 +5,8 @@
 
 #include <assert.h>
 
-#include <hvx_hexagon_protos.h>
-#include <hexagon_protos.h>
-#include <hexagon_types.h>
+#include "xnnpack/simd/f32-hvx.h"
 
-#include "xnnpack/common.h"
-#include "xnnpack/intrinsics-polyfill.h"
 #include "xnnpack/math.h"
 #include "xnnpack/vbinary.h"
 
@@ -27,27 +23,27 @@ void xnn_f32_vsubc_minmax_ukernel__hvx_u32(
   assert(input_b != NULL);
   assert(output != NULL);
 
-  const HVX_Vector voutput_min = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.min));
-  const HVX_Vector voutput_max = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.max));
-  HVX_Vector vb = Q6_V_vsplat_R(*((int32_t*) input_b));
+  const HVX_Vector voutput_min = xnn_set1_f32(params->scalar.min);
+  const HVX_Vector voutput_max = xnn_set1_f32(params->scalar.max);
+  HVX_Vector vb = xnn_set1_f32(*input_b);
 
   for (; batch >= 32 * sizeof(float); batch -= 32 * sizeof(float)) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
     input_a += 32;
 
-    HVX_Vector vacc = Q6_Vsf_vsub_VsfVsf(va, vb);
-    vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-    vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+    HVX_Vector vacc = xnn_sub_f32(va, vb);
+    vacc = xnn_max_f32(vacc, voutput_min);
+    vacc = xnn_min_f32(vacc, voutput_max);
 
-    *((HVX_UVector *) output) = vacc;
+    xnn_storeu_f32(output, vacc);
     output+= 32;
   }
   if XNN_UNLIKELY(batch != 0) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
 
-    HVX_Vector vacc = Q6_Vsf_vsub_VsfVsf(va, vb);
-    vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-    vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+    HVX_Vector vacc = xnn_sub_f32(va, vb);
+    vacc = xnn_max_f32(vacc, voutput_min);
+    vacc = xnn_min_f32(vacc, voutput_max);
 
     Q6_V_vstu_variable(output, batch, vacc);
   }

--- a/src/f32-vbinary/gen/f32-vsubc-minmax-hvx-u64.c
+++ b/src/f32-vbinary/gen/f32-vsubc-minmax-hvx-u64.c
@@ -5,12 +5,8 @@
 
 #include <assert.h>
 
-#include <hvx_hexagon_protos.h>
-#include <hexagon_protos.h>
-#include <hexagon_types.h>
+#include "xnnpack/simd/f32-hvx.h"
 
-#include "xnnpack/common.h"
-#include "xnnpack/intrinsics-polyfill.h"
 #include "xnnpack/math.h"
 #include "xnnpack/vbinary.h"
 
@@ -27,46 +23,46 @@ void xnn_f32_vsubc_minmax_ukernel__hvx_u64(
   assert(input_b != NULL);
   assert(output != NULL);
 
-  const HVX_Vector voutput_min = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.min));
-  const HVX_Vector voutput_max = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.max));
-  HVX_Vector vb = Q6_V_vsplat_R(*((int32_t*) input_b));
+  const HVX_Vector voutput_min = xnn_set1_f32(params->scalar.min);
+  const HVX_Vector voutput_max = xnn_set1_f32(params->scalar.max);
+  HVX_Vector vb = xnn_set1_f32(*input_b);
 
   for (; batch >= 64 * sizeof(float); batch -= 64 * sizeof(float)) {
-    HVX_Vector va0 = *((HVX_UVector*) input_a);
-    HVX_Vector va1 = *((HVX_UVector*)(input_a + 32));
+    HVX_Vector va0 = xnn_loadu_f32(input_a);
+    HVX_Vector va1 = xnn_loadu_f32(input_a + 32);
     input_a += 64;
 
-    HVX_Vector vacc0 = Q6_Vsf_vsub_VsfVsf(va0, vb);
-    HVX_Vector vacc1 = Q6_Vsf_vsub_VsfVsf(va1, vb);
+    HVX_Vector vacc0 = xnn_sub_f32(va0, vb);
+    HVX_Vector vacc1 = xnn_sub_f32(va1, vb);
 
 
-    vacc0 = Q6_Vsf_vmax_VsfVsf(vacc0, voutput_min);
-    vacc1 = Q6_Vsf_vmax_VsfVsf(vacc1, voutput_min);
+    vacc0 = xnn_max_f32(vacc0, voutput_min);
+    vacc1 = xnn_max_f32(vacc1, voutput_min);
 
-    vacc0 = Q6_Vsf_vmin_VsfVsf(vacc0, voutput_max);
-    vacc1 = Q6_Vsf_vmin_VsfVsf(vacc1, voutput_max);
+    vacc0 = xnn_min_f32(vacc0, voutput_max);
+    vacc1 = xnn_min_f32(vacc1, voutput_max);
 
-    *((HVX_UVector *) output) = vacc0;
-    *((HVX_UVector *)(output + 32)) = vacc1;
+   xnn_storeu_f32(output, vacc0);
+    xnn_storeu_f32(output + 32, vacc1);
     output += 64;
   }
   for (; batch >= 32 * sizeof(float); batch -= 32 * sizeof(float)) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
     input_a += 32;
 
-    HVX_Vector vacc = Q6_Vsf_vsub_VsfVsf(va, vb);
-    vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-    vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+    HVX_Vector vacc = xnn_sub_f32(va, vb);
+    vacc = xnn_max_f32(vacc, voutput_min);
+    vacc = xnn_min_f32(vacc, voutput_max);
 
-    *((HVX_UVector *) output) = vacc;
+    xnn_storeu_f32(output, vacc);
     output+= 32;
   }
   if XNN_UNLIKELY(batch != 0) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
 
-    HVX_Vector vacc = Q6_Vsf_vsub_VsfVsf(va, vb);
-    vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-    vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+    HVX_Vector vacc = xnn_sub_f32(va, vb);
+    vacc = xnn_max_f32(vacc, voutput_min);
+    vacc = xnn_min_f32(vacc, voutput_max);
 
     Q6_V_vstu_variable(output, batch, vacc);
   }

--- a/src/f32-vbinary/vop-hvx.c.in
+++ b/src/f32-vbinary/vop-hvx.c.in
@@ -6,22 +6,18 @@ $assert OP in ["ADD", "MAX", "MIN", "MUL", "SUB", "SQRDIFF"]
 $assert ACTIVATION in ["LINEAR", "MINMAX"]
 #include <assert.h>
 
-#include <hvx_hexagon_protos.h>
-#include <hexagon_protos.h>
-#include <hexagon_types.h>
+#include "xnnpack/simd/f32-hvx.h"
 
-#include "xnnpack/common.h"
-#include "xnnpack/intrinsics-polyfill.h"
 #include "xnnpack/math.h"
 #include "xnnpack/vbinary.h"
 
 $_HEXAGON_OP_HVX = {
-$  "ADD": "Q6_Vsf_vadd_VsfVsf",
-$  "MAX": "Q6_Vsf_vmax_VsfVsf",
-$  "MIN": "Q6_Vsf_vmin_VsfVsf", 
-$  "MUL": "Q6_Vsf_vmpy_VsfVsf", 
-$  "SUB": "Q6_Vsf_vsub_VsfVsf",
-$  "SQRDIFF": "Q6_Vsf_vsub_VsfVsf",
+$  "ADD": "xnn_add_f32",
+$  "MAX": "xnn_max_f32",
+$  "MIN": "xnn_min_f32", 
+$  "MUL": "xnn_mul_f32", 
+$  "SUB": "xnn_sub_f32",
+$  "SQRDIFF": "xnn_sub_f32",
 $}[OP]
 $SUFFIX = {"LINEAR": "", "MINMAX": "_minmax"}[ACTIVATION]
 $PARAMS = {"LINEAR": "xnn_f32_default_params", "MINMAX": "xnn_f32_minmax_params"}[ACTIVATION]
@@ -39,60 +35,66 @@ void xnn_f32_v${OP.lower()}${SUFFIX}_ukernel__hvx_u${BATCH_TILE}(
   assert(output != NULL);
 
   $if ACTIVATION == "MINMAX":
-    const HVX_Vector voutput_min = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.min));
-    const HVX_Vector voutput_max = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.max));
-
-  const HVX_UVector *vptr_a = (const HVX_UVector *) input_a;
-  const HVX_UVector *vptr_b = (const HVX_UVector *) input_b;
-  HVX_UVector *vptr_o = (HVX_UVector*) output;
+    const HVX_Vector voutput_min = xnn_set1_f32(params->scalar.min);
+    const HVX_Vector voutput_max = xnn_set1_f32(params->scalar.max);
 
   $if BATCH_TILE > 32:
     for (; batch >= ${BATCH_TILE} * sizeof(float); batch -= ${BATCH_TILE} * sizeof(float)) {
-      $for N in range(SIMD_TILE):
-        HVX_Vector va${N} = *vptr_a++;
-      $for N in range(SIMD_TILE):
-        HVX_Vector vb${N} = *vptr_b++;
+      HVX_Vector va0 = xnn_loadu_f32(input_a);
+      $for N in range(32, BATCH_TILE, 32):
+        HVX_Vector va${int(N/32)} = xnn_loadu_f32(input_a + ${N});
+      HVX_Vector vb0 = xnn_loadu_f32(input_b);
+      $for N in range(32, BATCH_TILE, 32):
+        HVX_Vector vb${int(N/32)} = xnn_loadu_f32(input_b + ${N});
+      input_a += ${BATCH_TILE};
+      input_b += ${BATCH_TILE};
 
       $for N in range(SIMD_TILE):
         HVX_Vector vacc${N} = ${_HEXAGON_OP_HVX}(va${N}, vb${N});
 
       $if OP == "SQRDIFF":
         $for N in range(SIMD_TILE):
-          vacc${N} = Q6_Vsf_vmpy_VsfVsf(vacc${N}, vacc${N});
+          vacc${N} = xnn_mul_f32(vacc${N}, vacc${N});
+
       $if ACTIVATION == "MINMAX":
         $for N in range(SIMD_TILE):
-          vacc${N} = Q6_Vsf_vmax_VsfVsf(vacc${N}, voutput_min);
+          vacc${N} = xnn_max_f32(vacc${N}, voutput_min);
 
         $for N in range(SIMD_TILE):
-          vacc${N} = Q6_Vsf_vmin_VsfVsf(vacc${N}, voutput_max);
+          vacc${N} = xnn_min_f32(vacc${N}, voutput_max);
 
-      $for N in range(SIMD_TILE):
-        *vptr_o++ = vacc${N};
+      xnn_storeu_f32(output, vacc0);
+      $for N in range(32, BATCH_TILE, 32):
+        xnn_storeu_f32(output + ${N}, vacc${int(N/32)});
+      output += ${BATCH_TILE};
     }
   for (; batch >= 32 * sizeof(float); batch -= 32 * sizeof(float)) {
-    HVX_Vector va = *vptr_a++;
-    HVX_Vector vb = *vptr_b++;
+    HVX_Vector va = xnn_loadu_f32(input_a);
+    HVX_Vector vb = xnn_loadu_f32(input_b);
+    input_a += 32;
+    input_b += 32;
 
     HVX_Vector vacc = ${_HEXAGON_OP_HVX}(va, vb);
     $if OP == "SQRDIFF":
-      vacc = Q6_Vsf_vmpy_VsfVsf(vacc, vacc);
+      vacc = xnn_mul_f32(vacc, vacc);
     $if ACTIVATION == "MINMAX":
-      vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-      vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+      vacc = xnn_max_f32(vacc, voutput_min);
+      vacc = xnn_min_f32(vacc, voutput_max);
 
-    *vptr_o++ = vacc;
+    xnn_storeu_f32(output, vacc);
+    output += 32;
   }
   if XNN_UNLIKELY(batch != 0) {
-     HVX_Vector va = *vptr_a;
-     HVX_Vector vb = *vptr_b;
+     HVX_Vector va = xnn_loadu_f32(input_a);
+     HVX_Vector vb = xnn_loadu_f32(input_b);
 
      HVX_Vector vacc = ${_HEXAGON_OP_HVX}(va, vb);
      $if OP == "SQRDIFF":
-       vacc = Q6_Vsf_vmpy_VsfVsf(vacc, vacc);
+       vacc = xnn_mul_f32(vacc, vacc);
      $if ACTIVATION == "MINMAX":
-       vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-       vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+       vacc = xnn_max_f32(vacc, voutput_min);
+       vacc = xnn_min_f32(vacc, voutput_max);
      
-     Q6_V_vstu_variable(vptr_o, batch, vacc);
+     Q6_V_vstu_variable(output, batch, vacc);
   }
 }

--- a/src/f32-vbinary/vopc-hvx.c.in
+++ b/src/f32-vbinary/vopc-hvx.c.in
@@ -6,23 +6,19 @@ $assert OP in ["ADD", "MAX", "MIN", "MUL", "SUB", "RSUB", "SQRDIFF"]
 $assert ACTIVATION in ["LINEAR", "MINMAX"]
 #include <assert.h>
 
-#include <hvx_hexagon_protos.h>
-#include <hexagon_protos.h>
-#include <hexagon_types.h>
+#include "xnnpack/simd/f32-hvx.h"
 
-#include "xnnpack/common.h"
-#include "xnnpack/intrinsics-polyfill.h"
 #include "xnnpack/math.h"
 #include "xnnpack/vbinary.h"
 
 $_HEXAGON_OP_HVX = {
-$  "ADD": lambda x: "Q6_Vsf_vadd_VsfVsf(%s, vb)" % x,
-$  "MAX": lambda x: "Q6_Vsf_vmax_VsfVsf(%s, vb)" % x,
-$  "MIN": lambda x: "Q6_Vsf_vmin_VsfVsf(%s, vb)" % x,
-$  "MUL": lambda x: "Q6_Vsf_vmpy_VsfVsf(%s, vb)" % x,
-$  "SUB": lambda x: "Q6_Vsf_vsub_VsfVsf(%s, vb)" % x,
-$  "RSUB": lambda x: "Q6_Vsf_vsub_VsfVsf(vb, %s)" % x,
-$  "SQRDIFF": lambda x: "Q6_Vsf_vsub_VsfVsf(%s, vb)" % x,
+$  "ADD": lambda x: "xnn_add_f32(%s, vb)" % x,
+$  "MAX": lambda x: "xnn_max_f32(%s, vb)" % x,
+$  "MIN": lambda x: "xnn_min_f32(%s, vb)" % x,
+$  "MUL": lambda x: "xnn_mul_f32(%s, vb)" % x,
+$  "SUB": lambda x: "xnn_sub_f32(%s, vb)" % x,
+$  "RSUB": lambda x: "xnn_sub_f32(vb, %s)" % x,
+$  "SQRDIFF": lambda x: "xnn_sub_f32(%s, vb)" % x,
 $}[OP]
 $SUFFIX = {"LINEAR": "", "MINMAX": "_minmax"}[ACTIVATION]
 $PARAMS = {"LINEAR": "xnn_f32_default_params", "MINMAX": "xnn_f32_minmax_params"}[ACTIVATION]
@@ -40,15 +36,15 @@ void xnn_f32_v${OP.lower()}c${SUFFIX}_ukernel__hvx_u${BATCH_TILE}(
   assert(output != NULL);
 
   $if ACTIVATION == "MINMAX":
-    const HVX_Vector voutput_min = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.min));
-    const HVX_Vector voutput_max = Q6_V_vsplat_R(*((uint32_t *) &params->scalar.max));
-  HVX_Vector vb = Q6_V_vsplat_R(*((int32_t*) input_b));
+    const HVX_Vector voutput_min = xnn_set1_f32(params->scalar.min);
+    const HVX_Vector voutput_max = xnn_set1_f32(params->scalar.max);
+  HVX_Vector vb = xnn_set1_f32(*input_b);
 
   $if BATCH_TILE > 32:
     for (; batch >= ${BATCH_TILE} * sizeof(float); batch -= ${BATCH_TILE} * sizeof(float)) {
-      HVX_Vector va0 = *((HVX_UVector*) input_a);
+      HVX_Vector va0 = xnn_loadu_f32(input_a);
       $for N in range(32, BATCH_TILE, 32):
-        HVX_Vector va${int(N/32)} = *((HVX_UVector*)(input_a + ${N}));
+        HVX_Vector va${int(N/32)} = xnn_loadu_f32(input_a + ${N});
       input_a += ${BATCH_TILE};
 
       $for N in range(SIMD_TILE):
@@ -56,43 +52,43 @@ void xnn_f32_v${OP.lower()}c${SUFFIX}_ukernel__hvx_u${BATCH_TILE}(
 
       $if OP == "SQRDIFF":
         $for N in range(SIMD_TILE):
-          vacc${N} = Q6_Vsf_vmpy_VsfVsf(vacc${N}, vacc${N});
+          vacc${N} = xnn_mul_f32(vacc${N}, vacc${N});
 
       $if ACTIVATION == "MINMAX":
         $for N in range(SIMD_TILE):
-          vacc${N} = Q6_Vsf_vmax_VsfVsf(vacc${N}, voutput_min);
+          vacc${N} = xnn_max_f32(vacc${N}, voutput_min);
 
         $for N in range(SIMD_TILE):
-          vacc${N} = Q6_Vsf_vmin_VsfVsf(vacc${N}, voutput_max);
+          vacc${N} = xnn_min_f32(vacc${N}, voutput_max);
 
-      *((HVX_UVector *) output) = vacc0;
+     xnn_storeu_f32(output, vacc0);
       $for N in range(32, BATCH_TILE, 32):
-        *((HVX_UVector *)(output + ${N})) = vacc${int(N/32)};
+        xnn_storeu_f32(output + ${N}, vacc${int(N/32)});
       output += ${BATCH_TILE};
     }
   for (; batch >= 32 * sizeof(float); batch -= 32 * sizeof(float)) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
     input_a += 32;
 
     HVX_Vector vacc = ${_HEXAGON_OP_HVX("va")};
     $if OP == "SQRDIFF":
-      vacc = Q6_Vsf_vmpy_VsfVsf(vacc, vacc);
+      vacc = xnn_mul_f32(vacc, vacc);
     $if ACTIVATION == "MINMAX":
-      vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-      vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+      vacc = xnn_max_f32(vacc, voutput_min);
+      vacc = xnn_min_f32(vacc, voutput_max);
 
-    *((HVX_UVector *) output) = vacc;
+    xnn_storeu_f32(output, vacc);
     output+= 32;
   }
   if XNN_UNLIKELY(batch != 0) {
-    HVX_Vector va = *((HVX_UVector*) input_a);
+    HVX_Vector va = xnn_loadu_f32(input_a);
 
     HVX_Vector vacc = ${_HEXAGON_OP_HVX("va")};
     $if OP == "SQRDIFF":
-      vacc = Q6_Vsf_vmpy_VsfVsf(vacc, vacc);
+      vacc = xnn_mul_f32(vacc, vacc);
     $if ACTIVATION == "MINMAX":
-      vacc = Q6_Vsf_vmax_VsfVsf(vacc, voutput_min);
-      vacc = Q6_Vsf_vmin_VsfVsf(vacc, voutput_max);
+      vacc = xnn_max_f32(vacc, voutput_min);
+      vacc = xnn_min_f32(vacc, voutput_max);
 
     Q6_V_vstu_variable(output, batch, vacc);
   }


### PR DESCRIPTION
- Utilize simd/f32-hvx.h instead of using intrinsic directly.
- Remove unnecessary pointers.