### PR TITLE
Minor Fixes to run-on-hexagon scripts + toolchain

### DIFF
--- a/cmake/hexagon.toolchain
+++ b/cmake/hexagon.toolchain
@@ -10,7 +10,7 @@ SET(CMAKE_CROSSCOMPILING TRUE)
 # For compatibility with with CMake toolchain from Hexagon SDK
 SET(HEXAGON TRUE)
 SET(HEXAGON_ARCH v68)
-SET(HEXAGON_TOOL_VER v87)
+SET(HEXAGON_TOOL_VER v86)
 
 # This is configured for Hexagon SDK 5.3.0.0
 IF(NOT DEFINED ENV{HEXAGON_SDK_ROOT})

--- a/scripts/run-on-hexagon-device.sh
+++ b/scripts/run-on-hexagon-device.sh
@@ -21,7 +21,7 @@ if [ -z "$HEXAGON_TOOLS_ROOT" ]; then
   exit 1
 fi
 
-# These rarely vary so just assume the current defaults.
+# These should match the versions specified in hexagon.toolchain
 : "${HEXAGON_ARCH:=v68}"
 : "${HEXAGON_SDK_VER:=5.3.0}"
 : "${HEXAGON_TOOL_VER:=v86}"

--- a/scripts/run-on-hexagon-device.sh
+++ b/scripts/run-on-hexagon-device.sh
@@ -9,7 +9,7 @@
 #
 # Syntax: run-on-hexagon-device.sh path-to-binary
 
-set -ex
+set -e
 
 if [ -z "$HEXAGON_SDK_ROOT" ]; then
   echo "HEXAGON_SDK_ROOT must be set!"

--- a/scripts/run-on-hexagon-sim.sh
+++ b/scripts/run-on-hexagon-sim.sh
@@ -9,7 +9,7 @@
 #
 # Syntax: run-on-hexagon-sim.sh path-to-binary
 
-set -ex
+set -e
 
 if [ -z "$HEXAGON_SDK_ROOT" ]; then
   echo "HEXAGON_SDK_ROOT must be set!"
@@ -21,7 +21,7 @@ if [ -z "$HEXAGON_TOOLS_ROOT" ]; then
   exit 1
 fi
 
-# These rarely vary so just assume the current defaults.
+# These should match the versions specified in hexagon.toolchain
 : "${HEXAGON_ARCH:=v68}"
 : "${HEXAGON_TOOL_VER:=v86}"
 
@@ -30,9 +30,9 @@ BINARY_PATH=$1
 shift
 
 EXE_NAME="$(basename ${BINARY_PATH})"
-HEXAGON_LIBS_DIR=${HEXAGON_TOOLS_ROOT}/Tools/lib
-HEXAGON_LIBC_DIR="${HEXAGON_TOOLS_ROOT}/Tools/target/hexagon/lib/${HEXAGON_ARCH}/G0/pic"
-HEXAGON_SIM="${HEXAGON_TOOLS_ROOT}/Tools/bin/hexagon-sim"
+HEXAGON_LIBS_DIR=${HEXAGON_TOOLS_ROOT}/lib
+HEXAGON_LIBC_DIR="${HEXAGON_TOOLS_ROOT}/target/hexagon/lib/${HEXAGON_ARCH}/G0/pic"
+HEXAGON_SIM="${HEXAGON_TOOLS_ROOT}/bin/hexagon-sim"
 SIM_STACK_SIZE=0x400000 # 4 MB
 
 # Copy everything into a temp dir to avoid scrambling our build (etc) dirs.


### PR DESCRIPTION
- hexagon.toolchain uses HEXAGON_TOOL_VER=v87, but Hexagon SDK 5.3 doesn't support that version, at least not for run_main_on_hexagon. Downgraded to v86.
- run-main-on-hexagon-sim built incorrect paths based off of HEXAGON_TOOLS_ROOT
- Both of the run-on-hexagon scripts erroneously left `set -x` in place

attn @ejparkqc @dsharlet 