### PR TITLE
Replace qb4w block_size division with loop add

### DIFF
--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x16-minmax-neonfp16arith-mlal-lane-prfm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x16-minmax-neonfp16arith-mlal-lane-prfm.c
@@ -59,8 +59,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x16__neonfp16arith_mlal_lane_prfm(
     float32x4_t vout0x89AB = vmulq_f32(vksum89AB, vzp0);
     float32x4_t vout0xCDEF = vmulq_f32(vksumCDEF, vzp0);
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);
       int32x4_t vacc0x89AB = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x16-minmax-neonfp16arith-mlal-lane.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x16-minmax-neonfp16arith-mlal-lane.c
@@ -58,8 +58,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x16__neonfp16arith_mlal_lane(
     float32x4_t vout0x89AB = vmulq_f32(vksum89AB, vzp0);
     float32x4_t vout0xCDEF = vmulq_f32(vksumCDEF, vzp0);
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);
       int32x4_t vacc0x89AB = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x16c4-minmax-neondotfp16arith.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x16c4-minmax-neondotfp16arith.c
@@ -45,7 +45,6 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x16c4__neondotfp16arith(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 16 columns.
   do {
@@ -61,7 +60,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x16c4__neondotfp16arith(
     const float32x4_t vksumCDEF = vld1q_f32(w); w = (const float*) w + 4;
     float32x4_t vout0xCDEF = vmulq_f32(vksumCDEF, vinput_zero_point0);
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);
       int32x4_t vacc0x89AB = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x16c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x16c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x16c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
@@ -62,7 +61,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x16c8__neoni8mm(
     float32x4_t vout0xCDEF = vmulq_f32(vksumCDEF, vinput_zero_point01);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x2-minmax-scalar.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x2-minmax-scalar.c
@@ -49,8 +49,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x2__scalar(
     float vout0x1 = vksum1 * vinput_zero_point0;
     w = (const float*) w + 2;
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32_t vacc0x0 = 0;
       int32_t vacc0x1 = 0;
       size_t k = bl;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x32c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x32c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x32c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
@@ -70,7 +69,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x32c8__neoni8mm(
     float32x4_t vout0xSTUV = vmulq_f32(vksumSTUV, vinput_zero_point01);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x4-minmax-scalar.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x4-minmax-scalar.c
@@ -52,8 +52,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x4__scalar(
     float vout0x3 = vksum3 * vinput_zero_point0;
     w = (const float*) w + 4;
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32_t vacc0x0 = 0;
       int32_t vacc0x1 = 0;
       int32_t vacc0x2 = 0;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x8-minmax-scalar.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x8-minmax-scalar.c
@@ -60,8 +60,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x8__scalar(
     float vout0x7 = vksum7 * vinput_zero_point0;
     w = (const float*) w + 8;
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32_t vacc0x0 = 0;
       int32_t vacc0x1 = 0;
       int32_t vacc0x2 = 0;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x8c4-minmax-neondotfp16arith.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x8c4-minmax-neondotfp16arith.c
@@ -45,7 +45,6 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x8c4__neondotfp16arith(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 8 columns.
   do {
@@ -57,7 +56,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x8c4__neondotfp16arith(
     const float32x4_t vksum4567 = vld1q_f32(w); w = (const float*) w + 4;
     float32x4_t vout0x4567 = vmulq_f32(vksum4567, vinput_zero_point0);
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);
       // Inner accumulation loop along the 8 columns.

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x8c8-minmax-avx2.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x8c8-minmax-avx2.c
@@ -68,8 +68,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x8c8__avx2(
     __m256 vout0x67 = _mm256_mul_ps(vinit67, vinput_zero_point0);
     w = (const int32_t*) w + 8;
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       __m256i vacc0x01 = _mm256_setzero_si256();
       __m256i vacc0x23 = _mm256_setzero_si256();
       __m256i vacc0x45 = _mm256_setzero_si256();

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x8c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x8c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x8c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
@@ -58,7 +57,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x8c8__neoni8mm(
     float32x4_t vout0x4567 = vmulq_f32(vksum4567, vinput_zero_point01);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x16-minmax-neonfp16arith-mlal-lane-prfm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x16-minmax-neonfp16arith-mlal-lane-prfm.c
@@ -69,8 +69,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x16__neonfp16arith_mlal_lane_prfm(
     float32x4_t vout0xCDEF = vmulq_lane_f32(vksumCDEF, vget_low_f32(vzp01), 0);
     float32x4_t vout1xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vzp01), 0);
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);
       int32x4_t vacc0x89AB = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x16-minmax-neonfp16arith-mlal-lane.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x16-minmax-neonfp16arith-mlal-lane.c
@@ -68,8 +68,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x16__neonfp16arith_mlal_lane(
     float32x4_t vout0xCDEF = vmulq_lane_f32(vksumCDEF, vget_low_f32(vzp01), 0);
     float32x4_t vout1xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vzp01), 0);
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);
       int32x4_t vacc0x89AB = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x16c4-minmax-neondotfp16arith.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x16c4-minmax-neondotfp16arith.c
@@ -51,7 +51,6 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x16c4__neondotfp16arith(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 16 columns.
   do {
@@ -71,7 +70,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x16c4__neondotfp16arith(
     float32x4_t vout0xCDEF = vmulq_lane_f32(vksumCDEF, vget_low_f32(vinput_zero_point01), 0);
     float32x4_t vout1xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vinput_zero_point01), 0);
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc1x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x16c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x16c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x16c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -72,7 +71,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x16c8__neoni8mm(
     float32x4_t vout1xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vinput_zero_point01), 0);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x2-minmax-scalar.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x2-minmax-scalar.c
@@ -58,8 +58,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x2__scalar(
     float vout1x1 = vksum1 * vinput_zero_point1;
     w = (const float*) w + 2;
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32_t vacc0x0 = 0;
       int32_t vacc0x1 = 0;
       int32_t vacc1x0 = 0;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x32c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x32c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x32c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -84,7 +83,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x32c8__neoni8mm(
     float32x4_t vout1xSTUV = vmulq_lane_f32(vksumSTUV, vget_high_f32(vinput_zero_point01), 0);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x4-minmax-scalar.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x4-minmax-scalar.c
@@ -63,8 +63,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x4__scalar(
     float vout1x3 = vksum3 * vinput_zero_point1;
     w = (const float*) w + 4;
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32_t vacc0x0 = 0;
       int32_t vacc0x1 = 0;
       int32_t vacc0x2 = 0;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x8-minmax-scalar.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x8-minmax-scalar.c
@@ -75,8 +75,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x8__scalar(
     float vout1x7 = vksum7 * vinput_zero_point1;
     w = (const float*) w + 8;
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32_t vacc0x0 = 0;
       int32_t vacc0x1 = 0;
       int32_t vacc0x2 = 0;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x8c4-minmax-neondotfp16arith.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x8c4-minmax-neondotfp16arith.c
@@ -51,7 +51,6 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x8c4__neondotfp16arith(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 8 columns.
   do {
@@ -65,7 +64,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x8c4__neondotfp16arith(
     float32x4_t vout0x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point01), 0);
     float32x4_t vout1x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point01), 0);
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc1x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x8c8-minmax-avx2.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x8c8-minmax-avx2.c
@@ -79,8 +79,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x8c8__avx2(
     __m256 vout1x67 = _mm256_mul_ps(vinit67, vinput_zero_point1);
     w = (const int32_t*) w + 8;
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       __m256i vacc0x01 = _mm256_setzero_si256();
       __m256i vacc0x23 = _mm256_setzero_si256();
       __m256i vacc0x45 = _mm256_setzero_si256();

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x8c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x8c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x8c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -66,7 +65,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x8c8__neoni8mm(
     float32x4_t vout1x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point01), 0);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x16-minmax-neonfp16arith-mlal-lane-prfm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x16-minmax-neonfp16arith-mlal-lane-prfm.c
@@ -80,8 +80,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_3x16__neonfp16arith_mlal_lane_prfm(
     float32x4_t vout2x89AB = vmulq_f32(vksum89AB, vzp2);
     float32x4_t vout2xCDEF = vmulq_f32(vksumCDEF, vzp2);
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);
       int32x4_t vacc0x89AB = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x16-minmax-neonfp16arith-mlal-lane.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x16-minmax-neonfp16arith-mlal-lane.c
@@ -79,8 +79,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_3x16__neonfp16arith_mlal_lane(
     float32x4_t vout2x89AB = vmulq_f32(vksum89AB, vzp2);
     float32x4_t vout2xCDEF = vmulq_f32(vksumCDEF, vzp2);
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);
       int32x4_t vacc0x89AB = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x16c4-minmax-neondotfp16arith.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x16c4-minmax-neondotfp16arith.c
@@ -57,7 +57,6 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_3x16c4__neondotfp16arith(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 16 columns.
   do {
@@ -82,7 +81,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_3x16c4__neondotfp16arith(
     float32x4_t vout2x89AB = vmulq_f32(vksum89AB, vinput_zero_point2);
     float32x4_t vout2xCDEF = vmulq_f32(vksumCDEF, vinput_zero_point2);
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc1x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x16c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x16c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_3x16c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -83,7 +82,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_3x16c8__neoni8mm(
     float32x4_t vout2xCDEF = vmulq_f32(vksumCDEF, vinput_zero_point23);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x32c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x32c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_3x32c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -99,7 +98,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_3x32c8__neoni8mm(
     float32x4_t vout2xSTUV = vmulq_f32(vksumSTUV, vinput_zero_point23);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x8c4-minmax-neondotfp16arith.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x8c4-minmax-neondotfp16arith.c
@@ -57,7 +57,6 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_3x8c4__neondotfp16arith(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 8 columns.
   do {
@@ -74,7 +73,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_3x8c4__neondotfp16arith(
     float32x4_t vout2x0123 = vmulq_f32(vksum0123, vinput_zero_point2);
     float32x4_t vout2x4567 = vmulq_f32(vksum4567, vinput_zero_point2);
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc1x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x8c8-minmax-avx2.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x8c8-minmax-avx2.c
@@ -90,8 +90,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_3x8c8__avx2(
     __m256 vout2x67 = _mm256_mul_ps(vinit67, vinput_zero_point2);
     w = (const int32_t*) w + 8;
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       __m256i vacc0x01 = _mm256_setzero_si256();
       __m256i vacc0x23 = _mm256_setzero_si256();
       __m256i vacc0x45 = _mm256_setzero_si256();

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x8c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x8c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_3x8c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -75,7 +74,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_3x8c8__neoni8mm(
     float32x4_t vout2x4567 = vmulq_f32(vksum4567, vinput_zero_point23);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x16-minmax-neonfp16arith-mlal-lane-prfm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x16-minmax-neonfp16arith-mlal-lane-prfm.c
@@ -90,8 +90,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x16__neonfp16arith_mlal_lane_prfm(
     float32x4_t vout2xCDEF = vmulq_lane_f32(vksumCDEF, vget_low_f32(vzp23), 0);
     float32x4_t vout3xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vzp23), 0);
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);
       int32x4_t vacc0x89AB = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x16-minmax-neonfp16arith-mlal-lane.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x16-minmax-neonfp16arith-mlal-lane.c
@@ -89,8 +89,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x16__neonfp16arith_mlal_lane(
     float32x4_t vout2xCDEF = vmulq_lane_f32(vksumCDEF, vget_low_f32(vzp23), 0);
     float32x4_t vout3xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vzp23), 0);
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);
       int32x4_t vacc0x89AB = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x16c4-minmax-neondotfp16arith.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x16c4-minmax-neondotfp16arith.c
@@ -63,7 +63,6 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x16c4__neondotfp16arith(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 16 columns.
   do {
@@ -92,7 +91,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x16c4__neondotfp16arith(
     float32x4_t vout2xCDEF = vmulq_lane_f32(vksumCDEF, vget_low_f32(vinput_zero_point23), 0);
     float32x4_t vout3xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vinput_zero_point23), 0);
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc1x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x16c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x16c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x16c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -93,7 +92,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x16c8__neoni8mm(
     float32x4_t vout3xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vinput_zero_point23), 0);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x32c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x32c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x32c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -113,7 +112,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x32c8__neoni8mm(
     float32x4_t vout3xSTUV = vmulq_lane_f32(vksumSTUV, vget_high_f32(vinput_zero_point23), 0);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x4-minmax-scalar.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x4-minmax-scalar.c
@@ -85,8 +85,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x4__scalar(
     float vout3x3 = vksum3 * vinput_zero_point3;
     w = (const float*) w + 4;
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32_t vacc0x0 = 0;
       int32_t vacc0x1 = 0;
       int32_t vacc0x2 = 0;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x8c4-minmax-neondotfp16arith.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x8c4-minmax-neondotfp16arith.c
@@ -63,7 +63,6 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x8c4__neondotfp16arith(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 8 columns.
   do {
@@ -82,7 +81,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x8c4__neondotfp16arith(
     float32x4_t vout2x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point23), 0);
     float32x4_t vout3x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point23), 0);
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc1x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x8c8-minmax-avx2.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x8c8-minmax-avx2.c
@@ -101,8 +101,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x8c8__avx2(
     __m256 vout3x67 = _mm256_mul_ps(vinit67, vinput_zero_point3);
     w = (const int32_t*) w + 8;
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       __m256i vacc0x01 = _mm256_setzero_si256();
       __m256i vacc0x23 = _mm256_setzero_si256();
       __m256i vacc0x45 = _mm256_setzero_si256();

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x8c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x8c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x8c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -83,7 +82,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x8c8__neoni8mm(
     float32x4_t vout3x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point23), 0);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-5x16c4-minmax-neondotfp16arith.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-5x16c4-minmax-neondotfp16arith.c
@@ -69,7 +69,6 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_5x16c4__neondotfp16arith(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 16 columns.
   do {
@@ -103,7 +102,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_5x16c4__neondotfp16arith(
     float32x4_t vout4x89AB = vmulq_f32(vksum89AB, vinput_zero_point4);
     float32x4_t vout4xCDEF = vmulq_f32(vksumCDEF, vinput_zero_point4);
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc1x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-5x16c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-5x16c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_5x16c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -104,7 +103,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_5x16c8__neoni8mm(
     float32x4_t vout4xCDEF = vmulq_f32(vksumCDEF, vinput_zero_point45);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-5x32c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-5x32c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_5x32c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -128,7 +127,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_5x32c8__neoni8mm(
     float32x4_t vout4xSTUV = vmulq_f32(vksumSTUV, vinput_zero_point45);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-5x8c4-minmax-neondotfp16arith.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-5x8c4-minmax-neondotfp16arith.c
@@ -69,7 +69,6 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_5x8c4__neondotfp16arith(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 8 columns.
   do {
@@ -91,7 +90,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_5x8c4__neondotfp16arith(
     float32x4_t vout4x0123 = vmulq_f32(vksum0123, vinput_zero_point4);
     float32x4_t vout4x4567 = vmulq_f32(vksum4567, vinput_zero_point4);
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc1x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-5x8c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-5x8c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_5x8c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -92,7 +91,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_5x8c8__neoni8mm(
     float32x4_t vout4x4567 = vmulq_f32(vksum4567, vinput_zero_point45);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-6x16-minmax-neonfp16arith-mlal-lane-prfm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-6x16-minmax-neonfp16arith-mlal-lane-prfm.c
@@ -111,8 +111,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_6x16__neonfp16arith_mlal_lane_prfm(
     float32x4_t vout4xCDEF = vmulq_lane_f32(vksumCDEF, vget_low_f32(vzp45), 0);
     float32x4_t vout5xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vzp45), 0);
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);
       int32x4_t vacc0x89AB = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-6x16-minmax-neonfp16arith-mlal-lane.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-6x16-minmax-neonfp16arith-mlal-lane.c
@@ -110,8 +110,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_6x16__neonfp16arith_mlal_lane(
     float32x4_t vout4xCDEF = vmulq_lane_f32(vksumCDEF, vget_low_f32(vzp45), 0);
     float32x4_t vout5xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vzp45), 0);
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);
       int32x4_t vacc0x89AB = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-6x16c4-minmax-neondotfp16arith.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-6x16c4-minmax-neondotfp16arith.c
@@ -75,7 +75,6 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_6x16c4__neondotfp16arith(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 16 columns.
   do {
@@ -113,7 +112,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_6x16c4__neondotfp16arith(
     float32x4_t vout4xCDEF = vmulq_lane_f32(vksumCDEF, vget_low_f32(vinput_zero_point45), 0);
     float32x4_t vout5xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vinput_zero_point45), 0);
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc1x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-6x16c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-6x16c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_6x16c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -114,7 +113,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_6x16c8__neoni8mm(
     float32x4_t vout5xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vinput_zero_point45), 0);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-6x32c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-6x32c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_6x32c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -142,7 +141,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_6x32c8__neoni8mm(
     float32x4_t vout5xSTUV = vmulq_lane_f32(vksumSTUV, vget_high_f32(vinput_zero_point45), 0);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-6x8c4-minmax-neondotfp16arith.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-6x8c4-minmax-neondotfp16arith.c
@@ -75,7 +75,6 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_6x8c4__neondotfp16arith(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 8 columns.
   do {
@@ -99,7 +98,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_6x8c4__neondotfp16arith(
     float32x4_t vout4x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point45), 0);
     float32x4_t vout5x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point45), 0);
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc1x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-6x8c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-6x8c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_6x8c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -100,7 +99,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_6x8c8__neoni8mm(
     float32x4_t vout5x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point45), 0);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-7x16c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-7x16c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_7x16c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -125,7 +124,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_7x16c8__neoni8mm(
     float32x4_t vout6xCDEF = vmulq_f32(vksumCDEF, vinput_zero_point67);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-7x32c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-7x32c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_7x32c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -157,7 +156,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_7x32c8__neoni8mm(
     float32x4_t vout6xSTUV = vmulq_f32(vksumSTUV, vinput_zero_point67);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-7x8c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-7x8c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_7x8c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -109,7 +108,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_7x8c8__neoni8mm(
     float32x4_t vout6x4567 = vmulq_f32(vksum4567, vinput_zero_point67);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-8x16c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-8x16c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_8x16c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -135,7 +134,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_8x16c8__neoni8mm(
     float32x4_t vout7xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vinput_zero_point67), 0);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-8x32c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-8x32c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_8x32c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -171,7 +170,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_8x32c8__neoni8mm(
     float32x4_t vout7xSTUV = vmulq_lane_f32(vksumSTUV, vget_high_f32(vinput_zero_point67), 0);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-8x8c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-8x8c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_8x8c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -117,7 +116,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_8x8c8__neoni8mm(
     float32x4_t vout7x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point67), 0);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x16-minmax-neon-mlal-lane-prfm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x16-minmax-neon-mlal-lane-prfm.c
@@ -59,8 +59,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x16__neon_mlal_lane_prfm(
     float32x4_t vout0x89AB = vmulq_f32(vksum89AB, vzp0);
     float32x4_t vout0xCDEF = vmulq_f32(vksumCDEF, vzp0);
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);
       int32x4_t vacc0x89AB = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x16-minmax-neon-mlal-lane.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x16-minmax-neon-mlal-lane.c
@@ -58,8 +58,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x16__neon_mlal_lane(
     float32x4_t vout0x89AB = vmulq_f32(vksum89AB, vzp0);
     float32x4_t vout0xCDEF = vmulq_f32(vksumCDEF, vzp0);
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);
       int32x4_t vacc0x89AB = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x16c4-minmax-neondot.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x16c4-minmax-neondot.c
@@ -45,7 +45,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x16c4__neondot(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 16 columns.
   do {
@@ -61,7 +60,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x16c4__neondot(
     const float32x4_t vksumCDEF = vld1q_f32(w); w = (const float*) w + 4;
     float32x4_t vout0xCDEF = vmulq_f32(vksumCDEF, vinput_zero_point0);
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);
       int32x4_t vacc0x89AB = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x16c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x16c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x16c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
@@ -62,7 +61,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x16c8__neoni8mm(
     float32x4_t vout0xCDEF = vmulq_f32(vksumCDEF, vinput_zero_point01);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x2-minmax-scalar.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x2-minmax-scalar.c
@@ -48,8 +48,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x2__scalar(
     float vout0x1 = vksum1 * vinput_zero_point0;
     w = (const float*) w + 2;
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32_t vacc0x0 = 0;
       int32_t vacc0x1 = 0;
       size_t k = bl;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x32c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x32c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x32c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
@@ -70,7 +69,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x32c8__neoni8mm(
     float32x4_t vout0xSTUV = vmulq_f32(vksumSTUV, vinput_zero_point01);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x4-minmax-scalar.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x4-minmax-scalar.c
@@ -51,8 +51,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x4__scalar(
     float vout0x3 = vksum3 * vinput_zero_point0;
     w = (const float*) w + 4;
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32_t vacc0x0 = 0;
       int32_t vacc0x1 = 0;
       int32_t vacc0x2 = 0;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x4c8-minmax-avx-ld128.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x4c8-minmax-avx-ld128.c
@@ -46,7 +46,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x4c8__avx_ld128(
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;
   float* c0 = c;
@@ -60,7 +59,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x4c8__avx_ld128(
     __m128 vout0x0123 = _mm_mul_ps(vksum, vinput_zero_point0_float);
     w = (const int32_t*) w + 4;
 
-    for (size_t nb=0; nb<n_blocks; ++nb){
+    for (size_t kb=0; kb < kc; kb += bl) {
       __m128i vacc0x0 = _mm_setzero_si128();
       __m128i vacc0x1 = _mm_setzero_si128();
       __m128i vacc0x2 = _mm_setzero_si128();

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x4c8-minmax-avx-ld64.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x4c8-minmax-avx-ld64.c
@@ -46,7 +46,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x4c8__avx_ld64(
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;
   float* c0 = c;
@@ -60,7 +59,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x4c8__avx_ld64(
     __m128 vout0x0123 = _mm_mul_ps(vksum, vinput_zero_point0_float);
     w = (const int32_t*) w + 4;
 
-    for (size_t nb=0; nb<n_blocks; ++nb){
+    for (size_t kb=0; kb < kc; kb += bl) {
       __m128i vacc0x0 = _mm_setzero_si128();
       __m128i vacc0x1 = _mm_setzero_si128();
       __m128i vacc0x2 = _mm_setzero_si128();

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x4c8-minmax-sse2-ld128.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x4c8-minmax-sse2-ld128.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x4c8__sse2_ld128(
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;
   float* c0 = c;
@@ -57,7 +56,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x4c8__sse2_ld128(
     __m128 vout0x0123 = _mm_mul_ps(vksum, vinput_zero_point0_float);
     w = (const int32_t*) w + 4;
 
-    for (size_t nb=0; nb<n_blocks; ++nb){
+    for (size_t kb=0; kb < kc; kb += bl) {
       __m128i vacc0x0 = _mm_setzero_si128();
       __m128i vacc0x1 = _mm_setzero_si128();
       __m128i vacc0x2 = _mm_setzero_si128();

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x4c8-minmax-sse2-ld64.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x4c8-minmax-sse2-ld64.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x4c8__sse2_ld64(
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;
   float* c0 = c;
@@ -57,7 +56,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x4c8__sse2_ld64(
     __m128 vout0x0123 = _mm_mul_ps(vksum, vinput_zero_point0_float);
     w = (const int32_t*) w + 4;
 
-    for (size_t nb=0; nb<n_blocks; ++nb){
+    for (size_t kb=0; kb < kc; kb += bl) {
       __m128i vacc0x0 = _mm_setzero_si128();
       __m128i vacc0x1 = _mm_setzero_si128();
       __m128i vacc0x2 = _mm_setzero_si128();

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x4c8-minmax-sse41-ld128.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x4c8-minmax-sse41-ld128.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x4c8__sse41_ld128(
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;
   float* c0 = c;
@@ -57,7 +56,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x4c8__sse41_ld128(
     __m128 vout0x0123 = _mm_mul_ps(vksum, vinput_zero_point0_float);
     w = (const int32_t*) w + 4;
 
-    for (size_t nb=0; nb<n_blocks; ++nb){
+    for (size_t kb=0; kb < kc; kb += bl) {
       __m128i vacc0x0 = _mm_setzero_si128();
       __m128i vacc0x1 = _mm_setzero_si128();
       __m128i vacc0x2 = _mm_setzero_si128();

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x4c8-minmax-sse41-ld64.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x4c8-minmax-sse41-ld64.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x4c8__sse41_ld64(
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;
   float* c0 = c;
@@ -57,7 +56,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x4c8__sse41_ld64(
     __m128 vout0x0123 = _mm_mul_ps(vksum, vinput_zero_point0_float);
     w = (const int32_t*) w + 4;
 
-    for (size_t nb=0; nb<n_blocks; ++nb){
+    for (size_t kb=0; kb < kc; kb += bl) {
       __m128i vacc0x0 = _mm_setzero_si128();
       __m128i vacc0x1 = _mm_setzero_si128();
       __m128i vacc0x2 = _mm_setzero_si128();

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x8-minmax-scalar.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x8-minmax-scalar.c
@@ -59,8 +59,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x8__scalar(
     float vout0x7 = vksum7 * vinput_zero_point0;
     w = (const float*) w + 8;
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32_t vacc0x0 = 0;
       int32_t vacc0x1 = 0;
       int32_t vacc0x2 = 0;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x8c4-minmax-neondot.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x8c4-minmax-neondot.c
@@ -45,7 +45,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x8c4__neondot(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 8 columns.
   do {
@@ -57,7 +56,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x8c4__neondot(
     const float32x4_t vksum4567 = vld1q_f32(w); w = (const float*) w + 4;
     float32x4_t vout0x4567 = vmulq_f32(vksum4567, vinput_zero_point0);
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);
       // Inner accumulation loop along the 8 columns.

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x8c8-minmax-avx2.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x8c8-minmax-avx2.c
@@ -68,8 +68,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x8c8__avx2(
     __m256 vout0x67 = _mm256_mul_ps(vinit67, vinput_zero_point0);
     w = (const int32_t*) w + 8;
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       __m256i vacc0x01 = _mm256_setzero_si256();
       __m256i vacc0x23 = _mm256_setzero_si256();
       __m256i vacc0x45 = _mm256_setzero_si256();

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x8c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x8c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x8c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
@@ -58,7 +57,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x8c8__neoni8mm(
     float32x4_t vout0x4567 = vmulq_f32(vksum4567, vinput_zero_point01);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x16-minmax-neon-mlal-lane-prfm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x16-minmax-neon-mlal-lane-prfm.c
@@ -69,8 +69,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x16__neon_mlal_lane_prfm(
     float32x4_t vout0xCDEF = vmulq_lane_f32(vksumCDEF, vget_low_f32(vzp01), 0);
     float32x4_t vout1xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vzp01), 0);
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);
       int32x4_t vacc0x89AB = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x16-minmax-neon-mlal-lane.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x16-minmax-neon-mlal-lane.c
@@ -68,8 +68,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x16__neon_mlal_lane(
     float32x4_t vout0xCDEF = vmulq_lane_f32(vksumCDEF, vget_low_f32(vzp01), 0);
     float32x4_t vout1xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vzp01), 0);
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);
       int32x4_t vacc0x89AB = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x16c4-minmax-neondot.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x16c4-minmax-neondot.c
@@ -51,7 +51,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x16c4__neondot(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 16 columns.
   do {
@@ -71,7 +70,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x16c4__neondot(
     float32x4_t vout0xCDEF = vmulq_lane_f32(vksumCDEF, vget_low_f32(vinput_zero_point01), 0);
     float32x4_t vout1xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vinput_zero_point01), 0);
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc1x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x16c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x16c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x16c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -72,7 +71,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x16c8__neoni8mm(
     float32x4_t vout1xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vinput_zero_point01), 0);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x2-minmax-scalar.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x2-minmax-scalar.c
@@ -57,8 +57,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x2__scalar(
     float vout1x1 = vksum1 * vinput_zero_point1;
     w = (const float*) w + 2;
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32_t vacc0x0 = 0;
       int32_t vacc0x1 = 0;
       int32_t vacc1x0 = 0;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x32c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x32c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x32c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -84,7 +83,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x32c8__neoni8mm(
     float32x4_t vout1xSTUV = vmulq_lane_f32(vksumSTUV, vget_high_f32(vinput_zero_point01), 0);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x4-minmax-scalar.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x4-minmax-scalar.c
@@ -62,8 +62,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x4__scalar(
     float vout1x3 = vksum3 * vinput_zero_point1;
     w = (const float*) w + 4;
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32_t vacc0x0 = 0;
       int32_t vacc0x1 = 0;
       int32_t vacc0x2 = 0;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x4c8-minmax-avx-ld128.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x4c8-minmax-avx-ld128.c
@@ -46,7 +46,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x4c8__avx_ld128(
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;
   float* c0 = c;
@@ -69,7 +68,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x4c8__avx_ld128(
     __m128 vout1x0123 = _mm_mul_ps(vksum, vinput_zero_point1_float);
     w = (const int32_t*) w + 4;
 
-    for (size_t nb=0; nb<n_blocks; ++nb){
+    for (size_t kb=0; kb < kc; kb += bl) {
       __m128i vacc0x0 = _mm_setzero_si128();
       __m128i vacc0x1 = _mm_setzero_si128();
       __m128i vacc0x2 = _mm_setzero_si128();

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x4c8-minmax-avx-ld64.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x4c8-minmax-avx-ld64.c
@@ -46,7 +46,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x4c8__avx_ld64(
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;
   float* c0 = c;
@@ -69,7 +68,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x4c8__avx_ld64(
     __m128 vout1x0123 = _mm_mul_ps(vksum, vinput_zero_point1_float);
     w = (const int32_t*) w + 4;
 
-    for (size_t nb=0; nb<n_blocks; ++nb){
+    for (size_t kb=0; kb < kc; kb += bl) {
       __m128i vacc0x0 = _mm_setzero_si128();
       __m128i vacc0x1 = _mm_setzero_si128();
       __m128i vacc0x2 = _mm_setzero_si128();

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x4c8-minmax-sse2-ld128.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x4c8-minmax-sse2-ld128.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x4c8__sse2_ld128(
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;
   float* c0 = c;
@@ -66,7 +65,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x4c8__sse2_ld128(
     __m128 vout1x0123 = _mm_mul_ps(vksum, vinput_zero_point1_float);
     w = (const int32_t*) w + 4;
 
-    for (size_t nb=0; nb<n_blocks; ++nb){
+    for (size_t kb=0; kb < kc; kb += bl) {
       __m128i vacc0x0 = _mm_setzero_si128();
       __m128i vacc0x1 = _mm_setzero_si128();
       __m128i vacc0x2 = _mm_setzero_si128();

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x4c8-minmax-sse2-ld64.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x4c8-minmax-sse2-ld64.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x4c8__sse2_ld64(
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;
   float* c0 = c;
@@ -66,7 +65,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x4c8__sse2_ld64(
     __m128 vout1x0123 = _mm_mul_ps(vksum, vinput_zero_point1_float);
     w = (const int32_t*) w + 4;
 
-    for (size_t nb=0; nb<n_blocks; ++nb){
+    for (size_t kb=0; kb < kc; kb += bl) {
       __m128i vacc0x0 = _mm_setzero_si128();
       __m128i vacc0x1 = _mm_setzero_si128();
       __m128i vacc0x2 = _mm_setzero_si128();

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x4c8-minmax-sse41-ld128.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x4c8-minmax-sse41-ld128.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x4c8__sse41_ld128(
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;
   float* c0 = c;
@@ -66,7 +65,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x4c8__sse41_ld128(
     __m128 vout1x0123 = _mm_mul_ps(vksum, vinput_zero_point1_float);
     w = (const int32_t*) w + 4;
 
-    for (size_t nb=0; nb<n_blocks; ++nb){
+    for (size_t kb=0; kb < kc; kb += bl) {
       __m128i vacc0x0 = _mm_setzero_si128();
       __m128i vacc0x1 = _mm_setzero_si128();
       __m128i vacc0x2 = _mm_setzero_si128();

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x4c8-minmax-sse41-ld64.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x4c8-minmax-sse41-ld64.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x4c8__sse41_ld64(
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;
   float* c0 = c;
@@ -66,7 +65,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x4c8__sse41_ld64(
     __m128 vout1x0123 = _mm_mul_ps(vksum, vinput_zero_point1_float);
     w = (const int32_t*) w + 4;
 
-    for (size_t nb=0; nb<n_blocks; ++nb){
+    for (size_t kb=0; kb < kc; kb += bl) {
       __m128i vacc0x0 = _mm_setzero_si128();
       __m128i vacc0x1 = _mm_setzero_si128();
       __m128i vacc0x2 = _mm_setzero_si128();

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x8-minmax-scalar.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x8-minmax-scalar.c
@@ -74,8 +74,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x8__scalar(
     float vout1x7 = vksum7 * vinput_zero_point1;
     w = (const float*) w + 8;
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32_t vacc0x0 = 0;
       int32_t vacc0x1 = 0;
       int32_t vacc0x2 = 0;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x8c4-minmax-neondot.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x8c4-minmax-neondot.c
@@ -51,7 +51,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x8c4__neondot(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 8 columns.
   do {
@@ -65,7 +64,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x8c4__neondot(
     float32x4_t vout0x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point01), 0);
     float32x4_t vout1x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point01), 0);
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc1x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x8c8-minmax-avx2.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x8c8-minmax-avx2.c
@@ -79,8 +79,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x8c8__avx2(
     __m256 vout1x67 = _mm256_mul_ps(vinit67, vinput_zero_point1);
     w = (const int32_t*) w + 8;
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       __m256i vacc0x01 = _mm256_setzero_si256();
       __m256i vacc0x23 = _mm256_setzero_si256();
       __m256i vacc0x45 = _mm256_setzero_si256();

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x8c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x8c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x8c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -66,7 +65,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x8c8__neoni8mm(
     float32x4_t vout1x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point01), 0);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x16-minmax-neon-mlal-lane-prfm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x16-minmax-neon-mlal-lane-prfm.c
@@ -80,8 +80,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x16__neon_mlal_lane_prfm(
     float32x4_t vout2x89AB = vmulq_f32(vksum89AB, vzp2);
     float32x4_t vout2xCDEF = vmulq_f32(vksumCDEF, vzp2);
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);
       int32x4_t vacc0x89AB = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x16-minmax-neon-mlal-lane.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x16-minmax-neon-mlal-lane.c
@@ -79,8 +79,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x16__neon_mlal_lane(
     float32x4_t vout2x89AB = vmulq_f32(vksum89AB, vzp2);
     float32x4_t vout2xCDEF = vmulq_f32(vksumCDEF, vzp2);
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);
       int32x4_t vacc0x89AB = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x16c4-minmax-neondot.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x16c4-minmax-neondot.c
@@ -57,7 +57,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x16c4__neondot(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 16 columns.
   do {
@@ -82,7 +81,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x16c4__neondot(
     float32x4_t vout2x89AB = vmulq_f32(vksum89AB, vinput_zero_point2);
     float32x4_t vout2xCDEF = vmulq_f32(vksumCDEF, vinput_zero_point2);
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc1x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x16c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x16c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x16c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -83,7 +82,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x16c8__neoni8mm(
     float32x4_t vout2xCDEF = vmulq_f32(vksumCDEF, vinput_zero_point23);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x32c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x32c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x32c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -99,7 +98,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x32c8__neoni8mm(
     float32x4_t vout2xSTUV = vmulq_f32(vksumSTUV, vinput_zero_point23);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x4c8-minmax-avx-ld128.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x4c8-minmax-avx-ld128.c
@@ -46,7 +46,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x4c8__avx_ld128(
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;
   float* c0 = c;
@@ -78,7 +77,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x4c8__avx_ld128(
     __m128 vout2x0123 = _mm_mul_ps(vksum, vinput_zero_point2_float);
     w = (const int32_t*) w + 4;
 
-    for (size_t nb=0; nb<n_blocks; ++nb){
+    for (size_t kb=0; kb < kc; kb += bl) {
       __m128i vacc0x0 = _mm_setzero_si128();
       __m128i vacc0x1 = _mm_setzero_si128();
       __m128i vacc0x2 = _mm_setzero_si128();

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x4c8-minmax-avx-ld64.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x4c8-minmax-avx-ld64.c
@@ -46,7 +46,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x4c8__avx_ld64(
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;
   float* c0 = c;
@@ -78,7 +77,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x4c8__avx_ld64(
     __m128 vout2x0123 = _mm_mul_ps(vksum, vinput_zero_point2_float);
     w = (const int32_t*) w + 4;
 
-    for (size_t nb=0; nb<n_blocks; ++nb){
+    for (size_t kb=0; kb < kc; kb += bl) {
       __m128i vacc0x0 = _mm_setzero_si128();
       __m128i vacc0x1 = _mm_setzero_si128();
       __m128i vacc0x2 = _mm_setzero_si128();

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x4c8-minmax-sse2-ld128.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x4c8-minmax-sse2-ld128.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x4c8__sse2_ld128(
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;
   float* c0 = c;
@@ -76,7 +75,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x4c8__sse2_ld128(
     __m128 vout2x0123 = _mm_mul_ps(vksum, vinput_zero_point2_float);
     w = (const int32_t*) w + 4;
 
-    for (size_t nb=0; nb<n_blocks; ++nb){
+    for (size_t kb=0; kb < kc; kb += bl) {
       __m128i vacc0x0 = _mm_setzero_si128();
       __m128i vacc0x1 = _mm_setzero_si128();
       __m128i vacc0x2 = _mm_setzero_si128();

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x4c8-minmax-sse2-ld64.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x4c8-minmax-sse2-ld64.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x4c8__sse2_ld64(
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;
   float* c0 = c;
@@ -76,7 +75,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x4c8__sse2_ld64(
     __m128 vout2x0123 = _mm_mul_ps(vksum, vinput_zero_point2_float);
     w = (const int32_t*) w + 4;
 
-    for (size_t nb=0; nb<n_blocks; ++nb){
+    for (size_t kb=0; kb < kc; kb += bl) {
       __m128i vacc0x0 = _mm_setzero_si128();
       __m128i vacc0x1 = _mm_setzero_si128();
       __m128i vacc0x2 = _mm_setzero_si128();

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x4c8-minmax-sse41-ld128.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x4c8-minmax-sse41-ld128.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x4c8__sse41_ld128(
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;
   float* c0 = c;
@@ -76,7 +75,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x4c8__sse41_ld128(
     __m128 vout2x0123 = _mm_mul_ps(vksum, vinput_zero_point2_float);
     w = (const int32_t*) w + 4;
 
-    for (size_t nb=0; nb<n_blocks; ++nb){
+    for (size_t kb=0; kb < kc; kb += bl) {
       __m128i vacc0x0 = _mm_setzero_si128();
       __m128i vacc0x1 = _mm_setzero_si128();
       __m128i vacc0x2 = _mm_setzero_si128();

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x4c8-minmax-sse41-ld64.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x4c8-minmax-sse41-ld64.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x4c8__sse41_ld64(
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;
   float* c0 = c;
@@ -76,7 +75,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x4c8__sse41_ld64(
     __m128 vout2x0123 = _mm_mul_ps(vksum, vinput_zero_point2_float);
     w = (const int32_t*) w + 4;
 
-    for (size_t nb=0; nb<n_blocks; ++nb){
+    for (size_t kb=0; kb < kc; kb += bl) {
       __m128i vacc0x0 = _mm_setzero_si128();
       __m128i vacc0x1 = _mm_setzero_si128();
       __m128i vacc0x2 = _mm_setzero_si128();

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x8c4-minmax-neondot.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x8c4-minmax-neondot.c
@@ -57,7 +57,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x8c4__neondot(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 8 columns.
   do {
@@ -74,7 +73,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x8c4__neondot(
     float32x4_t vout2x0123 = vmulq_f32(vksum0123, vinput_zero_point2);
     float32x4_t vout2x4567 = vmulq_f32(vksum4567, vinput_zero_point2);
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc1x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x8c8-minmax-avx2.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x8c8-minmax-avx2.c
@@ -90,8 +90,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x8c8__avx2(
     __m256 vout2x67 = _mm256_mul_ps(vinit67, vinput_zero_point2);
     w = (const int32_t*) w + 8;
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       __m256i vacc0x01 = _mm256_setzero_si256();
       __m256i vacc0x23 = _mm256_setzero_si256();
       __m256i vacc0x45 = _mm256_setzero_si256();

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x8c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x8c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x8c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -75,7 +74,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x8c8__neoni8mm(
     float32x4_t vout2x4567 = vmulq_f32(vksum4567, vinput_zero_point23);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x16-minmax-neon-mlal-lane-prfm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x16-minmax-neon-mlal-lane-prfm.c
@@ -90,8 +90,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x16__neon_mlal_lane_prfm(
     float32x4_t vout2xCDEF = vmulq_lane_f32(vksumCDEF, vget_low_f32(vzp23), 0);
     float32x4_t vout3xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vzp23), 0);
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);
       int32x4_t vacc0x89AB = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x16-minmax-neon-mlal-lane.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x16-minmax-neon-mlal-lane.c
@@ -89,8 +89,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x16__neon_mlal_lane(
     float32x4_t vout2xCDEF = vmulq_lane_f32(vksumCDEF, vget_low_f32(vzp23), 0);
     float32x4_t vout3xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vzp23), 0);
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);
       int32x4_t vacc0x89AB = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x16c4-minmax-neondot.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x16c4-minmax-neondot.c
@@ -63,7 +63,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x16c4__neondot(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 16 columns.
   do {
@@ -92,7 +91,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x16c4__neondot(
     float32x4_t vout2xCDEF = vmulq_lane_f32(vksumCDEF, vget_low_f32(vinput_zero_point23), 0);
     float32x4_t vout3xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vinput_zero_point23), 0);
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc1x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x16c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x16c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x16c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -93,7 +92,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x16c8__neoni8mm(
     float32x4_t vout3xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vinput_zero_point23), 0);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x32c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x32c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x32c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -113,7 +112,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x32c8__neoni8mm(
     float32x4_t vout3xSTUV = vmulq_lane_f32(vksumSTUV, vget_high_f32(vinput_zero_point23), 0);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x4-minmax-scalar.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x4-minmax-scalar.c
@@ -84,8 +84,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x4__scalar(
     float vout3x3 = vksum3 * vinput_zero_point3;
     w = (const float*) w + 4;
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32_t vacc0x0 = 0;
       int32_t vacc0x1 = 0;
       int32_t vacc0x2 = 0;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x4c8-minmax-avx-ld128.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x4c8-minmax-avx-ld128.c
@@ -46,7 +46,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x4c8__avx_ld128(
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;
   float* c0 = c;
@@ -87,7 +86,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x4c8__avx_ld128(
     __m128 vout3x0123 = _mm_mul_ps(vksum, vinput_zero_point3_float);
     w = (const int32_t*) w + 4;
 
-    for (size_t nb=0; nb<n_blocks; ++nb){
+    for (size_t kb=0; kb < kc; kb += bl) {
       __m128i vacc0x0 = _mm_setzero_si128();
       __m128i vacc0x1 = _mm_setzero_si128();
       __m128i vacc0x2 = _mm_setzero_si128();

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x4c8-minmax-avx-ld64.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x4c8-minmax-avx-ld64.c
@@ -46,7 +46,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x4c8__avx_ld64(
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;
   float* c0 = c;
@@ -87,7 +86,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x4c8__avx_ld64(
     __m128 vout3x0123 = _mm_mul_ps(vksum, vinput_zero_point3_float);
     w = (const int32_t*) w + 4;
 
-    for (size_t nb=0; nb<n_blocks; ++nb){
+    for (size_t kb=0; kb < kc; kb += bl) {
       __m128i vacc0x0 = _mm_setzero_si128();
       __m128i vacc0x1 = _mm_setzero_si128();
       __m128i vacc0x2 = _mm_setzero_si128();

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x4c8-minmax-sse2-ld128.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x4c8-minmax-sse2-ld128.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x4c8__sse2_ld128(
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;
   float* c0 = c;
@@ -85,7 +84,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x4c8__sse2_ld128(
     __m128 vout3x0123 = _mm_mul_ps(vksum, vinput_zero_point3_float);
     w = (const int32_t*) w + 4;
 
-    for (size_t nb=0; nb<n_blocks; ++nb){
+    for (size_t kb=0; kb < kc; kb += bl) {
       __m128i vacc0x0 = _mm_setzero_si128();
       __m128i vacc0x1 = _mm_setzero_si128();
       __m128i vacc0x2 = _mm_setzero_si128();

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x4c8-minmax-sse2-ld64.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x4c8-minmax-sse2-ld64.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x4c8__sse2_ld64(
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;
   float* c0 = c;
@@ -85,7 +84,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x4c8__sse2_ld64(
     __m128 vout3x0123 = _mm_mul_ps(vksum, vinput_zero_point3_float);
     w = (const int32_t*) w + 4;
 
-    for (size_t nb=0; nb<n_blocks; ++nb){
+    for (size_t kb=0; kb < kc; kb += bl) {
       __m128i vacc0x0 = _mm_setzero_si128();
       __m128i vacc0x1 = _mm_setzero_si128();
       __m128i vacc0x2 = _mm_setzero_si128();

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x4c8-minmax-sse41-ld128.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x4c8-minmax-sse41-ld128.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x4c8__sse41_ld128(
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;
   float* c0 = c;
@@ -85,7 +84,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x4c8__sse41_ld128(
     __m128 vout3x0123 = _mm_mul_ps(vksum, vinput_zero_point3_float);
     w = (const int32_t*) w + 4;
 
-    for (size_t nb=0; nb<n_blocks; ++nb){
+    for (size_t kb=0; kb < kc; kb += bl) {
       __m128i vacc0x0 = _mm_setzero_si128();
       __m128i vacc0x1 = _mm_setzero_si128();
       __m128i vacc0x2 = _mm_setzero_si128();

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x4c8-minmax-sse41-ld64.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x4c8-minmax-sse41-ld64.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x4c8__sse41_ld64(
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;
   float* c0 = c;
@@ -85,7 +84,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x4c8__sse41_ld64(
     __m128 vout3x0123 = _mm_mul_ps(vksum, vinput_zero_point3_float);
     w = (const int32_t*) w + 4;
 
-    for (size_t nb=0; nb<n_blocks; ++nb){
+    for (size_t kb=0; kb < kc; kb += bl) {
       __m128i vacc0x0 = _mm_setzero_si128();
       __m128i vacc0x1 = _mm_setzero_si128();
       __m128i vacc0x2 = _mm_setzero_si128();

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x8c4-minmax-neondot.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x8c4-minmax-neondot.c
@@ -63,7 +63,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x8c4__neondot(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 8 columns.
   do {
@@ -82,7 +81,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x8c4__neondot(
     float32x4_t vout2x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point23), 0);
     float32x4_t vout3x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point23), 0);
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc1x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x8c8-minmax-avx2.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x8c8-minmax-avx2.c
@@ -101,8 +101,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x8c8__avx2(
     __m256 vout3x67 = _mm256_mul_ps(vinit67, vinput_zero_point3);
     w = (const int32_t*) w + 8;
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       __m256i vacc0x01 = _mm256_setzero_si256();
       __m256i vacc0x23 = _mm256_setzero_si256();
       __m256i vacc0x45 = _mm256_setzero_si256();

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x8c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x8c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x8c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -83,7 +82,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x8c8__neoni8mm(
     float32x4_t vout3x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point23), 0);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-5x16c4-minmax-neondot.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-5x16c4-minmax-neondot.c
@@ -69,7 +69,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_5x16c4__neondot(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 16 columns.
   do {
@@ -103,7 +102,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_5x16c4__neondot(
     float32x4_t vout4x89AB = vmulq_f32(vksum89AB, vinput_zero_point4);
     float32x4_t vout4xCDEF = vmulq_f32(vksumCDEF, vinput_zero_point4);
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc1x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-5x16c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-5x16c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_5x16c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -104,7 +103,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_5x16c8__neoni8mm(
     float32x4_t vout4xCDEF = vmulq_f32(vksumCDEF, vinput_zero_point45);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-5x32c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-5x32c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_5x32c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -128,7 +127,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_5x32c8__neoni8mm(
     float32x4_t vout4xSTUV = vmulq_f32(vksumSTUV, vinput_zero_point45);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-5x8c4-minmax-neondot.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-5x8c4-minmax-neondot.c
@@ -69,7 +69,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_5x8c4__neondot(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 8 columns.
   do {
@@ -91,7 +90,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_5x8c4__neondot(
     float32x4_t vout4x0123 = vmulq_f32(vksum0123, vinput_zero_point4);
     float32x4_t vout4x4567 = vmulq_f32(vksum4567, vinput_zero_point4);
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc1x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-5x8c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-5x8c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_5x8c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -92,7 +91,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_5x8c8__neoni8mm(
     float32x4_t vout4x4567 = vmulq_f32(vksum4567, vinput_zero_point45);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-6x16-minmax-neon-mlal-lane-prfm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-6x16-minmax-neon-mlal-lane-prfm.c
@@ -111,8 +111,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_6x16__neon_mlal_lane_prfm(
     float32x4_t vout4xCDEF = vmulq_lane_f32(vksumCDEF, vget_low_f32(vzp45), 0);
     float32x4_t vout5xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vzp45), 0);
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);
       int32x4_t vacc0x89AB = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-6x16-minmax-neon-mlal-lane.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-6x16-minmax-neon-mlal-lane.c
@@ -110,8 +110,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_6x16__neon_mlal_lane(
     float32x4_t vout4xCDEF = vmulq_lane_f32(vksumCDEF, vget_low_f32(vzp45), 0);
     float32x4_t vout5xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vzp45), 0);
 
-    size_t n_blocks = kc / bl;
-    for (size_t nb = 0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);
       int32x4_t vacc0x89AB = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-6x16c4-minmax-neondot.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-6x16c4-minmax-neondot.c
@@ -75,7 +75,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_6x16c4__neondot(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 16 columns.
   do {
@@ -113,7 +112,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_6x16c4__neondot(
     float32x4_t vout4xCDEF = vmulq_lane_f32(vksumCDEF, vget_low_f32(vinput_zero_point45), 0);
     float32x4_t vout5xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vinput_zero_point45), 0);
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc1x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-6x16c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-6x16c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_6x16c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -114,7 +113,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_6x16c8__neoni8mm(
     float32x4_t vout5xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vinput_zero_point45), 0);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-6x32c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-6x32c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_6x32c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -142,7 +141,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_6x32c8__neoni8mm(
     float32x4_t vout5xSTUV = vmulq_lane_f32(vksumSTUV, vget_high_f32(vinput_zero_point45), 0);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-6x8c4-minmax-neondot.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-6x8c4-minmax-neondot.c
@@ -75,7 +75,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_6x8c4__neondot(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 8 columns.
   do {
@@ -99,7 +98,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_6x8c4__neondot(
     float32x4_t vout4x4567 = vmulq_lane_f32(vksum4567, vget_low_f32(vinput_zero_point45), 0);
     float32x4_t vout5x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point45), 0);
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc0x0123 = vdupq_n_s32(0);
       int32x4_t vacc1x0123 = vdupq_n_s32(0);
       int32x4_t vacc0x4567 = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-6x8c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-6x8c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_6x8c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -100,7 +99,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_6x8c8__neoni8mm(
     float32x4_t vout5x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point45), 0);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-7x16c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-7x16c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_7x16c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -125,7 +124,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_7x16c8__neoni8mm(
     float32x4_t vout6xCDEF = vmulq_f32(vksumCDEF, vinput_zero_point67);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-7x32c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-7x32c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_7x32c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -157,7 +156,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_7x32c8__neoni8mm(
     float32x4_t vout6xSTUV = vmulq_f32(vksumSTUV, vinput_zero_point67);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-7x8c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-7x8c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_7x8c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -109,7 +108,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_7x8c8__neoni8mm(
     float32x4_t vout6x4567 = vmulq_f32(vksum4567, vinput_zero_point67);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-8x16c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-8x16c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_8x16c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -135,7 +134,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_8x16c8__neoni8mm(
     float32x4_t vout7xCDEF = vmulq_lane_f32(vksumCDEF, vget_high_f32(vinput_zero_point67), 0);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-8x32c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-8x32c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_8x32c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -171,7 +170,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_8x32c8__neoni8mm(
     float32x4_t vout7xSTUV = vmulq_lane_f32(vksumSTUV, vget_high_f32(vinput_zero_point67), 0);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-8x8c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-8x8c8-minmax-neoni8mm.c
@@ -42,7 +42,6 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_8x8c8__neoni8mm(
   assert(bl <= kc);
   assert(bl != 0);
   assert(bl % 32 == 0);
-  size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);
@@ -117,7 +116,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_8x8c8__neoni8mm(
     float32x4_t vout7x4567 = vmulq_lane_f32(vksum4567, vget_high_f32(vinput_zero_point67), 0);
 
 
-    for (size_t nb=0; nb < n_blocks; ++nb) {
+    for (size_t kb=0; kb < kc; kb += bl) {
       int32x4_t vacc01x01 = vdupq_n_s32(0);
       int32x4_t vacc01x23 = vdupq_n_s32(0);
       int32x4_t vacc01x45 = vdupq_n_s32(0);

--- a/src/qs8-gemm/MRx4c8-sse.c.in
+++ b/src/qs8-gemm/MRx4c8-sse.c.in
@@ -91,7 +91,6 @@ void xnn_${DATATYPE_SPEC}_gemm${GEMM_SUFFIX}_minmax${REQUANTIZATION_SPEC}_ukerne
     assert(bl <= round_up_po2(kc, 2));
     assert(bl != 0);
     assert(bl % 32 == 0);
-    size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(${XINT8_T}));
   const ${XINT8_T}* a0 = a;
   ${OUT_T}* c0 = c;
@@ -202,7 +201,7 @@ void xnn_${DATATYPE_SPEC}_gemm${GEMM_SUFFIX}_minmax${REQUANTIZATION_SPEC}_ukerne
       $if SSE < 4 or VARIANT == "LD128":
         const __m128i vzero = _mm_setzero_si128();
     $if DATATYPE == "QB4":
-      for (size_t nb=0; nb<n_blocks; ++nb){
+      for (size_t kb=0; kb < kc; kb += bl) {
         $for M in range(MR):
           __m128i vacc${M}x0 = _mm_setzero_si128();
           __m128i vacc${M}x1 = _mm_setzero_si128();

--- a/src/qs8-gemm/MRx8c8-avx2.c.in
+++ b/src/qs8-gemm/MRx8c8-avx2.c.in
@@ -138,8 +138,7 @@ void xnn_${DATATYPE_SPEC}_gemm_minmax${REQUANTIZATION_SPEC}_ukernel_${MR}x8c8__$
     w = (const int32_t*) w + 8;
 
     $if BLOCKWISE:
-      size_t n_blocks = kc / bl;
-      for (size_t nb = 0; nb < n_blocks; ++nb) {
+      for (size_t kb=0; kb < kc; kb += bl) {
         $for M in range(MR):
           $for N in range(0, 8, 2):
             __m256i vacc${M}x${N}${N+1} = _mm256_setzero_si256();

--- a/src/qs8-gemm/c4-neondot.c.in
+++ b/src/qs8-gemm/c4-neondot.c.in
@@ -106,7 +106,6 @@ void xnn_${DATATYPE_SPEC}_gemm_minmax${REQUANTIZATION_SPEC}_ukernel_${MR}x${NR}c
     assert(bl <= kc);
     assert(bl != 0);
     assert(bl % 32 == 0);
-    size_t n_blocks = kc / bl;
   $if DATATYPE in ["QC4_F16", "QC4_F32", "QB4_F16", "QB4_F32"]:
     const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of ${NR} columns.
@@ -154,7 +153,7 @@ void xnn_${DATATYPE_SPEC}_gemm_minmax${REQUANTIZATION_SPEC}_ukernel_${MR}x${NR}c
 
     $if BLOCKWISE:
       $SET_INDENT(1)
-      for (size_t nb=0; nb < n_blocks; ++nb) {
+      for (size_t kb=0; kb < kc; kb += bl) {
         $for M in range(0, MR, 2):
           $if M + 1 == MR:
             $for N in range(0, NR, 4):

--- a/src/qs8-gemm/c8-neoni8mm.c.in
+++ b/src/qs8-gemm/c8-neoni8mm.c.in
@@ -77,7 +77,6 @@ void xnn_${DATATYPE_SPEC}_gemm_minmax${REQUANTIZATION_SPEC}_ukernel_${MR}x${NR}c
     assert(bl <= kc);
     assert(bl != 0);
     assert(bl % 32 == 0);
-    size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   $if DATATYPE in ["QD8_F16", "QC4_F16", "QB4_F16"]:
     uint16_t* c0 = (uint16_t*) c;
@@ -181,7 +180,7 @@ void xnn_${DATATYPE_SPEC}_gemm_minmax${REQUANTIZATION_SPEC}_ukernel_${MR}x${NR}c
 
     $if BLOCKWISE:
       $SET_INDENT(1)
-      for (size_t nb=0; nb < n_blocks; ++nb) {
+      for (size_t kb=0; kb < kc; kb += bl) {
         $for M in range(0, MR, 2):
           $for N in range(0, NR, 4):
             int32x4_t vacc${M}${M+1}x${ABC[N:N+2]} = vdupq_n_s32(0);

--- a/src/qs8-gemm/neon-mlal-lane.c.in
+++ b/src/qs8-gemm/neon-mlal-lane.c.in
@@ -174,8 +174,7 @@ void xnn_${DATATYPE_SPEC}_gemm_minmax${REQUANTIZATION_SPEC}_ukernel_${MR}x${NR}_
           int32x4_t vacc${M}x${ABC[N:N+4]} = vacc0x${ABC[N:N+4]};
 
     $if BLOCKWISE:
-      size_t n_blocks = kc / bl;
-      for (size_t nb = 0; nb < n_blocks; ++nb) {
+      for (size_t kb=0; kb < kc; kb += bl) {
         $for M in range(MR):
           $for N in range(0, NR, 4):
             int32x4_t vacc${M}x${ABC[N:N+4]} = vdupq_n_s32(0);

--- a/src/qs8-gemm/scalar.c.in
+++ b/src/qs8-gemm/scalar.c.in
@@ -140,8 +140,7 @@ void xnn_${DATATYPE_SPEC}_gemm_minmax${REQUANTIZATION_SPEC}_ukernel_${MR}x${NR}_
       w = (const int32_t*) w + ${NR};
 
     $if BLOCKWISE:
-      size_t n_blocks = kc / bl;
-      for (size_t nb = 0; nb < n_blocks; ++nb) {
+      for (size_t kb=0; kb < kc; kb += bl) {
         $for M in range(MR):
           $for N in range(NR):
             int32_t vacc${M}x${N} = 0;


### PR DESCRIPTION
This change removes the integer division used to determine the block count with loop addition. This is in-line with suggestions on the outstanding QB4W kernel PRs. I have not benchmarked this change, but removing a per-column integer division should make it marginally faster.

The following PRs are intended to be merged first to reduce merge conflicts:
https://github.com/google/XNNPACK/pull/6756/