### PR TITLE
Introduce flags for qb4 scale format in xnn_define_blockwise_quantized_tensor_value

### DIFF
--- a/include/xnnpack.h
+++ b/include/xnnpack.h
@@ -236,6 +236,15 @@ enum xnn_status xnn_delete_subgraph(
 #define XNN_VALUE_FLAG_EXTERNAL_OUTPUT 0x00000002
 #define XNN_VALUE_FLAG_PERSISTENT      0x00000004
 
+/// Quantized block scales for the tensor are in fp32 format.
+#define XNN_VALUE_FLAG_FP32_SCALES 0x00000008
+
+/// Quantized block scales for the tensor are in fp16 format.
+#define XNN_VALUE_FLAG_FP16_SCALES 0x00000010
+
+/// Quantized block scales for the tensor are in bf16 format.
+#define XNN_VALUE_FLAG_BF16_SCALES 0x00000020
+
 #define XNN_INVALID_VALUE_ID UINT32_MAX
 
 /// Type of elements in a Value object.
@@ -273,8 +282,8 @@ enum xnn_datatype {
   /// 32-bit signed integers.
   xnn_datatype_int32 = 11,
   /// Quantized 4-bit signed integer with shared per-channel-block quantization
-  /// parameters.
-  xnn_datatype_qbint4 = 12,
+  /// parameters (bf16 format).
+  xnn_datatype_qbint4_bf16 = 12,
 };
 
 /// Define a tensor-type Value and add it to a Subgraph.
@@ -423,11 +432,12 @@ enum xnn_status xnn_define_channelwise_quantized_tensor_value_v2(
 ///                     number of input channel element per output channel.
 ///                     For Fully connected operators with 2d filters of size [output_channels, input_channels],
 ///                     expecting number of scale values to be = output_channels * (input_channels / block_size).
+/// @param flags - binary features of the Value. Supported values are XNN_VALUE_FLAG_BF16_SCALES.
 enum xnn_status xnn_define_blockwise_quantized_tensor_value(
   xnn_subgraph_t subgraph,
   enum xnn_datatype datatype,
   int32_t zero_point,
-  const uint16_t* scale,
+  const void* scale,
   size_t num_dims,
   size_t channel_dim,
   size_t block_size,

--- a/src/enums/datatype-strings.c
+++ b/src/enums/datatype-strings.c
@@ -39,8 +39,8 @@ const char* xnn_datatype_to_string(enum xnn_datatype type) {
       return "QPINT8";
     case xnn_datatype_int32:
      return "INT32";
-    case xnn_datatype_qbint4:
-     return "QBINT4";
+    case xnn_datatype_qbint4_bf16:
+     return "QBINT4_BF16";
   }
   XNN_UNREACHABLE;
   return NULL;

--- a/src/subgraph/fully-connected.c
+++ b/src/subgraph/fully-connected.c
@@ -174,7 +174,7 @@ static enum xnn_status create_fully_connected_operator(
             weights_cache,
             &opdata->operator_objects[0]);
           break;
-        case xnn_datatype_qbint4:
+        case xnn_datatype_qbint4_bf16:
           status = xnn_create_fully_connected_nc_qd8_f16_qb4w(
             input_channels,
             output_channels,
@@ -235,7 +235,7 @@ static enum xnn_status create_fully_connected_operator(
             weights_cache,
             &opdata->operator_objects[0]);
           break;
-        case xnn_datatype_qbint4:
+        case xnn_datatype_qbint4_bf16:
           status = xnn_create_fully_connected_nc_qd8_f32_qb4w(
             input_channels,
             output_channels,
@@ -795,7 +795,7 @@ static inline enum xnn_compute_type validate_datatypes_with_bias(
         return xnn_compute_type_qd8_to_fp16;
       }
       break;
-    case xnn_datatype_qbint4:
+    case xnn_datatype_qbint4_bf16:
       if (input_datatype == xnn_datatype_qdint8 &&
           bias_datatype == xnn_datatype_fp32 &&
           output_datatype == xnn_datatype_fp32)
@@ -882,7 +882,7 @@ static inline enum xnn_compute_type validate_datatypes_without_bias(
         return xnn_compute_type_qd8_to_fp16;
       }
       break;
-    case xnn_datatype_qbint4:
+    case xnn_datatype_qbint4_bf16:
       if (input_datatype == xnn_datatype_qdint8 && output_datatype == xnn_datatype_fp32) {
         return xnn_compute_type_qd8_to_fp32;
       } else if (input_datatype == xnn_datatype_qdint8 && output_datatype == xnn_datatype_fp16) {
@@ -1010,7 +1010,7 @@ enum xnn_status xnn_define_fully_connected(
   switch (kernel_value->datatype) {
     case xnn_datatype_fp32:
       break;
-    case xnn_datatype_qbint4:
+    case xnn_datatype_qbint4_bf16:
     case xnn_datatype_qcint4:
       if (kernel_value->quantization.zero_point != 8 && kernel_value->quantization.zero_point != 0) {
         xnn_log_error(
@@ -1054,7 +1054,7 @@ enum xnn_status xnn_define_fully_connected(
     }
   }
 
-  const bool is_blockwise_quantized = kernel_value->datatype == xnn_datatype_qbint4;
+  const bool is_blockwise_quantized = kernel_value->datatype == xnn_datatype_qbint4_bf16;
 
   if (is_blockwise_quantized) {
     // TODO: Unsupported features

--- a/test/fully-connected.cc
+++ b/test/fully-connected.cc
@@ -2993,7 +2993,7 @@ TEST_F(FullyConnectedTestQD8F16QB4W, define)
   uint32_t kernel_id = XNN_INVALID_VALUE_ID;
   ASSERT_EQ(
     xnn_status_success, xnn_define_blockwise_quantized_tensor_value(
-        subgraph, xnn_datatype_qbint4, kernel_zero_point, kernel_scale.data(), kernel_dims.size(),
+        subgraph, xnn_datatype_qbint4_bf16, kernel_zero_point, kernel_scale.data(), kernel_dims.size(),
         /*channel_dim=*/0, block_size, kernel_dims.data(), kernel.data(), /*external_id=*/1, /*flags=*/0, &kernel_id));
 
   uint32_t bias_id = XNN_INVALID_VALUE_ID;
@@ -3115,7 +3115,7 @@ TEST_F(FullyConnectedTestQD8F16QB4W, internally_allocated_dynamic_quantization_p
   uint32_t kernel_id = XNN_INVALID_VALUE_ID;
   ASSERT_EQ(
     xnn_status_success, xnn_define_blockwise_quantized_tensor_value(
-        subgraph, xnn_datatype_qbint4, kernel_zero_point, kernel_scale.data(), kernel_dims.size(),
+        subgraph, xnn_datatype_qbint4_bf16, kernel_zero_point, kernel_scale.data(), kernel_dims.size(),
         /*channel_dim=*/0, block_size, kernel_dims.data(), kernel.data(), /*external_id=*/1, /*flags=*/0, &kernel_id));
 
   uint32_t bias_id = XNN_INVALID_VALUE_ID;
@@ -3945,7 +3945,7 @@ TEST_F(FullyConnectedTestQD8F32QB4W, define)
   uint32_t kernel_id = XNN_INVALID_VALUE_ID;
   ASSERT_EQ(
     xnn_status_success, xnn_define_blockwise_quantized_tensor_value(
-        subgraph, xnn_datatype_qbint4, kernel_zero_point, kernel_scale.data(), kernel_dims.size(),
+        subgraph, xnn_datatype_qbint4_bf16, kernel_zero_point, kernel_scale.data(), kernel_dims.size(),
         /*channel_dim=*/0, block_size, kernel_dims.data(), kernel.data(), /*external_id=*/1, /*flags=*/0, &kernel_id));
 
   uint32_t bias_id = XNN_INVALID_VALUE_ID;
@@ -4067,7 +4067,7 @@ TEST_F(FullyConnectedTestQD8F32QB4W, internally_allocated_dynamic_quantization_p
   uint32_t kernel_id = XNN_INVALID_VALUE_ID;
   ASSERT_EQ(
     xnn_status_success, xnn_define_blockwise_quantized_tensor_value(
-        subgraph, xnn_datatype_qbint4, kernel_zero_point, kernel_scale.data(), kernel_dims.size(),
+        subgraph, xnn_datatype_qbint4_bf16, kernel_zero_point, kernel_scale.data(), kernel_dims.size(),
         /*channel_dim=*/0, block_size, kernel_dims.data(), kernel.data(), /*external_id=*/1, /*flags=*/0, &kernel_id));
 
   uint32_t bias_id = XNN_INVALID_VALUE_ID;


### PR DESCRIPTION
This change extends the xnn_define_blockwise_quantized_tensor_value API to accept flags to control block scale format, though only bf16 is currently supported. The intent of this change is to allow for other block scale formats (fp16 or fp32) in the future without breaking API backwards compatibility.