### PR TITLE
Require bl % 32 = 0 for qb4w gemm kernels

### DIFF
--- a/bench/gemm-benchmark.cc
+++ b/bench/gemm-benchmark.cc
@@ -412,8 +412,8 @@ void GEMMBenchmark(benchmark::State& state,
 
   const size_t mc = state.range(0);
   const size_t nc = state.range(1);
-  const size_t kc = state.range(2);
-  const size_t bl = round_up_po2(state.range(3), 2 * kr * sr);
+  const size_t bl = state.range(3);
+  const size_t kc = round_up_po2(state.range(2), bl);
 
   std::random_device random_device;
   auto rng = std::mt19937(random_device());
@@ -606,8 +606,8 @@ void GEMMBenchmark(benchmark::State& state,
 
   const size_t mc = state.range(0);
   const size_t nc = state.range(1);
-  const size_t kc = state.range(2);
-  const size_t bl = round_up_po2(state.range(3), 2 * kr * sr);
+  const size_t bl = state.range(3);
+  const size_t kc = round_up_po2(state.range(2), bl);
 
   std::random_device random_device;
   auto rng = std::mt19937(random_device());

--- a/bench/gemm.h
+++ b/bench/gemm.h
@@ -55,7 +55,7 @@ class BenchmarkWrapper {
       if (blockwise_ && args.size() < 4) {
         // Use K as default blocksize for parity with non-blockwise kernels.
         // This is equivalent to per-channel quantization.
-        vals.push_back(k);
+        vals.push_back(round_up_po2(k, 32));
       }
       else if (!blockwise_ && vals.size() == 4) {
         // Drop blocksize argument for non-blockwise kernels. This declutters the

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x16-minmax-neonfp16arith-mlal-lane-prfm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x16-minmax-neonfp16arith-mlal-lane-prfm.c
@@ -42,6 +42,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x16__neonfp16arith_mlal_lane_prfm(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;
 

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x16-minmax-neonfp16arith-mlal-lane.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x16-minmax-neonfp16arith-mlal-lane.c
@@ -41,6 +41,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x16__neonfp16arith_mlal_lane(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;
 

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x16c4-minmax-neondotfp16arith.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x16c4-minmax-neondotfp16arith.c
@@ -44,6 +44,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x16c4__neondotfp16arith(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 16 columns.

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x16c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x16c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x16c8__neoni8mm(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x2-minmax-scalar.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x2-minmax-scalar.c
@@ -35,6 +35,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x2__scalar(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
 
   const int8_t* a0 = a;
   uint16_t* c0 = c;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x32c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x32c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x32c8__neoni8mm(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x4-minmax-scalar.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x4-minmax-scalar.c
@@ -34,6 +34,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x4__scalar(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
 
   const int8_t* a0 = a;
   uint16_t* c0 = c;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x8-minmax-scalar.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x8-minmax-scalar.c
@@ -34,6 +34,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x8__scalar(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
 
   const int8_t* a0 = a;
   uint16_t* c0 = c;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x8c4-minmax-neondotfp16arith.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x8c4-minmax-neondotfp16arith.c
@@ -44,6 +44,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x8c4__neondotfp16arith(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 8 columns.

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x8c8-minmax-avx2.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x8c8-minmax-avx2.c
@@ -43,6 +43,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x8c8__avx2(
   size_t bl = params->avx.blocksize;
   assert(bl <= round_up_po2(kc, 16));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;
 

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x8c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x8c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x8c8__neoni8mm(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x16-minmax-neonfp16arith-mlal-lane-prfm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x16-minmax-neonfp16arith-mlal-lane-prfm.c
@@ -42,6 +42,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x16__neonfp16arith_mlal_lane_prfm(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x16-minmax-neonfp16arith-mlal-lane.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x16-minmax-neonfp16arith-mlal-lane.c
@@ -41,6 +41,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x16__neonfp16arith_mlal_lane(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x16c4-minmax-neondotfp16arith.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x16c4-minmax-neondotfp16arith.c
@@ -50,6 +50,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x16c4__neondotfp16arith(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 16 columns.

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x16c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x16c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x16c8__neoni8mm(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x2-minmax-scalar.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x2-minmax-scalar.c
@@ -35,6 +35,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x2__scalar(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
 
   const int8_t* a0 = a;
   uint16_t* c0 = c;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x32c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x32c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x32c8__neoni8mm(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x4-minmax-scalar.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x4-minmax-scalar.c
@@ -34,6 +34,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x4__scalar(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
 
   const int8_t* a0 = a;
   uint16_t* c0 = c;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x8-minmax-scalar.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x8-minmax-scalar.c
@@ -34,6 +34,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x8__scalar(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
 
   const int8_t* a0 = a;
   uint16_t* c0 = c;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x8c4-minmax-neondotfp16arith.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x8c4-minmax-neondotfp16arith.c
@@ -50,6 +50,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x8c4__neondotfp16arith(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 8 columns.

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x8c8-minmax-avx2.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x8c8-minmax-avx2.c
@@ -43,6 +43,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x8c8__avx2(
   size_t bl = params->avx.blocksize;
   assert(bl <= round_up_po2(kc, 16));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x8c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x8c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x8c8__neoni8mm(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x16-minmax-neonfp16arith-mlal-lane-prfm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x16-minmax-neonfp16arith-mlal-lane-prfm.c
@@ -42,6 +42,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_3x16__neonfp16arith_mlal_lane_prfm(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x16-minmax-neonfp16arith-mlal-lane.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x16-minmax-neonfp16arith-mlal-lane.c
@@ -41,6 +41,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_3x16__neonfp16arith_mlal_lane(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x16c4-minmax-neondotfp16arith.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x16c4-minmax-neondotfp16arith.c
@@ -56,6 +56,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_3x16c4__neondotfp16arith(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 16 columns.

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x16c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x16c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_3x16c8__neoni8mm(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x32c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x32c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_3x32c8__neoni8mm(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x8c4-minmax-neondotfp16arith.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x8c4-minmax-neondotfp16arith.c
@@ -56,6 +56,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_3x8c4__neondotfp16arith(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 8 columns.

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x8c8-minmax-avx2.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x8c8-minmax-avx2.c
@@ -43,6 +43,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_3x8c8__avx2(
   size_t bl = params->avx.blocksize;
   assert(bl <= round_up_po2(kc, 16));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x8c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-3x8c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_3x8c8__neoni8mm(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x16-minmax-neonfp16arith-mlal-lane-prfm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x16-minmax-neonfp16arith-mlal-lane-prfm.c
@@ -42,6 +42,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x16__neonfp16arith_mlal_lane_prfm(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x16-minmax-neonfp16arith-mlal-lane.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x16-minmax-neonfp16arith-mlal-lane.c
@@ -41,6 +41,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x16__neonfp16arith_mlal_lane(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x16c4-minmax-neondotfp16arith.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x16c4-minmax-neondotfp16arith.c
@@ -62,6 +62,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x16c4__neondotfp16arith(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 16 columns.

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x16c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x16c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x16c8__neoni8mm(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x32c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x32c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x32c8__neoni8mm(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x4-minmax-scalar.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x4-minmax-scalar.c
@@ -34,6 +34,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x4__scalar(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
 
   const int8_t* a0 = a;
   uint16_t* c0 = c;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x8c4-minmax-neondotfp16arith.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x8c4-minmax-neondotfp16arith.c
@@ -62,6 +62,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x8c4__neondotfp16arith(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 8 columns.

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x8c8-minmax-avx2.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x8c8-minmax-avx2.c
@@ -43,6 +43,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x8c8__avx2(
   size_t bl = params->avx.blocksize;
   assert(bl <= round_up_po2(kc, 16));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x8c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x8c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x8c8__neoni8mm(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-5x16c4-minmax-neondotfp16arith.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-5x16c4-minmax-neondotfp16arith.c
@@ -68,6 +68,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_5x16c4__neondotfp16arith(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 16 columns.

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-5x16c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-5x16c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_5x16c8__neoni8mm(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-5x32c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-5x32c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_5x32c8__neoni8mm(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-5x8c4-minmax-neondotfp16arith.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-5x8c4-minmax-neondotfp16arith.c
@@ -68,6 +68,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_5x8c4__neondotfp16arith(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 8 columns.

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-5x8c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-5x8c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_5x8c8__neoni8mm(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-6x16-minmax-neonfp16arith-mlal-lane-prfm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-6x16-minmax-neonfp16arith-mlal-lane-prfm.c
@@ -42,6 +42,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_6x16__neonfp16arith_mlal_lane_prfm(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-6x16-minmax-neonfp16arith-mlal-lane.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-6x16-minmax-neonfp16arith-mlal-lane.c
@@ -41,6 +41,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_6x16__neonfp16arith_mlal_lane(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-6x16c4-minmax-neondotfp16arith.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-6x16c4-minmax-neondotfp16arith.c
@@ -74,6 +74,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_6x16c4__neondotfp16arith(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 16 columns.

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-6x16c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-6x16c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_6x16c8__neoni8mm(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-6x32c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-6x32c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_6x32c8__neoni8mm(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-6x8c4-minmax-neondotfp16arith.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-6x8c4-minmax-neondotfp16arith.c
@@ -74,6 +74,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_6x8c4__neondotfp16arith(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 8 columns.

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-6x8c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-6x8c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_6x8c8__neoni8mm(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-7x16c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-7x16c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_7x16c8__neoni8mm(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-7x32c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-7x32c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_7x32c8__neoni8mm(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-7x8c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-7x8c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_7x8c8__neoni8mm(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-8x16c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-8x16c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_8x16c8__neoni8mm(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-8x32c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-8x32c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_8x32c8__neoni8mm(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-8x8c8-minmax-neoni8mm.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-8x8c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_8x8c8__neoni8mm(
   size_t bl = params->fp16arith.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   uint16_t* c0 = (uint16_t*) c;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-10x16c8-minmax-avx512vnni-prfm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-10x16c8-minmax-avx512vnni-prfm.c
@@ -101,6 +101,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_10x16c8__avx512vnni_prfm(
   assert(bl != 0);
   assert(bl <= kc);
   assert(kc % bl == 0);
+  assert(bl % 32 == 0);
 
   const __m512 vinput_zero_point0 = _mm512_set1_ps((float) quantization_params[0].zero_point + 128);
   const __m512 vinput_zero_point1 = _mm512_set1_ps((float) quantization_params[1].zero_point + 128);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-10x16c8-minmax-avx512vnni.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-10x16c8-minmax-avx512vnni.c
@@ -100,6 +100,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_10x16c8__avx512vnni(
   assert(bl != 0);
   assert(bl <= kc);
   assert(kc % bl == 0);
+  assert(bl % 32 == 0);
 
   const __m512 vinput_zero_point0 = _mm512_set1_ps((float) quantization_params[0].zero_point + 128);
   const __m512 vinput_zero_point1 = _mm512_set1_ps((float) quantization_params[1].zero_point + 128);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-10x16c8-minmax-avx512vnnigfni-prfm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-10x16c8-minmax-avx512vnnigfni-prfm.c
@@ -101,6 +101,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_10x16c8__avx512vnnigfni_prfm(
   assert(bl != 0);
   assert(bl <= kc);
   assert(kc % bl == 0);
+  assert(bl % 32 == 0);
 
   const __m512 vinput_zero_point0 = _mm512_set1_ps((float) quantization_params[0].zero_point + 128);
   const __m512 vinput_zero_point1 = _mm512_set1_ps((float) quantization_params[1].zero_point + 128);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-10x16c8-minmax-avx512vnnigfni.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-10x16c8-minmax-avx512vnnigfni.c
@@ -100,6 +100,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_10x16c8__avx512vnnigfni(
   assert(bl != 0);
   assert(bl <= kc);
   assert(kc % bl == 0);
+  assert(bl % 32 == 0);
 
   const __m512 vinput_zero_point0 = _mm512_set1_ps((float) quantization_params[0].zero_point + 128);
   const __m512 vinput_zero_point1 = _mm512_set1_ps((float) quantization_params[1].zero_point + 128);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-12x16c8-minmax-avx512vnni-prfm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-12x16c8-minmax-avx512vnni-prfm.c
@@ -113,6 +113,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_12x16c8__avx512vnni_prfm(
   assert(bl != 0);
   assert(bl <= kc);
   assert(kc % bl == 0);
+  assert(bl % 32 == 0);
 
   const __m512 vinput_zero_point0 = _mm512_set1_ps((float) quantization_params[0].zero_point + 128);
   const __m512 vinput_zero_point1 = _mm512_set1_ps((float) quantization_params[1].zero_point + 128);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-12x16c8-minmax-avx512vnni.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-12x16c8-minmax-avx512vnni.c
@@ -112,6 +112,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_12x16c8__avx512vnni(
   assert(bl != 0);
   assert(bl <= kc);
   assert(kc % bl == 0);
+  assert(bl % 32 == 0);
 
   const __m512 vinput_zero_point0 = _mm512_set1_ps((float) quantization_params[0].zero_point + 128);
   const __m512 vinput_zero_point1 = _mm512_set1_ps((float) quantization_params[1].zero_point + 128);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-12x16c8-minmax-avx512vnnigfni-prfm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-12x16c8-minmax-avx512vnnigfni-prfm.c
@@ -113,6 +113,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_12x16c8__avx512vnnigfni_prfm(
   assert(bl != 0);
   assert(bl <= kc);
   assert(kc % bl == 0);
+  assert(bl % 32 == 0);
 
   const __m512 vinput_zero_point0 = _mm512_set1_ps((float) quantization_params[0].zero_point + 128);
   const __m512 vinput_zero_point1 = _mm512_set1_ps((float) quantization_params[1].zero_point + 128);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-12x16c8-minmax-avx512vnnigfni.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-12x16c8-minmax-avx512vnnigfni.c
@@ -112,6 +112,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_12x16c8__avx512vnnigfni(
   assert(bl != 0);
   assert(bl <= kc);
   assert(kc % bl == 0);
+  assert(bl % 32 == 0);
 
   const __m512 vinput_zero_point0 = _mm512_set1_ps((float) quantization_params[0].zero_point + 128);
   const __m512 vinput_zero_point1 = _mm512_set1_ps((float) quantization_params[1].zero_point + 128);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-14x16c8-minmax-avx512vnni-prfm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-14x16c8-minmax-avx512vnni-prfm.c
@@ -125,6 +125,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_14x16c8__avx512vnni_prfm(
   assert(bl != 0);
   assert(bl <= kc);
   assert(kc % bl == 0);
+  assert(bl % 32 == 0);
 
   const __m512 vinput_zero_point0 = _mm512_set1_ps((float) quantization_params[0].zero_point + 128);
   const __m512 vinput_zero_point1 = _mm512_set1_ps((float) quantization_params[1].zero_point + 128);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-14x16c8-minmax-avx512vnni.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-14x16c8-minmax-avx512vnni.c
@@ -124,6 +124,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_14x16c8__avx512vnni(
   assert(bl != 0);
   assert(bl <= kc);
   assert(kc % bl == 0);
+  assert(bl % 32 == 0);
 
   const __m512 vinput_zero_point0 = _mm512_set1_ps((float) quantization_params[0].zero_point + 128);
   const __m512 vinput_zero_point1 = _mm512_set1_ps((float) quantization_params[1].zero_point + 128);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-14x16c8-minmax-avx512vnnigfni-prfm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-14x16c8-minmax-avx512vnnigfni-prfm.c
@@ -125,6 +125,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_14x16c8__avx512vnnigfni_prfm(
   assert(bl != 0);
   assert(bl <= kc);
   assert(kc % bl == 0);
+  assert(bl % 32 == 0);
 
   const __m512 vinput_zero_point0 = _mm512_set1_ps((float) quantization_params[0].zero_point + 128);
   const __m512 vinput_zero_point1 = _mm512_set1_ps((float) quantization_params[1].zero_point + 128);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-14x16c8-minmax-avx512vnnigfni.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-14x16c8-minmax-avx512vnnigfni.c
@@ -124,6 +124,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_14x16c8__avx512vnnigfni(
   assert(bl != 0);
   assert(bl <= kc);
   assert(kc % bl == 0);
+  assert(bl % 32 == 0);
 
   const __m512 vinput_zero_point0 = _mm512_set1_ps((float) quantization_params[0].zero_point + 128);
   const __m512 vinput_zero_point1 = _mm512_set1_ps((float) quantization_params[1].zero_point + 128);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x16-minmax-neon-mlal-lane-prfm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x16-minmax-neon-mlal-lane-prfm.c
@@ -42,6 +42,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x16__neon_mlal_lane_prfm(
   size_t bl = params->scalar.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   const int8_t* a0 = a;
   float* c0 = c;
 

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x16-minmax-neon-mlal-lane.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x16-minmax-neon-mlal-lane.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x16__neon_mlal_lane(
   size_t bl = params->scalar.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   const int8_t* a0 = a;
   float* c0 = c;
 

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x16c4-minmax-neondot.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x16c4-minmax-neondot.c
@@ -44,6 +44,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x16c4__neondot(
   size_t bl = params->scalar.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 16 columns.

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x16c8-minmax-avx512vnni-prfm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x16c8-minmax-avx512vnni-prfm.c
@@ -47,6 +47,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x16c8__avx512vnni_prfm(
   assert(bl != 0);
   assert(bl <= kc);
   assert(kc % bl == 0);
+  assert(bl % 32 == 0);
 
   const __m512 vinput_zero_point0 = _mm512_set1_ps((float) quantization_params[0].zero_point + 128);
   const __m512 voutput_min = _mm512_set1_ps(params->avx512vnni.min);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x16c8-minmax-avx512vnni.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x16c8-minmax-avx512vnni.c
@@ -46,6 +46,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x16c8__avx512vnni(
   assert(bl != 0);
   assert(bl <= kc);
   assert(kc % bl == 0);
+  assert(bl % 32 == 0);
 
   const __m512 vinput_zero_point0 = _mm512_set1_ps((float) quantization_params[0].zero_point + 128);
   const __m512 voutput_min = _mm512_set1_ps(params->avx512vnni.min);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x16c8-minmax-avx512vnnigfni-prfm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x16c8-minmax-avx512vnnigfni-prfm.c
@@ -47,6 +47,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x16c8__avx512vnnigfni_prfm(
   assert(bl != 0);
   assert(bl <= kc);
   assert(kc % bl == 0);
+  assert(bl % 32 == 0);
 
   const __m512 vinput_zero_point0 = _mm512_set1_ps((float) quantization_params[0].zero_point + 128);
   const __m512 voutput_min = _mm512_set1_ps(params->avx512vnni.min);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x16c8-minmax-avx512vnnigfni.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x16c8-minmax-avx512vnnigfni.c
@@ -46,6 +46,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x16c8__avx512vnnigfni(
   assert(bl != 0);
   assert(bl <= kc);
   assert(kc % bl == 0);
+  assert(bl % 32 == 0);
 
   const __m512 vinput_zero_point0 = _mm512_set1_ps((float) quantization_params[0].zero_point + 128);
   const __m512 voutput_min = _mm512_set1_ps(params->avx512vnni.min);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x16c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x16c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x16c8__neoni8mm(
   size_t bl = params->scalar.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x2-minmax-scalar.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x2-minmax-scalar.c
@@ -34,6 +34,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x2__scalar(
   size_t bl = params->scalar.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
 
   const int8_t* a0 = a;
   float* c0 = c;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x32c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x32c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x32c8__neoni8mm(
   size_t bl = params->scalar.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x4-minmax-scalar.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x4-minmax-scalar.c
@@ -33,6 +33,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x4__scalar(
   size_t bl = params->scalar.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
 
   const int8_t* a0 = a;
   float* c0 = c;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x4c8-minmax-avx-ld128.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x4c8-minmax-avx-ld128.c
@@ -45,6 +45,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x4c8__avx_ld128(
   size_t bl = params->sse.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x4c8-minmax-avx-ld64.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x4c8-minmax-avx-ld64.c
@@ -45,6 +45,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x4c8__avx_ld64(
   size_t bl = params->sse.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x4c8-minmax-sse2-ld128.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x4c8-minmax-sse2-ld128.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x4c8__sse2_ld128(
   size_t bl = params->sse.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x4c8-minmax-sse2-ld64.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x4c8-minmax-sse2-ld64.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x4c8__sse2_ld64(
   size_t bl = params->sse.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x4c8-minmax-sse41-ld128.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x4c8-minmax-sse41-ld128.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x4c8__sse41_ld128(
   size_t bl = params->sse.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x4c8-minmax-sse41-ld64.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x4c8-minmax-sse41-ld64.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x4c8__sse41_ld64(
   size_t bl = params->sse.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x8-minmax-scalar.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x8-minmax-scalar.c
@@ -33,6 +33,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x8__scalar(
   size_t bl = params->scalar.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
 
   const int8_t* a0 = a;
   float* c0 = c;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x8c4-minmax-neondot.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x8c4-minmax-neondot.c
@@ -44,6 +44,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x8c4__neondot(
   size_t bl = params->scalar.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 8 columns.

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x8c8-minmax-avx2.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x8c8-minmax-avx2.c
@@ -43,6 +43,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x8c8__avx2(
   size_t bl = params->avx.blocksize;
   assert(bl <= round_up_po2(kc, 16));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   const int8_t* a0 = a;
   float* c0 = c;
 

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x8c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x8c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x8c8__neoni8mm(
   size_t bl = params->scalar.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x16-minmax-neon-mlal-lane-prfm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x16-minmax-neon-mlal-lane-prfm.c
@@ -42,6 +42,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x16__neon_mlal_lane_prfm(
   size_t bl = params->scalar.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   const int8_t* a0 = a;
   float* c0 = c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x16-minmax-neon-mlal-lane.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x16-minmax-neon-mlal-lane.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x16__neon_mlal_lane(
   size_t bl = params->scalar.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   const int8_t* a0 = a;
   float* c0 = c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x16c4-minmax-neondot.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x16c4-minmax-neondot.c
@@ -50,6 +50,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x16c4__neondot(
   size_t bl = params->scalar.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 16 columns.

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x16c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x16c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x16c8__neoni8mm(
   size_t bl = params->scalar.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x2-minmax-scalar.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x2-minmax-scalar.c
@@ -34,6 +34,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x2__scalar(
   size_t bl = params->scalar.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
 
   const int8_t* a0 = a;
   float* c0 = c;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x32c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x32c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x32c8__neoni8mm(
   size_t bl = params->scalar.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x4-minmax-scalar.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x4-minmax-scalar.c
@@ -33,6 +33,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x4__scalar(
   size_t bl = params->scalar.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
 
   const int8_t* a0 = a;
   float* c0 = c;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x4c8-minmax-avx-ld128.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x4c8-minmax-avx-ld128.c
@@ -45,6 +45,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x4c8__avx_ld128(
   size_t bl = params->sse.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x4c8-minmax-avx-ld64.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x4c8-minmax-avx-ld64.c
@@ -45,6 +45,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x4c8__avx_ld64(
   size_t bl = params->sse.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x4c8-minmax-sse2-ld128.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x4c8-minmax-sse2-ld128.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x4c8__sse2_ld128(
   size_t bl = params->sse.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x4c8-minmax-sse2-ld64.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x4c8-minmax-sse2-ld64.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x4c8__sse2_ld64(
   size_t bl = params->sse.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x4c8-minmax-sse41-ld128.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x4c8-minmax-sse41-ld128.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x4c8__sse41_ld128(
   size_t bl = params->sse.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x4c8-minmax-sse41-ld64.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x4c8-minmax-sse41-ld64.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x4c8__sse41_ld64(
   size_t bl = params->sse.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x8-minmax-scalar.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x8-minmax-scalar.c
@@ -33,6 +33,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x8__scalar(
   size_t bl = params->scalar.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
 
   const int8_t* a0 = a;
   float* c0 = c;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x8c4-minmax-neondot.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x8c4-minmax-neondot.c
@@ -50,6 +50,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x8c4__neondot(
   size_t bl = params->scalar.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 8 columns.

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x8c8-minmax-avx2.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x8c8-minmax-avx2.c
@@ -43,6 +43,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x8c8__avx2(
   size_t bl = params->avx.blocksize;
   assert(bl <= round_up_po2(kc, 16));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   const int8_t* a0 = a;
   float* c0 = c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x8c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x8c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x8c8__neoni8mm(
   size_t bl = params->scalar.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x16-minmax-neon-mlal-lane-prfm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x16-minmax-neon-mlal-lane-prfm.c
@@ -42,6 +42,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x16__neon_mlal_lane_prfm(
   size_t bl = params->scalar.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   const int8_t* a0 = a;
   float* c0 = c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x16-minmax-neon-mlal-lane.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x16-minmax-neon-mlal-lane.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x16__neon_mlal_lane(
   size_t bl = params->scalar.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   const int8_t* a0 = a;
   float* c0 = c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x16c4-minmax-neondot.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x16c4-minmax-neondot.c
@@ -56,6 +56,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x16c4__neondot(
   size_t bl = params->scalar.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 16 columns.

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x16c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x16c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x16c8__neoni8mm(
   size_t bl = params->scalar.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x32c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x32c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x32c8__neoni8mm(
   size_t bl = params->scalar.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x4c8-minmax-avx-ld128.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x4c8-minmax-avx-ld128.c
@@ -45,6 +45,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x4c8__avx_ld128(
   size_t bl = params->sse.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x4c8-minmax-avx-ld64.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x4c8-minmax-avx-ld64.c
@@ -45,6 +45,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x4c8__avx_ld64(
   size_t bl = params->sse.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x4c8-minmax-sse2-ld128.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x4c8-minmax-sse2-ld128.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x4c8__sse2_ld128(
   size_t bl = params->sse.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x4c8-minmax-sse2-ld64.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x4c8-minmax-sse2-ld64.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x4c8__sse2_ld64(
   size_t bl = params->sse.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x4c8-minmax-sse41-ld128.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x4c8-minmax-sse41-ld128.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x4c8__sse41_ld128(
   size_t bl = params->sse.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x4c8-minmax-sse41-ld64.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x4c8-minmax-sse41-ld64.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x4c8__sse41_ld64(
   size_t bl = params->sse.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x8c4-minmax-neondot.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x8c4-minmax-neondot.c
@@ -56,6 +56,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x8c4__neondot(
   size_t bl = params->scalar.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 8 columns.

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x8c8-minmax-avx2.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x8c8-minmax-avx2.c
@@ -43,6 +43,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x8c8__avx2(
   size_t bl = params->avx.blocksize;
   assert(bl <= round_up_po2(kc, 16));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   const int8_t* a0 = a;
   float* c0 = c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x8c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-3x8c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x8c8__neoni8mm(
   size_t bl = params->scalar.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x16-minmax-neon-mlal-lane-prfm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x16-minmax-neon-mlal-lane-prfm.c
@@ -42,6 +42,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x16__neon_mlal_lane_prfm(
   size_t bl = params->scalar.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   const int8_t* a0 = a;
   float* c0 = c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x16-minmax-neon-mlal-lane.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x16-minmax-neon-mlal-lane.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x16__neon_mlal_lane(
   size_t bl = params->scalar.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   const int8_t* a0 = a;
   float* c0 = c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x16c4-minmax-neondot.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x16c4-minmax-neondot.c
@@ -62,6 +62,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x16c4__neondot(
   size_t bl = params->scalar.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 16 columns.

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x16c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x16c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x16c8__neoni8mm(
   size_t bl = params->scalar.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x32c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x32c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x32c8__neoni8mm(
   size_t bl = params->scalar.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x4-minmax-scalar.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x4-minmax-scalar.c
@@ -33,6 +33,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x4__scalar(
   size_t bl = params->scalar.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
 
   const int8_t* a0 = a;
   float* c0 = c;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x4c8-minmax-avx-ld128.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x4c8-minmax-avx-ld128.c
@@ -45,6 +45,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x4c8__avx_ld128(
   size_t bl = params->sse.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x4c8-minmax-avx-ld64.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x4c8-minmax-avx-ld64.c
@@ -45,6 +45,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x4c8__avx_ld64(
   size_t bl = params->sse.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x4c8-minmax-sse2-ld128.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x4c8-minmax-sse2-ld128.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x4c8__sse2_ld128(
   size_t bl = params->sse.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x4c8-minmax-sse2-ld64.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x4c8-minmax-sse2-ld64.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x4c8__sse2_ld64(
   size_t bl = params->sse.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x4c8-minmax-sse41-ld128.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x4c8-minmax-sse41-ld128.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x4c8__sse41_ld128(
   size_t bl = params->sse.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x4c8-minmax-sse41-ld64.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x4c8-minmax-sse41-ld64.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x4c8__sse41_ld64(
   size_t bl = params->sse.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(int8_t));
   const int8_t* a0 = a;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x8c4-minmax-neondot.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x8c4-minmax-neondot.c
@@ -62,6 +62,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x8c4__neondot(
   size_t bl = params->scalar.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 8 columns.

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x8c8-minmax-avx2.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x8c8-minmax-avx2.c
@@ -43,6 +43,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x8c8__avx2(
   size_t bl = params->avx.blocksize;
   assert(bl <= round_up_po2(kc, 16));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   const int8_t* a0 = a;
   float* c0 = c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x8c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x8c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x8c8__neoni8mm(
   size_t bl = params->scalar.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-5x16c4-minmax-neondot.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-5x16c4-minmax-neondot.c
@@ -68,6 +68,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_5x16c4__neondot(
   size_t bl = params->scalar.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 16 columns.

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-5x16c8-minmax-avx512vnni-prfm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-5x16c8-minmax-avx512vnni-prfm.c
@@ -71,6 +71,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_5x16c8__avx512vnni_prfm(
   assert(bl != 0);
   assert(bl <= kc);
   assert(kc % bl == 0);
+  assert(bl % 32 == 0);
 
   const __m512 vinput_zero_point0 = _mm512_set1_ps((float) quantization_params[0].zero_point + 128);
   const __m512 vinput_zero_point1 = _mm512_set1_ps((float) quantization_params[1].zero_point + 128);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-5x16c8-minmax-avx512vnni.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-5x16c8-minmax-avx512vnni.c
@@ -70,6 +70,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_5x16c8__avx512vnni(
   assert(bl != 0);
   assert(bl <= kc);
   assert(kc % bl == 0);
+  assert(bl % 32 == 0);
 
   const __m512 vinput_zero_point0 = _mm512_set1_ps((float) quantization_params[0].zero_point + 128);
   const __m512 vinput_zero_point1 = _mm512_set1_ps((float) quantization_params[1].zero_point + 128);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-5x16c8-minmax-avx512vnnigfni-prfm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-5x16c8-minmax-avx512vnnigfni-prfm.c
@@ -71,6 +71,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_5x16c8__avx512vnnigfni_prfm(
   assert(bl != 0);
   assert(bl <= kc);
   assert(kc % bl == 0);
+  assert(bl % 32 == 0);
 
   const __m512 vinput_zero_point0 = _mm512_set1_ps((float) quantization_params[0].zero_point + 128);
   const __m512 vinput_zero_point1 = _mm512_set1_ps((float) quantization_params[1].zero_point + 128);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-5x16c8-minmax-avx512vnnigfni.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-5x16c8-minmax-avx512vnnigfni.c
@@ -70,6 +70,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_5x16c8__avx512vnnigfni(
   assert(bl != 0);
   assert(bl <= kc);
   assert(kc % bl == 0);
+  assert(bl % 32 == 0);
 
   const __m512 vinput_zero_point0 = _mm512_set1_ps((float) quantization_params[0].zero_point + 128);
   const __m512 vinput_zero_point1 = _mm512_set1_ps((float) quantization_params[1].zero_point + 128);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-5x16c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-5x16c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_5x16c8__neoni8mm(
   size_t bl = params->scalar.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-5x32c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-5x32c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_5x32c8__neoni8mm(
   size_t bl = params->scalar.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-5x8c4-minmax-neondot.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-5x8c4-minmax-neondot.c
@@ -68,6 +68,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_5x8c4__neondot(
   size_t bl = params->scalar.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 8 columns.

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-5x8c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-5x8c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_5x8c8__neoni8mm(
   size_t bl = params->scalar.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-6x16-minmax-neon-mlal-lane-prfm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-6x16-minmax-neon-mlal-lane-prfm.c
@@ -42,6 +42,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_6x16__neon_mlal_lane_prfm(
   size_t bl = params->scalar.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   const int8_t* a0 = a;
   float* c0 = c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-6x16-minmax-neon-mlal-lane.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-6x16-minmax-neon-mlal-lane.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_6x16__neon_mlal_lane(
   size_t bl = params->scalar.blocksize;
   assert(bl <= round_up_po2(kc, 2));
   assert(bl != 0);
+  assert(bl % 32 == 0);
   const int8_t* a0 = a;
   float* c0 = c;
   const int8_t* a1 = (const int8_t*) ((uintptr_t) a0 + a_stride);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-6x16c4-minmax-neondot.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-6x16c4-minmax-neondot.c
@@ -74,6 +74,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_6x16c4__neondot(
   size_t bl = params->scalar.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 16 columns.

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-6x16c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-6x16c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_6x16c8__neoni8mm(
   size_t bl = params->scalar.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-6x32c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-6x32c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_6x32c8__neoni8mm(
   size_t bl = params->scalar.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-6x8c4-minmax-neondot.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-6x8c4-minmax-neondot.c
@@ -74,6 +74,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_6x8c4__neondot(
   size_t bl = params->scalar.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));
   // Loop over groups of 8 columns.

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-6x8c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-6x8c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_6x8c8__neoni8mm(
   size_t bl = params->scalar.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-7x16c8-minmax-avx512vnni-prfm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-7x16c8-minmax-avx512vnni-prfm.c
@@ -83,6 +83,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_7x16c8__avx512vnni_prfm(
   assert(bl != 0);
   assert(bl <= kc);
   assert(kc % bl == 0);
+  assert(bl % 32 == 0);
 
   const __m512 vinput_zero_point0 = _mm512_set1_ps((float) quantization_params[0].zero_point + 128);
   const __m512 vinput_zero_point1 = _mm512_set1_ps((float) quantization_params[1].zero_point + 128);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-7x16c8-minmax-avx512vnni.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-7x16c8-minmax-avx512vnni.c
@@ -82,6 +82,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_7x16c8__avx512vnni(
   assert(bl != 0);
   assert(bl <= kc);
   assert(kc % bl == 0);
+  assert(bl % 32 == 0);
 
   const __m512 vinput_zero_point0 = _mm512_set1_ps((float) quantization_params[0].zero_point + 128);
   const __m512 vinput_zero_point1 = _mm512_set1_ps((float) quantization_params[1].zero_point + 128);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-7x16c8-minmax-avx512vnnigfni-prfm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-7x16c8-minmax-avx512vnnigfni-prfm.c
@@ -83,6 +83,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_7x16c8__avx512vnnigfni_prfm(
   assert(bl != 0);
   assert(bl <= kc);
   assert(kc % bl == 0);
+  assert(bl % 32 == 0);
 
   const __m512 vinput_zero_point0 = _mm512_set1_ps((float) quantization_params[0].zero_point + 128);
   const __m512 vinput_zero_point1 = _mm512_set1_ps((float) quantization_params[1].zero_point + 128);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-7x16c8-minmax-avx512vnnigfni.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-7x16c8-minmax-avx512vnnigfni.c
@@ -82,6 +82,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_7x16c8__avx512vnnigfni(
   assert(bl != 0);
   assert(bl <= kc);
   assert(kc % bl == 0);
+  assert(bl % 32 == 0);
 
   const __m512 vinput_zero_point0 = _mm512_set1_ps((float) quantization_params[0].zero_point + 128);
   const __m512 vinput_zero_point1 = _mm512_set1_ps((float) quantization_params[1].zero_point + 128);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-7x16c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-7x16c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_7x16c8__neoni8mm(
   size_t bl = params->scalar.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-7x32c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-7x32c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_7x32c8__neoni8mm(
   size_t bl = params->scalar.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-7x8c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-7x8c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_7x8c8__neoni8mm(
   size_t bl = params->scalar.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-8x16c8-minmax-avx512vnni-prfm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-8x16c8-minmax-avx512vnni-prfm.c
@@ -89,6 +89,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_8x16c8__avx512vnni_prfm(
   assert(bl != 0);
   assert(bl <= kc);
   assert(kc % bl == 0);
+  assert(bl % 32 == 0);
 
   const __m512 vinput_zero_point0 = _mm512_set1_ps((float) quantization_params[0].zero_point + 128);
   const __m512 vinput_zero_point1 = _mm512_set1_ps((float) quantization_params[1].zero_point + 128);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-8x16c8-minmax-avx512vnni.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-8x16c8-minmax-avx512vnni.c
@@ -88,6 +88,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_8x16c8__avx512vnni(
   assert(bl != 0);
   assert(bl <= kc);
   assert(kc % bl == 0);
+  assert(bl % 32 == 0);
 
   const __m512 vinput_zero_point0 = _mm512_set1_ps((float) quantization_params[0].zero_point + 128);
   const __m512 vinput_zero_point1 = _mm512_set1_ps((float) quantization_params[1].zero_point + 128);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-8x16c8-minmax-avx512vnnigfni-prfm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-8x16c8-minmax-avx512vnnigfni-prfm.c
@@ -89,6 +89,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_8x16c8__avx512vnnigfni_prfm(
   assert(bl != 0);
   assert(bl <= kc);
   assert(kc % bl == 0);
+  assert(bl % 32 == 0);
 
   const __m512 vinput_zero_point0 = _mm512_set1_ps((float) quantization_params[0].zero_point + 128);
   const __m512 vinput_zero_point1 = _mm512_set1_ps((float) quantization_params[1].zero_point + 128);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-8x16c8-minmax-avx512vnnigfni.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-8x16c8-minmax-avx512vnnigfni.c
@@ -88,6 +88,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_8x16c8__avx512vnnigfni(
   assert(bl != 0);
   assert(bl <= kc);
   assert(kc % bl == 0);
+  assert(bl % 32 == 0);
 
   const __m512 vinput_zero_point0 = _mm512_set1_ps((float) quantization_params[0].zero_point + 128);
   const __m512 vinput_zero_point1 = _mm512_set1_ps((float) quantization_params[1].zero_point + 128);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-8x16c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-8x16c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_8x16c8__neoni8mm(
   size_t bl = params->scalar.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-8x32c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-8x32c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_8x32c8__neoni8mm(
   size_t bl = params->scalar.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-8x8c8-minmax-neoni8mm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-8x8c8-minmax-neoni8mm.c
@@ -41,6 +41,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_8x8c8__neoni8mm(
   size_t bl = params->scalar.blocksize;
   assert(bl <= kc);
   assert(bl != 0);
+  assert(bl % 32 == 0);
   size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   float* c0 = c;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-9x16c8-minmax-avx512vnni-prfm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-9x16c8-minmax-avx512vnni-prfm.c
@@ -95,6 +95,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_9x16c8__avx512vnni_prfm(
   assert(bl != 0);
   assert(bl <= kc);
   assert(kc % bl == 0);
+  assert(bl % 32 == 0);
 
   const __m512 vinput_zero_point0 = _mm512_set1_ps((float) quantization_params[0].zero_point + 128);
   const __m512 vinput_zero_point1 = _mm512_set1_ps((float) quantization_params[1].zero_point + 128);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-9x16c8-minmax-avx512vnni.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-9x16c8-minmax-avx512vnni.c
@@ -94,6 +94,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_9x16c8__avx512vnni(
   assert(bl != 0);
   assert(bl <= kc);
   assert(kc % bl == 0);
+  assert(bl % 32 == 0);
 
   const __m512 vinput_zero_point0 = _mm512_set1_ps((float) quantization_params[0].zero_point + 128);
   const __m512 vinput_zero_point1 = _mm512_set1_ps((float) quantization_params[1].zero_point + 128);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-9x16c8-minmax-avx512vnnigfni-prfm.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-9x16c8-minmax-avx512vnnigfni-prfm.c
@@ -95,6 +95,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_9x16c8__avx512vnnigfni_prfm(
   assert(bl != 0);
   assert(bl <= kc);
   assert(kc % bl == 0);
+  assert(bl % 32 == 0);
 
   const __m512 vinput_zero_point0 = _mm512_set1_ps((float) quantization_params[0].zero_point + 128);
   const __m512 vinput_zero_point1 = _mm512_set1_ps((float) quantization_params[1].zero_point + 128);

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-9x16c8-minmax-avx512vnnigfni.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-9x16c8-minmax-avx512vnnigfni.c
@@ -94,6 +94,7 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_9x16c8__avx512vnnigfni(
   assert(bl != 0);
   assert(bl <= kc);
   assert(kc % bl == 0);
+  assert(bl % 32 == 0);
 
   const __m512 vinput_zero_point0 = _mm512_set1_ps((float) quantization_params[0].zero_point + 128);
   const __m512 vinput_zero_point1 = _mm512_set1_ps((float) quantization_params[1].zero_point + 128);

--- a/src/qs8-gemm/MRx16c8-avx512vnni.c.in
+++ b/src/qs8-gemm/MRx16c8-avx512vnni.c.in
@@ -99,6 +99,7 @@ void xnn_${DATATYPE_SPEC}_gemm_minmax${REQUANTIZATION_SPEC}_ukernel_${MR}x16c8__
     assert(bl != 0);
     assert(bl <= kc);
     assert(kc % bl == 0);
+    assert(bl % 32 == 0);
 
   $if DATATYPE in ["QD8", "QC4", "QB4"]:
     $for M in range(MR):

--- a/src/qs8-gemm/MRx4c8-sse.c.in
+++ b/src/qs8-gemm/MRx4c8-sse.c.in
@@ -90,6 +90,7 @@ void xnn_${DATATYPE_SPEC}_gemm${GEMM_SUFFIX}_minmax${REQUANTIZATION_SPEC}_ukerne
     size_t bl = params->sse.blocksize;
     assert(bl <= round_up_po2(kc, 2));
     assert(bl != 0);
+    assert(bl % 32 == 0);
     size_t n_blocks = kc / bl;
   kc = round_up_po2(kc, 8 * sizeof(${XINT8_T}));
   const ${XINT8_T}* a0 = a;

--- a/src/qs8-gemm/MRx8c8-avx2.c.in
+++ b/src/qs8-gemm/MRx8c8-avx2.c.in
@@ -76,6 +76,7 @@ void xnn_${DATATYPE_SPEC}_gemm_minmax${REQUANTIZATION_SPEC}_ukernel_${MR}x8c8__$
     size_t bl = params->avx.blocksize;
     assert(bl <= round_up_po2(kc, 16));
     assert(bl != 0);
+    assert(bl % 32 == 0);
   const ${XINT8_T}* a0 = a;
   $if DATATYPE in ["QD8_F16", "QC4_F16", "QB4_F16"]:
     uint16_t* c0 = (uint16_t*) c;

--- a/src/qs8-gemm/c4-neondot.c.in
+++ b/src/qs8-gemm/c4-neondot.c.in
@@ -105,6 +105,7 @@ void xnn_${DATATYPE_SPEC}_gemm_minmax${REQUANTIZATION_SPEC}_ukernel_${MR}x${NR}c
       size_t bl = params->scalar.blocksize;
     assert(bl <= kc);
     assert(bl != 0);
+    assert(bl % 32 == 0);
     size_t n_blocks = kc / bl;
   $if DATATYPE in ["QC4_F16", "QC4_F32", "QB4_F16", "QB4_F32"]:
     const int8x16_t vmask = vmovq_n_s8(INT8_C(0xF0));

--- a/src/qs8-gemm/c8-neoni8mm.c.in
+++ b/src/qs8-gemm/c8-neoni8mm.c.in
@@ -76,6 +76,7 @@ void xnn_${DATATYPE_SPEC}_gemm_minmax${REQUANTIZATION_SPEC}_ukernel_${MR}x${NR}c
       size_t bl = params->scalar.blocksize;
     assert(bl <= kc);
     assert(bl != 0);
+    assert(bl % 32 == 0);
     size_t n_blocks = kc / bl;
   const int8_t* a0 = a;
   $if DATATYPE in ["QD8_F16", "QC4_F16", "QB4_F16"]:

--- a/src/qs8-gemm/neon-mlal-lane.c.in
+++ b/src/qs8-gemm/neon-mlal-lane.c.in
@@ -108,6 +108,7 @@ void xnn_${DATATYPE_SPEC}_gemm_minmax${REQUANTIZATION_SPEC}_ukernel_${MR}x${NR}_
       size_t bl = params->scalar.blocksize;
     assert(bl <= round_up_po2(kc, 2));
     assert(bl != 0);
+    assert(bl % 32 == 0);
   const ${XINT8_T}* a0 = a;
   $if DATATYPE in ["QC4_F16", "QB4_F16"]:
     uint16_t* c0 = (uint16_t*) c;

--- a/src/qs8-gemm/scalar.c.in
+++ b/src/qs8-gemm/scalar.c.in
@@ -74,6 +74,7 @@ void xnn_${DATATYPE_SPEC}_gemm_minmax${REQUANTIZATION_SPEC}_ukernel_${MR}x${NR}_
       size_t bl = params->scalar.blocksize;
     assert(bl <= round_up_po2(kc, 2));
     assert(bl != 0);
+    assert(bl % 32 == 0);
 
   const ${XINT8_T}* a0 = a;
   ${OUT_T}* c0 = c;

--- a/test/qd8-f16-qb4w-gemm-minmax.cc
+++ b/test/qd8-f16-qb4w-gemm-minmax.cc
@@ -53,7 +53,7 @@ std::vector<GemmTestParams> CreateTests1(
       tester.clone()
           .m(mr).n(nr).k(k_block)
           .b_zero_point(8)
-          .bl(kr * sr * 2)
+          .bl(32)
       , test_func, isa_check));
   gemm_tests.push_back(GemmTestParams(
       "strided_cn",
@@ -61,7 +61,7 @@ std::vector<GemmTestParams> CreateTests1(
           .m(mr).n(nr).k(k_block)
           .cn_stride(xnnpack::NextPrime(nr + 1))
           .b_zero_point(8)
-          .bl(kr * sr * 2)
+          .bl(32)
     , test_func, isa_check));
   if (!is_igemm) {
     gemm_tests.push_back(GemmTestParams(
@@ -70,7 +70,7 @@ std::vector<GemmTestParams> CreateTests1(
             .m(mr).n(nr).k(k_block)
             .a_stride(xnnpack::NextPrime(k_block + 1))
             .b_zero_point(8)
-            .bl(kr * sr * 2)
+            .bl(32)
         , test_func, isa_check));
   }
   gemm_tests.push_back(GemmTestParams(
@@ -78,7 +78,7 @@ std::vector<GemmTestParams> CreateTests1(
       tester.clone()
           .k(k_block).iterations(1)
           .b_zero_point(8)
-          .bl(kr * sr * 2)
+          .bl(32)
       , test_func, isa_check)
       .loop_n(1, nr)
       .loop_m(1, mr));
@@ -87,7 +87,7 @@ std::vector<GemmTestParams> CreateTests1(
       tester.clone()
           .n(nr).k(k_block).iterations(1)
           .b_zero_point(8)
-          .bl(kr * sr * 2)
+          .bl(32)
       , test_func, isa_check)
       .loop_m(1, mr));
   gemm_tests.push_back(GemmTestParams(
@@ -95,7 +95,7 @@ std::vector<GemmTestParams> CreateTests1(
       tester.clone()
           .m(mr).k(k_block).iterations(1)
           .b_zero_point(8)
-          .bl(kr * sr * 2)
+          .bl(32)
       , test_func, isa_check)
       .loop_n(1, nr));
   gemm_tests.push_back(GemmTestParams(
@@ -105,7 +105,7 @@ std::vector<GemmTestParams> CreateTests1(
           .b_zero_point(8)
       , test_func, isa_check)
       .loop_k(k_block, k_block * 12, k_block, LoopStepType::Linear)
-      .loop_bl(2 * kr * sr, k_block * 12, 2 * kr * sr));
+      .loop_bl(32, k_block * 32, 32));
 
   return gemm_tests;
 }
@@ -116,8 +116,8 @@ std::vector<GemmTestParams> CreateTests1(
 INSTANTIATE_TEST_SUITE_P(
     QD8_F16_QB4W_GEMM_MINMAX_1X2__SCALAR, GemmTest,
     testing::ValuesIn(CreateTests1(
-        /*k_block=*/2,
-        /*adj_k_block=*/2,
+        /*k_block=*/32,
+        /*adj_k_block=*/32,
         /*mr=*/1, /*nr=*/2, /*kr=*/1, /*sr=*/1,
         /*is_igemm=*/false,
         [](GemmMicrokernelTester& tester) {
@@ -133,8 +133,8 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     QD8_F16_QB4W_GEMM_MINMAX_1X4__SCALAR, GemmTest,
     testing::ValuesIn(CreateTests1(
-        /*k_block=*/2,
-        /*adj_k_block=*/2,
+        /*k_block=*/32,
+        /*adj_k_block=*/32,
         /*mr=*/1, /*nr=*/4, /*kr=*/1, /*sr=*/1,
         /*is_igemm=*/false,
         [](GemmMicrokernelTester& tester) {
@@ -150,8 +150,8 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     QD8_F16_QB4W_GEMM_MINMAX_1X8__SCALAR, GemmTest,
     testing::ValuesIn(CreateTests1(
-        /*k_block=*/2,
-        /*adj_k_block=*/2,
+        /*k_block=*/32,
+        /*adj_k_block=*/32,
         /*mr=*/1, /*nr=*/8, /*kr=*/1, /*sr=*/1,
         /*is_igemm=*/false,
         [](GemmMicrokernelTester& tester) {
@@ -167,8 +167,8 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     QD8_F16_QB4W_GEMM_MINMAX_2X2__SCALAR, GemmTest,
     testing::ValuesIn(CreateTests1(
-        /*k_block=*/2,
-        /*adj_k_block=*/2,
+        /*k_block=*/32,
+        /*adj_k_block=*/32,
         /*mr=*/2, /*nr=*/2, /*kr=*/1, /*sr=*/1,
         /*is_igemm=*/false,
         [](GemmMicrokernelTester& tester) {
@@ -184,8 +184,8 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     QD8_F16_QB4W_GEMM_MINMAX_2X4__SCALAR, GemmTest,
     testing::ValuesIn(CreateTests1(
-        /*k_block=*/2,
-        /*adj_k_block=*/2,
+        /*k_block=*/32,
+        /*adj_k_block=*/32,
         /*mr=*/2, /*nr=*/4, /*kr=*/1, /*sr=*/1,
         /*is_igemm=*/false,
         [](GemmMicrokernelTester& tester) {
@@ -201,8 +201,8 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     QD8_F16_QB4W_GEMM_MINMAX_2X8__SCALAR, GemmTest,
     testing::ValuesIn(CreateTests1(
-        /*k_block=*/2,
-        /*adj_k_block=*/2,
+        /*k_block=*/32,
+        /*adj_k_block=*/32,
         /*mr=*/2, /*nr=*/8, /*kr=*/1, /*sr=*/1,
         /*is_igemm=*/false,
         [](GemmMicrokernelTester& tester) {
@@ -218,8 +218,8 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     QD8_F16_QB4W_GEMM_MINMAX_4X4__SCALAR, GemmTest,
     testing::ValuesIn(CreateTests1(
-        /*k_block=*/2,
-        /*adj_k_block=*/2,
+        /*k_block=*/32,
+        /*adj_k_block=*/32,
         /*mr=*/4, /*nr=*/4, /*kr=*/1, /*sr=*/1,
         /*is_igemm=*/false,
         [](GemmMicrokernelTester& tester) {
@@ -236,8 +236,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_1X8C4__NEONDOTFP16ARITH, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/1, /*nr=*/8, /*kr=*/4, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -255,8 +255,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_1X16C4__NEONDOTFP16ARITH, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/1, /*nr=*/16, /*kr=*/4, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -274,8 +274,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_2X8C4__NEONDOTFP16ARITH, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/2, /*nr=*/8, /*kr=*/4, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -293,8 +293,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_2X16C4__NEONDOTFP16ARITH, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/2, /*nr=*/16, /*kr=*/4, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -312,8 +312,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_3X8C4__NEONDOTFP16ARITH, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/3, /*nr=*/8, /*kr=*/4, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -331,8 +331,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_3X16C4__NEONDOTFP16ARITH, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/3, /*nr=*/16, /*kr=*/4, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -350,8 +350,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_4X8C4__NEONDOTFP16ARITH, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/4, /*nr=*/8, /*kr=*/4, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -369,8 +369,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_4X16C4__NEONDOTFP16ARITH, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/4, /*nr=*/16, /*kr=*/4, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -388,8 +388,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_5X8C4__NEONDOTFP16ARITH, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/5, /*nr=*/8, /*kr=*/4, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -407,8 +407,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_5X16C4__NEONDOTFP16ARITH, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/5, /*nr=*/16, /*kr=*/4, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -426,8 +426,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_6X8C4__NEONDOTFP16ARITH, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/6, /*nr=*/8, /*kr=*/4, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -445,8 +445,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_6X16C4__NEONDOTFP16ARITH, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/6, /*nr=*/16, /*kr=*/4, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -467,8 +467,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_1X8C8__AVX2, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/1, /*nr=*/8, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -486,8 +486,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_2X8C8__AVX2, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/2, /*nr=*/8, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -505,8 +505,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_3X8C8__AVX2, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/3, /*nr=*/8, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -524,8 +524,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_4X8C8__AVX2, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/4, /*nr=*/8, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -546,8 +546,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_1X16__NEONFP16ARITH_MLAL_LANE, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/1, /*nr=*/16, /*kr=*/1, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -565,8 +565,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_2X16__NEONFP16ARITH_MLAL_LANE, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/2, /*nr=*/16, /*kr=*/1, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -584,8 +584,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_3X16__NEONFP16ARITH_MLAL_LANE, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/3, /*nr=*/16, /*kr=*/1, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -603,8 +603,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_4X16__NEONFP16ARITH_MLAL_LANE, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/4, /*nr=*/16, /*kr=*/1, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -622,8 +622,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_6X16__NEONFP16ARITH_MLAL_LANE, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/6, /*nr=*/16, /*kr=*/1, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -641,8 +641,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_1X16__NEONFP16ARITH_MLAL_LANE_PRFM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/1, /*nr=*/16, /*kr=*/1, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -660,8 +660,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_2X16__NEONFP16ARITH_MLAL_LANE_PRFM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/2, /*nr=*/16, /*kr=*/1, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -679,8 +679,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_3X16__NEONFP16ARITH_MLAL_LANE_PRFM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/3, /*nr=*/16, /*kr=*/1, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -698,8 +698,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_4X16__NEONFP16ARITH_MLAL_LANE_PRFM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/4, /*nr=*/16, /*kr=*/1, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -717,8 +717,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_6X16__NEONFP16ARITH_MLAL_LANE_PRFM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/6, /*nr=*/16, /*kr=*/1, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -739,8 +739,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_1X8C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/1, /*nr=*/8, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -758,8 +758,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_1X16C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/1, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -777,8 +777,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_1X32C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/1, /*nr=*/32, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -796,8 +796,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_2X8C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/2, /*nr=*/8, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -815,8 +815,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_2X16C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/2, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -834,8 +834,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_2X32C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/2, /*nr=*/32, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -853,8 +853,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_3X8C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/3, /*nr=*/8, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -872,8 +872,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_3X16C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/3, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -891,8 +891,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_3X32C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/3, /*nr=*/32, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -910,8 +910,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_4X8C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/4, /*nr=*/8, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -929,8 +929,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_4X16C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/4, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -948,8 +948,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_4X32C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/4, /*nr=*/32, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -967,8 +967,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_5X8C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/5, /*nr=*/8, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -986,8 +986,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_5X16C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/5, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1005,8 +1005,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_5X32C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/5, /*nr=*/32, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1024,8 +1024,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_6X8C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/6, /*nr=*/8, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1043,8 +1043,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_6X16C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/6, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1062,8 +1062,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_6X32C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/6, /*nr=*/32, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1081,8 +1081,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_7X8C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/7, /*nr=*/8, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1100,8 +1100,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_7X16C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/7, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1119,8 +1119,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_7X32C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/7, /*nr=*/32, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1138,8 +1138,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_8X8C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/8, /*nr=*/8, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1157,8 +1157,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_8X16C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/8, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1176,8 +1176,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F16_QB4W_GEMM_MINMAX_8X32C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/8, /*nr=*/32, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {

--- a/test/qd8-f16-qb4w-gemm-minmax.yaml
+++ b/test/qd8-f16-qb4w-gemm-minmax.yaml
@@ -7,254 +7,254 @@
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x2__scalar
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 2
+  k-block: 32
 
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x4__scalar
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 2
+  k-block: 32
 
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x8__scalar
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 2
+  k-block: 32
 
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x2__scalar
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 2
+  k-block: 32
 
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x4__scalar
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 2
+  k-block: 32
 
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x8__scalar
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 2
+  k-block: 32
 
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x4__scalar
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 2
+  k-block: 32
 
 # ARM NEONDOT
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x8c4__neondotfp16arith
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x16c4__neondotfp16arith
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x8c4__neondotfp16arith
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x16c4__neondotfp16arith
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_3x8c4__neondotfp16arith
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_3x16c4__neondotfp16arith
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x8c4__neondotfp16arith
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x16c4__neondotfp16arith
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_5x8c4__neondotfp16arith
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_5x16c4__neondotfp16arith
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_6x8c4__neondotfp16arith
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_6x16c4__neondotfp16arith
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 
 # x86 AVX2
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x8c8__avx2
   init: xnn_init_f16_qb4w_minmax_avx_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x8c8__avx2
   init: xnn_init_f16_qb4w_minmax_avx_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_3x8c8__avx2
   init: xnn_init_f16_qb4w_minmax_avx_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x8c8__avx2
   init: xnn_init_f16_qb4w_minmax_avx_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 
 # ARM NEON
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x16__neonfp16arith_mlal_lane
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x16__neonfp16arith_mlal_lane
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_3x16__neonfp16arith_mlal_lane
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x16__neonfp16arith_mlal_lane
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_6x16__neonfp16arith_mlal_lane
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x16__neonfp16arith_mlal_lane_prfm
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x16__neonfp16arith_mlal_lane_prfm
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_3x16__neonfp16arith_mlal_lane_prfm
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x16__neonfp16arith_mlal_lane_prfm
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_6x16__neonfp16arith_mlal_lane_prfm
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 
 # ARM NEONI8MM
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x8c8__neoni8mm
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x16c8__neoni8mm
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x32c8__neoni8mm
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x8c8__neoni8mm
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x16c8__neoni8mm
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x32c8__neoni8mm
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_3x8c8__neoni8mm
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_3x16c8__neoni8mm
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_3x32c8__neoni8mm
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x8c8__neoni8mm
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x16c8__neoni8mm
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x32c8__neoni8mm
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_5x8c8__neoni8mm
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_5x16c8__neoni8mm
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_5x32c8__neoni8mm
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_6x8c8__neoni8mm
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_6x16c8__neoni8mm
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_6x32c8__neoni8mm
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_7x8c8__neoni8mm
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_7x16c8__neoni8mm
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_7x32c8__neoni8mm
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_8x8c8__neoni8mm
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_8x16c8__neoni8mm
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f16_qb4w_gemm_minmax_ukernel_8x32c8__neoni8mm
   init: xnn_init_f16_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32

--- a/test/qd8-f32-qb4w-gemm-minmax.cc
+++ b/test/qd8-f32-qb4w-gemm-minmax.cc
@@ -53,7 +53,7 @@ std::vector<GemmTestParams> CreateTests1(
       tester.clone()
           .m(mr).n(nr).k(k_block)
           .b_zero_point(8)
-          .bl(kr * sr * 2)
+          .bl(32)
       , test_func, isa_check));
   gemm_tests.push_back(GemmTestParams(
       "strided_cn",
@@ -61,7 +61,7 @@ std::vector<GemmTestParams> CreateTests1(
           .m(mr).n(nr).k(k_block)
           .cn_stride(xnnpack::NextPrime(nr + 1))
           .b_zero_point(8)
-          .bl(kr * sr * 2)
+          .bl(32)
     , test_func, isa_check));
   if (!is_igemm) {
     gemm_tests.push_back(GemmTestParams(
@@ -70,7 +70,7 @@ std::vector<GemmTestParams> CreateTests1(
             .m(mr).n(nr).k(k_block)
             .a_stride(xnnpack::NextPrime(k_block + 1))
             .b_zero_point(8)
-            .bl(kr * sr * 2)
+            .bl(32)
         , test_func, isa_check));
   }
   gemm_tests.push_back(GemmTestParams(
@@ -78,7 +78,7 @@ std::vector<GemmTestParams> CreateTests1(
       tester.clone()
           .k(k_block).iterations(1)
           .b_zero_point(8)
-          .bl(kr * sr * 2)
+          .bl(32)
       , test_func, isa_check)
       .loop_n(1, nr)
       .loop_m(1, mr));
@@ -87,7 +87,7 @@ std::vector<GemmTestParams> CreateTests1(
       tester.clone()
           .n(nr).k(k_block).iterations(1)
           .b_zero_point(8)
-          .bl(kr * sr * 2)
+          .bl(32)
       , test_func, isa_check)
       .loop_m(1, mr));
   gemm_tests.push_back(GemmTestParams(
@@ -95,7 +95,7 @@ std::vector<GemmTestParams> CreateTests1(
       tester.clone()
           .m(mr).k(k_block).iterations(1)
           .b_zero_point(8)
-          .bl(kr * sr * 2)
+          .bl(32)
       , test_func, isa_check)
       .loop_n(1, nr));
   gemm_tests.push_back(GemmTestParams(
@@ -105,7 +105,7 @@ std::vector<GemmTestParams> CreateTests1(
           .b_zero_point(8)
       , test_func, isa_check)
       .loop_k(k_block, k_block * 12, k_block, LoopStepType::Linear)
-      .loop_bl(2 * kr * sr, k_block * 12, 2 * kr * sr));
+      .loop_bl(32, k_block * 32, 32));
 
   return gemm_tests;
 }
@@ -116,8 +116,8 @@ std::vector<GemmTestParams> CreateTests1(
 INSTANTIATE_TEST_SUITE_P(
     QD8_F32_QB4W_GEMM_MINMAX_1X2__SCALAR, GemmTest,
     testing::ValuesIn(CreateTests1(
-        /*k_block=*/2,
-        /*adj_k_block=*/2,
+        /*k_block=*/32,
+        /*adj_k_block=*/32,
         /*mr=*/1, /*nr=*/2, /*kr=*/1, /*sr=*/1,
         /*is_igemm=*/false,
         [](GemmMicrokernelTester& tester) {
@@ -133,8 +133,8 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     QD8_F32_QB4W_GEMM_MINMAX_1X4__SCALAR, GemmTest,
     testing::ValuesIn(CreateTests1(
-        /*k_block=*/2,
-        /*adj_k_block=*/2,
+        /*k_block=*/32,
+        /*adj_k_block=*/32,
         /*mr=*/1, /*nr=*/4, /*kr=*/1, /*sr=*/1,
         /*is_igemm=*/false,
         [](GemmMicrokernelTester& tester) {
@@ -150,8 +150,8 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     QD8_F32_QB4W_GEMM_MINMAX_1X8__SCALAR, GemmTest,
     testing::ValuesIn(CreateTests1(
-        /*k_block=*/2,
-        /*adj_k_block=*/2,
+        /*k_block=*/32,
+        /*adj_k_block=*/32,
         /*mr=*/1, /*nr=*/8, /*kr=*/1, /*sr=*/1,
         /*is_igemm=*/false,
         [](GemmMicrokernelTester& tester) {
@@ -167,8 +167,8 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     QD8_F32_QB4W_GEMM_MINMAX_2X2__SCALAR, GemmTest,
     testing::ValuesIn(CreateTests1(
-        /*k_block=*/2,
-        /*adj_k_block=*/2,
+        /*k_block=*/32,
+        /*adj_k_block=*/32,
         /*mr=*/2, /*nr=*/2, /*kr=*/1, /*sr=*/1,
         /*is_igemm=*/false,
         [](GemmMicrokernelTester& tester) {
@@ -184,8 +184,8 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     QD8_F32_QB4W_GEMM_MINMAX_2X4__SCALAR, GemmTest,
     testing::ValuesIn(CreateTests1(
-        /*k_block=*/2,
-        /*adj_k_block=*/2,
+        /*k_block=*/32,
+        /*adj_k_block=*/32,
         /*mr=*/2, /*nr=*/4, /*kr=*/1, /*sr=*/1,
         /*is_igemm=*/false,
         [](GemmMicrokernelTester& tester) {
@@ -201,8 +201,8 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     QD8_F32_QB4W_GEMM_MINMAX_2X8__SCALAR, GemmTest,
     testing::ValuesIn(CreateTests1(
-        /*k_block=*/2,
-        /*adj_k_block=*/2,
+        /*k_block=*/32,
+        /*adj_k_block=*/32,
         /*mr=*/2, /*nr=*/8, /*kr=*/1, /*sr=*/1,
         /*is_igemm=*/false,
         [](GemmMicrokernelTester& tester) {
@@ -218,8 +218,8 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     QD8_F32_QB4W_GEMM_MINMAX_4X4__SCALAR, GemmTest,
     testing::ValuesIn(CreateTests1(
-        /*k_block=*/2,
-        /*adj_k_block=*/2,
+        /*k_block=*/32,
+        /*adj_k_block=*/32,
         /*mr=*/4, /*nr=*/4, /*kr=*/1, /*sr=*/1,
         /*is_igemm=*/false,
         [](GemmMicrokernelTester& tester) {
@@ -236,8 +236,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_1X4C8__AVX_LD128, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/1, /*nr=*/4, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -255,8 +255,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_2X4C8__AVX_LD128, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/2, /*nr=*/4, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -274,8 +274,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_3X4C8__AVX_LD128, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/3, /*nr=*/4, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -293,8 +293,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_4X4C8__AVX_LD128, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/4, /*nr=*/4, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -312,8 +312,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_1X4C8__AVX_LD64, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/1, /*nr=*/4, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -331,8 +331,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_2X4C8__AVX_LD64, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/2, /*nr=*/4, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -350,8 +350,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_3X4C8__AVX_LD64, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/3, /*nr=*/4, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -369,8 +369,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_4X4C8__AVX_LD64, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/4, /*nr=*/4, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -388,8 +388,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_1X4C8__SSE2_LD128, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/1, /*nr=*/4, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -407,8 +407,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_2X4C8__SSE2_LD128, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/2, /*nr=*/4, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -426,8 +426,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_3X4C8__SSE2_LD128, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/3, /*nr=*/4, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -445,8 +445,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_4X4C8__SSE2_LD128, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/4, /*nr=*/4, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -464,8 +464,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_1X4C8__SSE2_LD64, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/1, /*nr=*/4, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -483,8 +483,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_2X4C8__SSE2_LD64, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/2, /*nr=*/4, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -502,8 +502,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_3X4C8__SSE2_LD64, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/3, /*nr=*/4, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -521,8 +521,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_4X4C8__SSE2_LD64, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/4, /*nr=*/4, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -540,8 +540,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_1X4C8__SSE41_LD128, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/1, /*nr=*/4, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -559,8 +559,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_2X4C8__SSE41_LD128, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/2, /*nr=*/4, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -578,8 +578,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_3X4C8__SSE41_LD128, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/3, /*nr=*/4, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -597,8 +597,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_4X4C8__SSE41_LD128, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/4, /*nr=*/4, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -616,8 +616,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_1X4C8__SSE41_LD64, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/1, /*nr=*/4, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -635,8 +635,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_2X4C8__SSE41_LD64, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/2, /*nr=*/4, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -654,8 +654,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_3X4C8__SSE41_LD64, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/3, /*nr=*/4, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -673,8 +673,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_4X4C8__SSE41_LD64, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/4, /*nr=*/4, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -695,8 +695,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_1X8C4__NEONDOT, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/1, /*nr=*/8, /*kr=*/4, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -714,8 +714,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_1X16C4__NEONDOT, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/1, /*nr=*/16, /*kr=*/4, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -733,8 +733,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_2X8C4__NEONDOT, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/2, /*nr=*/8, /*kr=*/4, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -752,8 +752,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_2X16C4__NEONDOT, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/2, /*nr=*/16, /*kr=*/4, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -771,8 +771,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_3X8C4__NEONDOT, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/3, /*nr=*/8, /*kr=*/4, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -790,8 +790,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_3X16C4__NEONDOT, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/3, /*nr=*/16, /*kr=*/4, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -809,8 +809,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_4X8C4__NEONDOT, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/4, /*nr=*/8, /*kr=*/4, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -828,8 +828,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_4X16C4__NEONDOT, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/4, /*nr=*/16, /*kr=*/4, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -847,8 +847,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_5X8C4__NEONDOT, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/5, /*nr=*/8, /*kr=*/4, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -866,8 +866,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_5X16C4__NEONDOT, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/5, /*nr=*/16, /*kr=*/4, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -885,8 +885,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_6X8C4__NEONDOT, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/6, /*nr=*/8, /*kr=*/4, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -904,8 +904,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_6X16C4__NEONDOT, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/6, /*nr=*/16, /*kr=*/4, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -926,8 +926,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_1X8C8__AVX2, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/1, /*nr=*/8, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -945,8 +945,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_2X8C8__AVX2, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/2, /*nr=*/8, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -964,8 +964,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_3X8C8__AVX2, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/3, /*nr=*/8, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -983,8 +983,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_4X8C8__AVX2, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/4, /*nr=*/8, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1005,8 +1005,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_1X16__NEON_MLAL_LANE, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/1, /*nr=*/16, /*kr=*/1, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1024,8 +1024,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_1X16__NEON_MLAL_LANE_PRFM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/1, /*nr=*/16, /*kr=*/1, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1043,8 +1043,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_2X16__NEON_MLAL_LANE, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/2, /*nr=*/16, /*kr=*/1, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1062,8 +1062,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_2X16__NEON_MLAL_LANE_PRFM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/2, /*nr=*/16, /*kr=*/1, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1081,8 +1081,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_3X16__NEON_MLAL_LANE, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/3, /*nr=*/16, /*kr=*/1, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1100,8 +1100,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_3X16__NEON_MLAL_LANE_PRFM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/3, /*nr=*/16, /*kr=*/1, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1119,8 +1119,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_4X16__NEON_MLAL_LANE, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/4, /*nr=*/16, /*kr=*/1, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1138,8 +1138,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_4X16__NEON_MLAL_LANE_PRFM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/4, /*nr=*/16, /*kr=*/1, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1157,8 +1157,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_6X16__NEON_MLAL_LANE, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/6, /*nr=*/16, /*kr=*/1, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1176,8 +1176,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_6X16__NEON_MLAL_LANE_PRFM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/8,
-          /*adj_k_block=*/8,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/6, /*nr=*/16, /*kr=*/1, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1198,8 +1198,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_1X8C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/1, /*nr=*/8, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1217,8 +1217,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_1X16C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/1, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1236,8 +1236,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_1X32C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/1, /*nr=*/32, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1255,8 +1255,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_2X8C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/2, /*nr=*/8, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1274,8 +1274,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_2X16C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/2, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1293,8 +1293,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_2X32C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/2, /*nr=*/32, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1312,8 +1312,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_3X8C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/3, /*nr=*/8, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1331,8 +1331,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_3X16C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/3, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1350,8 +1350,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_3X32C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/3, /*nr=*/32, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1369,8 +1369,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_4X8C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/4, /*nr=*/8, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1388,8 +1388,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_4X16C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/4, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1407,8 +1407,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_4X32C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/4, /*nr=*/32, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1426,8 +1426,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_5X8C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/5, /*nr=*/8, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1445,8 +1445,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_5X16C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/5, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1464,8 +1464,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_5X32C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/5, /*nr=*/32, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1483,8 +1483,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_6X8C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/6, /*nr=*/8, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1502,8 +1502,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_6X16C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/6, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1521,8 +1521,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_6X32C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/6, /*nr=*/32, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1540,8 +1540,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_7X8C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/7, /*nr=*/8, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1559,8 +1559,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_7X16C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/7, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1578,8 +1578,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_7X32C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/7, /*nr=*/32, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1597,8 +1597,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_8X8C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/8, /*nr=*/8, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1616,8 +1616,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_8X16C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/8, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1635,8 +1635,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_8X32C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/8, /*nr=*/32, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1657,8 +1657,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_1X16C8__AVX512VNNI, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/1, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1676,8 +1676,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_5X16C8__AVX512VNNI, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/5, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1695,8 +1695,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_7X16C8__AVX512VNNI, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/7, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1714,8 +1714,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_8X16C8__AVX512VNNI, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/8, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1733,8 +1733,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_9X16C8__AVX512VNNI, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/9, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1752,8 +1752,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_10X16C8__AVX512VNNI, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/10, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1771,8 +1771,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_12X16C8__AVX512VNNI, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/12, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1790,8 +1790,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_14X16C8__AVX512VNNI, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/14, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1809,8 +1809,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_1X16C8__AVX512VNNI_PRFM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/1, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1828,8 +1828,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_5X16C8__AVX512VNNI_PRFM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/5, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1847,8 +1847,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_7X16C8__AVX512VNNI_PRFM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/7, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1866,8 +1866,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_8X16C8__AVX512VNNI_PRFM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/8, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1885,8 +1885,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_9X16C8__AVX512VNNI_PRFM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/9, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1904,8 +1904,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_10X16C8__AVX512VNNI_PRFM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/10, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1923,8 +1923,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_12X16C8__AVX512VNNI_PRFM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/12, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1942,8 +1942,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_14X16C8__AVX512VNNI_PRFM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/14, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1964,8 +1964,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_1X16C8__AVX512VNNIGFNI, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/1, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -1983,8 +1983,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_5X16C8__AVX512VNNIGFNI, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/5, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -2002,8 +2002,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_7X16C8__AVX512VNNIGFNI, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/7, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -2021,8 +2021,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_8X16C8__AVX512VNNIGFNI, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/8, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -2040,8 +2040,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_9X16C8__AVX512VNNIGFNI, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/9, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -2059,8 +2059,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_10X16C8__AVX512VNNIGFNI, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/10, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -2078,8 +2078,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_12X16C8__AVX512VNNIGFNI, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/12, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -2097,8 +2097,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_14X16C8__AVX512VNNIGFNI, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/14, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -2116,8 +2116,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_1X16C8__AVX512VNNIGFNI_PRFM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/1, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -2135,8 +2135,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_5X16C8__AVX512VNNIGFNI_PRFM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/5, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -2154,8 +2154,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_7X16C8__AVX512VNNIGFNI_PRFM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/7, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -2173,8 +2173,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_8X16C8__AVX512VNNIGFNI_PRFM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/8, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -2192,8 +2192,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_9X16C8__AVX512VNNIGFNI_PRFM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/9, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -2211,8 +2211,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_10X16C8__AVX512VNNIGFNI_PRFM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/10, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -2230,8 +2230,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_12X16C8__AVX512VNNIGFNI_PRFM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/12, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {
@@ -2249,8 +2249,8 @@ INSTANTIATE_TEST_SUITE_P(
   INSTANTIATE_TEST_SUITE_P(
       QD8_F32_QB4W_GEMM_MINMAX_14X16C8__AVX512VNNIGFNI_PRFM, GemmTest,
       testing::ValuesIn(CreateTests1(
-          /*k_block=*/16,
-          /*adj_k_block=*/16,
+          /*k_block=*/32,
+          /*adj_k_block=*/32,
           /*mr=*/14, /*nr=*/16, /*kr=*/8, /*sr=*/1,
           /*is_igemm=*/false,
           [](GemmMicrokernelTester& tester) {

--- a/test/qd8-f32-qb4w-gemm-minmax.yaml
+++ b/test/qd8-f32-qb4w-gemm-minmax.yaml
@@ -7,499 +7,499 @@
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x2__scalar
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 2
+  k-block: 32
 
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x4__scalar
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 2
+  k-block: 32
 
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x8__scalar
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 2
+  k-block: 32
 
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x2__scalar
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 2
+  k-block: 32
 
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x4__scalar
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 2
+  k-block: 32
 
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x8__scalar
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 2
+  k-block: 32
 
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x4__scalar
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 2
+  k-block: 32
 
 # x86 AVX
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x4c8__avx_ld128
   init: xnn_init_f32_qb4w_minmax_sse_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x4c8__avx_ld128
   init: xnn_init_f32_qb4w_minmax_sse_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x4c8__avx_ld128
   init: xnn_init_f32_qb4w_minmax_sse_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x4c8__avx_ld128
   init: xnn_init_f32_qb4w_minmax_sse_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x4c8__avx_ld64
   init: xnn_init_f32_qb4w_minmax_sse_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x4c8__avx_ld64
   init: xnn_init_f32_qb4w_minmax_sse_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x4c8__avx_ld64
   init: xnn_init_f32_qb4w_minmax_sse_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x4c8__avx_ld64
   init: xnn_init_f32_qb4w_minmax_sse_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 
 # x86 SSE2
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x4c8__sse2_ld128
   init: xnn_init_f32_qb4w_minmax_sse_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x4c8__sse2_ld128
   init: xnn_init_f32_qb4w_minmax_sse_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x4c8__sse2_ld128
   init: xnn_init_f32_qb4w_minmax_sse_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x4c8__sse2_ld128
   init: xnn_init_f32_qb4w_minmax_sse_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x4c8__sse2_ld64
   init: xnn_init_f32_qb4w_minmax_sse_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x4c8__sse2_ld64
   init: xnn_init_f32_qb4w_minmax_sse_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x4c8__sse2_ld64
   init: xnn_init_f32_qb4w_minmax_sse_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x4c8__sse2_ld64
   init: xnn_init_f32_qb4w_minmax_sse_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 
 # x86 SSE4.1
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x4c8__sse41_ld128
   init: xnn_init_f32_qb4w_minmax_sse_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x4c8__sse41_ld128
   init: xnn_init_f32_qb4w_minmax_sse_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x4c8__sse41_ld128
   init: xnn_init_f32_qb4w_minmax_sse_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x4c8__sse41_ld128
   init: xnn_init_f32_qb4w_minmax_sse_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x4c8__sse41_ld64
   init: xnn_init_f32_qb4w_minmax_sse_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x4c8__sse41_ld64
   init: xnn_init_f32_qb4w_minmax_sse_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x4c8__sse41_ld64
   init: xnn_init_f32_qb4w_minmax_sse_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x4c8__sse41_ld64
   init: xnn_init_f32_qb4w_minmax_sse_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 
   # ARM NEONDOT
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x8c4__neondot
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x16c4__neondot
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x8c4__neondot
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x16c4__neondot
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x8c4__neondot
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x16c4__neondot
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x8c4__neondot
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x16c4__neondot
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_5x8c4__neondot
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_5x16c4__neondot
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_6x8c4__neondot
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_6x16c4__neondot
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 
 # x86 AVX2
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x8c8__avx2
   init: xnn_init_f32_qb4w_minmax_avx_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x8c8__avx2
   init: xnn_init_f32_qb4w_minmax_avx_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x8c8__avx2
   init: xnn_init_f32_qb4w_minmax_avx_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x8c8__avx2
   init: xnn_init_f32_qb4w_minmax_avx_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 
 # ARM NEON
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x16__neon_mlal_lane
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x16__neon_mlal_lane_prfm
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x16__neon_mlal_lane
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x16__neon_mlal_lane_prfm
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x16__neon_mlal_lane
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x16__neon_mlal_lane_prfm
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x16__neon_mlal_lane
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x16__neon_mlal_lane_prfm
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_6x16__neon_mlal_lane
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_6x16__neon_mlal_lane_prfm
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 8
+  k-block: 32
 
 # ARM NEONI8MM
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x8c8__neoni8mm
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x16c8__neoni8mm
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x32c8__neoni8mm
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x8c8__neoni8mm
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x16c8__neoni8mm
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x32c8__neoni8mm
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x8c8__neoni8mm
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x16c8__neoni8mm
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_3x32c8__neoni8mm
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x8c8__neoni8mm
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x16c8__neoni8mm
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x32c8__neoni8mm
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_5x8c8__neoni8mm
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_5x16c8__neoni8mm
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_5x32c8__neoni8mm
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_6x8c8__neoni8mm
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_6x16c8__neoni8mm
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_6x32c8__neoni8mm
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_7x8c8__neoni8mm
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_7x16c8__neoni8mm
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_7x32c8__neoni8mm
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_8x8c8__neoni8mm
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_8x16c8__neoni8mm
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_8x32c8__neoni8mm
   init: xnn_init_f32_qb4w_minmax_scalar_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 
 # AVX512VNNI
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x16c8__avx512vnni
   init: xnn_init_f32_qb4w_minmax_avx512vnni_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_5x16c8__avx512vnni
   init: xnn_init_f32_qb4w_minmax_avx512vnni_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_7x16c8__avx512vnni
   init: xnn_init_f32_qb4w_minmax_avx512vnni_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_8x16c8__avx512vnni
   init: xnn_init_f32_qb4w_minmax_avx512vnni_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_9x16c8__avx512vnni
   init: xnn_init_f32_qb4w_minmax_avx512vnni_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_10x16c8__avx512vnni
   init: xnn_init_f32_qb4w_minmax_avx512vnni_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_12x16c8__avx512vnni
   init: xnn_init_f32_qb4w_minmax_avx512vnni_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_14x16c8__avx512vnni
   init: xnn_init_f32_qb4w_minmax_avx512vnni_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x16c8__avx512vnni_prfm
   init: xnn_init_f32_qb4w_minmax_avx512vnni_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_5x16c8__avx512vnni_prfm
   init: xnn_init_f32_qb4w_minmax_avx512vnni_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_7x16c8__avx512vnni_prfm
   init: xnn_init_f32_qb4w_minmax_avx512vnni_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_8x16c8__avx512vnni_prfm
   init: xnn_init_f32_qb4w_minmax_avx512vnni_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_9x16c8__avx512vnni_prfm
   init: xnn_init_f32_qb4w_minmax_avx512vnni_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_10x16c8__avx512vnni_prfm
   init: xnn_init_f32_qb4w_minmax_avx512vnni_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_12x16c8__avx512vnni_prfm
   init: xnn_init_f32_qb4w_minmax_avx512vnni_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_14x16c8__avx512vnni_prfm
   init: xnn_init_f32_qb4w_minmax_avx512vnni_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 
 # AVX512VNNIGFNI
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x16c8__avx512vnnigfni
   init: xnn_init_f32_qb4w_minmax_avx512vnni_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_5x16c8__avx512vnnigfni
   init: xnn_init_f32_qb4w_minmax_avx512vnni_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_7x16c8__avx512vnnigfni
   init: xnn_init_f32_qb4w_minmax_avx512vnni_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_8x16c8__avx512vnnigfni
   init: xnn_init_f32_qb4w_minmax_avx512vnni_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_9x16c8__avx512vnnigfni
   init: xnn_init_f32_qb4w_minmax_avx512vnni_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_10x16c8__avx512vnnigfni
   init: xnn_init_f32_qb4w_minmax_avx512vnni_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_12x16c8__avx512vnnigfni
   init: xnn_init_f32_qb4w_minmax_avx512vnni_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_14x16c8__avx512vnnigfni
   init: xnn_init_f32_qb4w_minmax_avx512vnni_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x16c8__avx512vnnigfni_prfm
   init: xnn_init_f32_qb4w_minmax_avx512vnni_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_5x16c8__avx512vnnigfni_prfm
   init: xnn_init_f32_qb4w_minmax_avx512vnni_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_7x16c8__avx512vnnigfni_prfm
   init: xnn_init_f32_qb4w_minmax_avx512vnni_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_8x16c8__avx512vnnigfni_prfm
   init: xnn_init_f32_qb4w_minmax_avx512vnni_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_9x16c8__avx512vnnigfni_prfm
   init: xnn_init_f32_qb4w_minmax_avx512vnni_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_10x16c8__avx512vnnigfni_prfm
   init: xnn_init_f32_qb4w_minmax_avx512vnni_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_12x16c8__avx512vnnigfni_prfm
   init: xnn_init_f32_qb4w_minmax_avx512vnni_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32
 - name: xnn_qd8_f32_qb4w_gemm_minmax_ukernel_14x16c8__avx512vnnigfni_prfm
   init: xnn_init_f32_qb4w_minmax_avx512vnni_params
   pack: xnn_pack_qs8_qb4w_gemm_goi_w
-  k-block: 16
+  k-block: 32

--- a/tools/generate-gemm-test.py
+++ b/tools/generate-gemm-test.py
@@ -154,7 +154,7 @@ std::vector<GemmTestParams> CreateTests(
           $if KERNELTYPE in ['qb4w', 'qc4w']:
             .b_zero_point(8)
           $if KERNELTYPE in ['qb4w']:
-            .bl(kr * sr * 2)
+            .bl(32)
       , test_func, isa_check));
   $if DATATYPE != "qp8":
     gemm_tests.push_back(GemmTestParams(
@@ -167,7 +167,7 @@ std::vector<GemmTestParams> CreateTests(
             $if KERNELTYPE in ['qb4w', 'qc4w']:
               .b_zero_point(8)
             $if KERNELTYPE in ['qb4w']:
-              .bl(kr * sr * 2)
+              .bl(32)
       , test_func, isa_check));
   if (!is_igemm) {
     gemm_tests.push_back(GemmTestParams(
@@ -180,7 +180,7 @@ std::vector<GemmTestParams> CreateTests(
             $if KERNELTYPE in ['qb4w', 'qc4w']:
               .b_zero_point(8)
             $if KERNELTYPE in ['qb4w']:
-              .bl(kr * sr * 2)
+              .bl(32)
         , test_func, isa_check));
   }
   gemm_tests.push_back(GemmTestParams(
@@ -192,7 +192,7 @@ std::vector<GemmTestParams> CreateTests(
           $if KERNELTYPE in ['qb4w', 'qc4w']:
             .b_zero_point(8)
           $if KERNELTYPE in ['qb4w']:
-            .bl(kr * sr * 2)
+            .bl(32)
       , test_func, isa_check)
       .loop_n(1, nr)
       .loop_m(1, mr));
@@ -205,7 +205,7 @@ std::vector<GemmTestParams> CreateTests(
           $if KERNELTYPE in ['qb4w', 'qc4w']:
             .b_zero_point(8)
           $if KERNELTYPE in ['qb4w']:
-            .bl(kr * sr * 2)
+            .bl(32)
       , test_func, isa_check)
       .loop_m(1, mr));
   gemm_tests.push_back(GemmTestParams(
@@ -217,7 +217,7 @@ std::vector<GemmTestParams> CreateTests(
           $if KERNELTYPE in ['qb4w', 'qc4w']:
             .b_zero_point(8)
           $if KERNELTYPE in ['qb4w']:
-            .bl(kr * sr * 2)
+            .bl(32)
       , test_func, isa_check)
       .loop_n(1, nr));
   $if IS_PIPELINED:
@@ -230,7 +230,7 @@ std::vector<GemmTestParams> CreateTests(
           $if KERNELTYPE in ['qb4w', 'qc4w']:
             .b_zero_point(8)
           $if KERNELTYPE in ['qb4w']:
-            .bl(kr * sr * 2)
+            .bl(32)
       , test_func, isa_check));
     if (!is_igemm) {
       gemm_tests.push_back(GemmTestParams(
@@ -243,7 +243,7 @@ std::vector<GemmTestParams> CreateTests(
               $if KERNELTYPE in ['qb4w', 'qc4w']:
                 .b_zero_point(8)
             $if KERNELTYPE in ['qb4w']:
-              .bl(kr * sr * 2)
+              .bl(32)
           , test_func, isa_check));
     }
     gemm_tests.push_back(GemmTestParams(
@@ -255,7 +255,7 @@ std::vector<GemmTestParams> CreateTests(
             $if KERNELTYPE in ['qb4w', 'qc4w']:
               .b_zero_point(8)
             $if KERNELTYPE in ['qb4w']:
-              .bl(kr * sr * 2)
+              .bl(32)
         , test_func, isa_check)
         .loop_n(1, nr)
         .loop_m(1, mr));
@@ -270,7 +270,7 @@ std::vector<GemmTestParams> CreateTests(
                 $if KERNELTYPE in ['qb4w', 'qc4w']:
                   .b_zero_point(8)
                 $if KERNELTYPE in ['qb4w']:
-                  .bl(kr * sr * 2)
+                  .bl(32)
             , test_func, isa_check)
             .loop_k(1, adj_k_block - 1));
         if (!is_igemm) {
@@ -284,7 +284,7 @@ std::vector<GemmTestParams> CreateTests(
                   $if KERNELTYPE in ['qb4w', 'qc4w']:
                     .b_zero_point(8)
                   $if KERNELTYPE in ['qb4w']:
-                    .bl(kr * sr * 2)
+                    .bl(32)
               , test_func, isa_check)
               .loop_k(1, adj_k_block - 1));
         }
@@ -297,7 +297,7 @@ std::vector<GemmTestParams> CreateTests(
                 $if KERNELTYPE in ['qb4w', 'qc4w']:
                   .b_zero_point(8)
                 $if KERNELTYPE in ['qb4w']:
-                  .bl(kr * sr * 2)
+                  .bl(32)
             , test_func, isa_check)
             .loop_k(1, adj_k_block - 1)
             .loop_n(1, nr)
@@ -312,7 +312,7 @@ std::vector<GemmTestParams> CreateTests(
               $if KERNELTYPE in ['qb4w', 'qc4w']:
                 .b_zero_point(8)
               $if KERNELTYPE in ['qb4w']:
-                .bl(kr * sr * 2)
+                .bl(32)
           , test_func, isa_check)
           .loop_k(adj_k_block + 1, adj_k_block * 2 - 1, k_block));
       if (is_igemm) {
@@ -326,7 +326,7 @@ std::vector<GemmTestParams> CreateTests(
                 $if KERNELTYPE in ['qb4w', 'qc4w']:
                   .b_zero_point(8)
               $if KERNELTYPE in ['qb4w']:
-                .bl(kr * sr * 2)
+                .bl(32)
           , test_func, isa_check)
           .loop_k(adj_k_block + 1, adj_k_block * 2 - 1, k_block));
       }
@@ -339,7 +339,7 @@ std::vector<GemmTestParams> CreateTests(
               $if KERNELTYPE in ['qb4w', 'qc4w']:
                 .b_zero_point(8)
               $if KERNELTYPE in ['qb4w']:
-                .bl(kr * sr * 2)
+                .bl(32)
           , test_func, isa_check)
           .loop_k(adj_k_block + 1, adj_k_block * 2 - 1, k_block)
           .loop_n(1, nr)
@@ -354,7 +354,7 @@ std::vector<GemmTestParams> CreateTests(
                 $if KERNELTYPE in ['qb4w', 'qc4w']:
                   .b_zero_point(8)
                 $if KERNELTYPE in ['qb4w']:
-                  .bl(kr * sr * 2)
+                  .bl(32)
             , test_func, isa_check)
             .loop_k(adj_k_block + k_block, k_block * 5, k_block));
         if (is_igemm) {
@@ -368,7 +368,7 @@ std::vector<GemmTestParams> CreateTests(
                   $if KERNELTYPE in ['qb4w', 'qc4w']:
                     .b_zero_point(8)
                   $if KERNELTYPE in ['qb4w']:
-                    .bl(kr * sr * 2)
+                    .bl(32)
               , test_func, isa_check)
               .loop_k(adj_k_block + k_block, k_block * 3, k_block));
         }
@@ -381,7 +381,7 @@ std::vector<GemmTestParams> CreateTests(
                 $if KERNELTYPE in ['qb4w', 'qc4w']:
                   .b_zero_point(8)
                 $if KERNELTYPE in ['qb4w']:
-                  .bl(kr * sr * 2)
+                  .bl(32)
             , test_func, isa_check)
             .loop_k(adj_k_block + k_block, k_block * 5, k_block)
             .loop_n(1, nr)
@@ -396,7 +396,7 @@ std::vector<GemmTestParams> CreateTests(
               $if KERNELTYPE in ['qb4w', 'qc4w']:
                 .b_zero_point(8)
               $if KERNELTYPE in ['qb4w']:
-                .bl(kr * sr * 2)
+                .bl(32)
           , test_func, isa_check)
           $if NR_SCALE != "":
             .loop_n(nr + 1, nr * 2 - 1, 4)
@@ -413,7 +413,7 @@ std::vector<GemmTestParams> CreateTests(
                 $if KERNELTYPE in ['qb4w', 'qc4w']:
                   .b_zero_point(8)
                 $if KERNELTYPE in ['qb4w']:
-                  .bl(kr * sr * 2)
+                  .bl(32)
             , test_func, isa_check)
             $if NR_SCALE != "":
               .loop_n(1, nr * 2 - 1, 4)
@@ -429,7 +429,7 @@ std::vector<GemmTestParams> CreateTests(
                 $if KERNELTYPE in ['qb4w', 'qc4w']:
                   .b_zero_point(8)
                 $if KERNELTYPE in ['qb4w']:
-                  .bl(kr * sr * 2)
+                  .bl(32)
             , test_func, isa_check));
       $if DATATYPE != "qp8":
         gemm_tests.push_back(GemmTestParams(
@@ -442,9 +442,9 @@ std::vector<GemmTestParams> CreateTests(
                 $if KERNELTYPE in ['qb4w', 'qc4w']:
                   .b_zero_point(8)
                 $if KERNELTYPE in ['qb4w']:
-                  .bl(kr * sr * 2)
+                  .bl(32)
                 $if KERNELTYPE in ['qb4w']:
-                  .bl(kr * sr * 2)
+                  .bl(32)
             , test_func, isa_check)
             $if NR_SCALE != "":
               .loop_n(nr + 1, nr * 2 - 1, 4)
@@ -462,7 +462,7 @@ std::vector<GemmTestParams> CreateTests(
                 $if KERNELTYPE in ['qb4w', 'qc4w']:
                   .b_zero_point(8)
                 $if KERNELTYPE in ['qb4w']:
-                  .bl(kr * sr * 2)
+                  .bl(32)
             , test_func, isa_check)
             $if NR_SCALE != "":
               .loop_n(nr + 1, nr * 2 - 1, 4)
@@ -479,7 +479,7 @@ std::vector<GemmTestParams> CreateTests(
               $if KERNELTYPE in ['qb4w', 'qc4w']:
                 .b_zero_point(8)
               $if KERNELTYPE in ['qb4w']:
-                .bl(kr * sr * 2)
+                .bl(32)
           , test_func, isa_check)
           $if NR_SCALE != "":
             .loop_n(nr + 1, nr * 2 - 1, 4)
@@ -496,7 +496,7 @@ std::vector<GemmTestParams> CreateTests(
               $if KERNELTYPE in ['qb4w', 'qc4w']:
                 .b_zero_point(8)
               $if KERNELTYPE in ['qb4w']:
-                .bl(kr * sr * 2)
+                .bl(32)
           , test_func, isa_check)
           .loop_n(nr * 2, nr * 3, nr)
           .loop_k(1, k_block * 3, k_block + 1));
@@ -511,7 +511,7 @@ std::vector<GemmTestParams> CreateTests(
                 $if KERNELTYPE in ['qb4w', 'qc4w']:
                   .b_zero_point(8)
                 $if KERNELTYPE in ['qb4w']:
-                  .bl(kr * sr * 2)
+                  .bl(32)
             , test_func, isa_check)
             .loop_n(nr * 2, nr * 3, nr)
             .loop_k(1, k_block * 3, k_block + 1));
@@ -526,7 +526,7 @@ std::vector<GemmTestParams> CreateTests(
                 $if KERNELTYPE in ['qb4w', 'qc4w']:
                   .b_zero_point(8)
                 $if KERNELTYPE in ['qb4w']:
-                  .bl(kr * sr * 2)
+                  .bl(32)
             , test_func, isa_check)
             .loop_n(nr * 2, nr * 3, nr)
             .loop_k(1, k_block * 3, k_block));
@@ -540,7 +540,7 @@ std::vector<GemmTestParams> CreateTests(
               $if KERNELTYPE in ['qb4w', 'qc4w']:
                 .b_zero_point(8)
               $if KERNELTYPE in ['qb4w']:
-                .bl(kr * sr * 2)
+                .bl(32)
           , test_func, isa_check)
           .loop_n(nr * 2, nr * 3, nr)
           .loop_k(1, k_block * 3, k_block + 1)
@@ -555,7 +555,7 @@ std::vector<GemmTestParams> CreateTests(
                 $if KERNELTYPE in ['qb4w', 'qc4w']:
                   .b_zero_point(8)
                 $if KERNELTYPE in ['qb4w']:
-                  .bl(kr * sr * 2)
+                  .bl(32)
             , test_func, isa_check)
             .loop_k(1, k_block * 3, k_block + 1));
         gemm_tests.push_back(GemmTestParams(
@@ -567,7 +567,7 @@ std::vector<GemmTestParams> CreateTests(
                 $if KERNELTYPE in ['qb4w', 'qc4w']:
                   .b_zero_point(8)
                 $if KERNELTYPE in ['qb4w']:
-                  .bl(kr * sr * 2)
+                  .bl(32)
             , test_func, isa_check)
             .loop_k(1, k_block * 3, k_block + 1)
             .loop_n(1, nr)
@@ -581,7 +581,7 @@ std::vector<GemmTestParams> CreateTests(
                 $if KERNELTYPE in ['qb4w', 'qc4w']:
                   .b_zero_point(8)
                 $if KERNELTYPE in ['qb4w']:
-                  .bl(kr * sr * 2)
+                  .bl(32)
             , test_func, isa_check)
             $if NR_SCALE != "":
               .loop_n(nr + 1, nr * 2 - 1, 4)
@@ -597,7 +597,7 @@ std::vector<GemmTestParams> CreateTests(
                 $if KERNELTYPE in ['qb4w', 'qc4w']:
                   .b_zero_point(8)
                 $if KERNELTYPE in ['qb4w']:
-                  .bl(kr * sr * 2)
+                  .bl(32)
             , test_func, isa_check)
             .loop_n(nr * 2, nr * 3, nr)
             .loop_k(1, k_block * 3, k_block + 1));
@@ -613,7 +613,7 @@ std::vector<GemmTestParams> CreateTests(
               $if KERNELTYPE in ['qb4w', 'qc4w']:
                 .b_zero_point(8)
               $if KERNELTYPE in ['qb4w']:
-                .bl(kr * sr * 2)
+                .bl(32)
           , test_func, isa_check)
           .loop_k(1, k_block * 3, k_block + 1)
           .loop_n(1, nr)
@@ -629,7 +629,7 @@ std::vector<GemmTestParams> CreateTests(
                 $if KERNELTYPE in ['qb4w', 'qc4w']:
                   .b_zero_point(8)
                 $if KERNELTYPE in ['qb4w']:
-                  .bl(kr * sr * 2)
+                  .bl(32)
             , test_func, isa_check)
             .loop_k(1, k_block * 3, k_block + 1));
         gemm_tests.push_back(GemmTestParams(
@@ -642,7 +642,7 @@ std::vector<GemmTestParams> CreateTests(
                 $if KERNELTYPE in ['qb4w', 'qc4w']:
                   .b_zero_point(8)
                 $if KERNELTYPE in ['qb4w']:
-                  .bl(kr * sr * 2)
+                  .bl(32)
             , test_func, isa_check)
             .loop_k(1, k_block * 3, k_block + 1)
             .loop_zi(0, mr - 1));
@@ -657,7 +657,7 @@ std::vector<GemmTestParams> CreateTests(
                 $if KERNELTYPE in ['qb4w', 'qc4w']:
                   .b_zero_point(8)
                 $if KERNELTYPE in ['qb4w']:
-                  .bl(kr * sr * 2)
+                  .bl(32)
             , test_func, isa_check));
         gemm_tests.push_back(GemmTestParams(
             "qmax",
@@ -668,7 +668,7 @@ std::vector<GemmTestParams> CreateTests(
                 $if KERNELTYPE in ['qb4w', 'qc4w']:
                   .b_zero_point(8)
                 $if KERNELTYPE in ['qb4w']:
-                  .bl(kr * sr * 2)
+                  .bl(32)
             , test_func, isa_check));
       gemm_tests.push_back(GemmTestParams(
           "strided_cm",
@@ -680,7 +680,7 @@ std::vector<GemmTestParams> CreateTests(
               $if KERNELTYPE in ['qb4w', 'qc4w']:
                 .b_zero_point(8)
               $if KERNELTYPE in ['qb4w']:
-                .bl(kr * sr * 2)
+                .bl(32)
           , test_func, isa_check));
       $if DATATYPE == "qu8":
         gemm_tests.push_back(GemmTestParams(
@@ -728,7 +728,7 @@ std::vector<GemmTestParams> CreateTests(
             .b_zero_point(8)
         , test_func, isa_check)
         .loop_k(k_block, k_block * 12, k_block, LoopStepType::Linear)
-        .loop_bl(2 * kr * sr, k_block * 12, 2 * kr * sr));
+        .loop_bl(32, k_block * 32, 32));
 
   return gemm_tests;
 }


### PR DESCRIPTION
Add an assertion to qb4w kernels to enforce bl % 32 == 0. Update tests accordingly.