### PR TITLE
Use find_package(Python) to find python at build time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -727,9 +727,17 @@ IF(XNNPACK_TARGET_PROCESSOR MATCHES "^riscv")
   ENDIF()
 ENDIF()
 
+IF (NOT DEFINED Python_EXECUTABLE)
+  find_package(Python COMPONENTS Interpreter)
+
+  IF(NOT Python_FOUND)
+    SET(PYTHON_EXECUTABLE "python3")
+  ENDIF()
+ENDIF()
+
 ADD_CUSTOM_COMMAND(
   OUTPUT "${PROJECT_BINARY_DIR}/build_identifier.c"
-  COMMAND python3 "scripts/generate-build-identifier.py" --output "${PROJECT_BINARY_DIR}/build_identifier.c" ${PROD_MICROKERNEL_SRCS}
+  COMMAND "${Python_EXECUTABLE}" "scripts/generate-build-identifier.py" --output "${PROJECT_BINARY_DIR}/build_identifier.c" ${PROD_MICROKERNEL_SRCS}
   DEPENDS ${PROD_MICROKERNEL_SRCS}
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
 )


### PR DESCRIPTION
The top-level CMakeLists currently hard-codes python as python3 when invoking generate-build-identifier.py. The python binary may not be named python3 or may not be on the path on all systems. This change uses the CMake-recommended method of using fInd_package(Python) to locate the installed python binary. This works on a wider range of systems and better respects the active python env.