### PR TITLE
Fix filepath formatting for Windows in update-microkernels.py

### DIFF
--- a/tools/update-microkernels.py
+++ b/tools/update-microkernels.py
@@ -234,6 +234,8 @@ def main(args):
 
       subdir = os.path.relpath(root, root_dir)
       filepath = os.path.join(subdir, name)
+      if os.name == 'nt':
+        filepath = filepath.replace('\\', '/')
 
       # Build microkernel name -> microkernel filepath mapping
       with open(os.path.join(root_dir, filepath), 'r', encoding='utf-8') as f:


### PR DESCRIPTION
When I generating new microkernels on Windows using `tools/update-microkernels.py`, the source paths in the generated CMake and Bazel files changed. Specifically, the paths were transformed from `src/f32-gemm/gen/f32-gemm-5x16-minmax-fma3-broadcast.c` to `src\f32-gemm\gen\f32-gemm-5x16-minmax-fma3-broadcast.c`.

This change in path formatting caused the following error when building with Bazel:
```
invalid escape sequence: \g. Use '\\' to insert '\'.
```
To fix this issue, I’ve updated the `update-microkernels.py` script to ensure that the path formatting remains consistent on Windows, preventing the generation of incorrect paths.