### PR TITLE
Guard qb4w AVX512-VNNIGFNI kernel references in gemm-config

### DIFF
--- a/src/configs/gemm-config.c
+++ b/src/configs/gemm-config.c
@@ -1954,6 +1954,7 @@ static void init_qd8_f32_qb4w_gemm_config(void) {
     const struct xnn_hardware_config* hardware_config = xnn_init_hardware_config();
     assert(hardware_config != NULL);
     // Zen4 has gfni but is slower and 8x16 works better on zen4.  14x16 is faster on Sapphire Rapids
+  #if XNN_ENABLE_AVX512VNNIGFNI
     if (!XNN_PLATFORM_MOBILE && hardware_config->use_x86_avx512vnnigfni && cpuinfo_get_core(0)->uarch != cpuinfo_uarch_zen4) {
       qd8_f32_qb4w_gemm_config.minmax.dqgemm[XNN_MR_TO_INDEX(1)] = xnn_init_hmp_dqgemm_ukernel((xnn_dqgemm_ukernel_fn) xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x16c8__avx512vnnigfni_prfm);
       qd8_f32_qb4w_gemm_config.minmax.dqgemm[XNN_MR_TO_INDEX(14)] = xnn_init_hmp_dqgemm_ukernel((xnn_dqgemm_ukernel_fn) xnn_qd8_f32_qb4w_gemm_minmax_ukernel_14x16c8__avx512vnnigfni_prfm);
@@ -1962,7 +1963,9 @@ static void init_qd8_f32_qb4w_gemm_config(void) {
       qd8_f32_qb4w_gemm_config.nr = 16;
       qd8_f32_qb4w_gemm_config.log2_kr = 3;
       qd8_f32_qb4w_gemm_config.planes = 2;
-    } else if (!XNN_PLATFORM_MOBILE && hardware_config->use_x86_avx512vnni) {
+    } else 
+  #endif  // XNN_ENABLE_AVX512VNNIGFNI
+  if (!XNN_PLATFORM_MOBILE && hardware_config->use_x86_avx512vnni) {
       qd8_f32_qb4w_gemm_config.minmax.dqgemm[XNN_MR_TO_INDEX(1)] = xnn_init_hmp_dqgemm_ukernel((xnn_dqgemm_ukernel_fn) xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x16c8__avx512vnni_prfm);
       qd8_f32_qb4w_gemm_config.minmax.dqgemm[XNN_MR_TO_INDEX(8)] = xnn_init_hmp_dqgemm_ukernel((xnn_dqgemm_ukernel_fn) xnn_qd8_f32_qb4w_gemm_minmax_ukernel_8x16c8__avx512vnni_prfm);
       qd8_f32_qb4w_gemm_config.init.f32_qb4w = xnn_init_f32_qb4w_minmax_avx512vnni_params;

--- a/src/tensor.c
+++ b/src/tensor.c
@@ -516,9 +516,10 @@ enum xnn_status xnn_define_blockwise_quantized_tensor_value(
       return xnn_status_unsupported_parameter;
   }
 
-  const size_t channels = dims[channel_dim];
-  const size_t block_count = channels / block_size;
-  for (size_t channel = 0; channel < channels; channel++) {
+  const size_t input_channels = dims[channel_dim];
+  const size_t output_channels = dims[1 - channel_dim];
+  const size_t block_count = input_channels / block_size;
+  for (size_t channel = 0; channel < output_channels; channel++) {
     for (size_t block = 0; block < block_count; block++) {
       float float_scale = math_cvt_fp32_bf16(scale[channel * block_count + block]);
       if (float_scale <= 0.0f || !isnormal(float_scale)) {


### PR DESCRIPTION
Needed to build on older GCC/Clang versions.