### PR TITLE
Add Emscripten support for Bazel benchmark builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -59,6 +59,10 @@ build:macos_arm64 --cpu=darwin_arm64
 # Disable Bzlmod for every Bazel command
 common --enable_bzlmod=false
 
+# wasm configs.
+build:wasm --enable_bzlmod=true
+build:wasm --features=wasm_relaxed_simd
+
 # Disable some warnings to allow a warning-free build
 build --cxxopt='-Wno-sign-compare'
 build --cxxopt='-Wno-comment'

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ out/
 *.pyc
 *.pyo
 *.log
+MODULE.bazel.lock
 
 # System files
 .DS_Store

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,3 @@
+module(name="xnnpack", version = "1.0")
+
+bazel_dep(name = "platforms", version = "0.0.9")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,3 +1,1 @@
-module(name="xnnpack", version = "1.0")
-
 bazel_dep(name = "platforms", version = "0.0.9")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -116,3 +116,20 @@ http_archive(
         "https://github.com/google/ruy/archive/9f53ba413e6fc879236dcaa3e008915973d67a4f.zip",
     ],
 )
+
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+git_repository(
+    name = "emsdk",
+    remote = "https://github.com/emscripten-core/emsdk.git",
+    tag = "3.1.68",
+    strip_prefix = "bazel",
+)
+
+load("@emsdk//:deps.bzl", emsdk_deps = "deps")
+emsdk_deps()
+
+load("@emsdk//:emscripten_deps.bzl", emsdk_emscripten_deps = "emscripten_deps")
+emsdk_emscripten_deps(emscripten_version = "3.1.68")
+
+load("@emsdk//:toolchains.bzl", "register_emscripten_toolchains")
+register_emscripten_toolchains()

--- a/bench/BUILD.bazel
+++ b/bench/BUILD.bazel
@@ -118,6 +118,11 @@ xnnpack_cxx_library(
     srcs = [
         "%s.cc" % kernel.replace("_", "-"),
     ],
+    copts = select({
+        "//build_config:emscripten": ["-mfp16"],
+        "//conditions:default": [],
+    }),
+    wasm = True,
     tags = xnnpack_slow_benchmark_tags(),
     deps = MICROKERNEL_BENCHMARK_DEPS + [
         ":gemm_benchmark",
@@ -148,6 +153,7 @@ xnnpack_cxx_library(
     ],
     copts = xnnpack_optional_ruy_copts() + xnnpack_optional_gemmlowp_copts(),
     tags = xnnpack_slow_benchmark_tags(),
+    wasm = True,
     deps = MICROKERNEL_BENCHMARK_DEPS + [
         ":gemm_benchmark",
         "//:allocator",

--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -2,6 +2,8 @@
 
 load("//:emscripten.bzl", "xnnpack_emscripten_benchmark_linkopts", "xnnpack_emscripten_deps", "xnnpack_emscripten_minimal_linkopts", "xnnpack_emscripten_test_linkopts")
 
+load("@emsdk//emscripten_toolchain:wasm_rules.bzl", "wasm_cc_binary")
+
 def xnnpack_visibility():
     """Visibility of :XNNPACK target.
 
@@ -376,7 +378,7 @@ def xnnpack_binary(name, srcs, copts = [], deps = [], linkopts = []):
         deps = deps,
     )
 
-def xnnpack_benchmark(name, srcs, copts = [], deps = [], tags = [], defines = []):
+def xnnpack_benchmark(name, srcs, copts = [], deps = [], tags = [], defines = [], wasm = False):
     """Microbenchmark binary based on Google Benchmark
 
     Args:
@@ -421,6 +423,15 @@ def xnnpack_benchmark(name, srcs, copts = [], deps = [], tags = [], defines = []
         defines = defines,
         args = ["--benchmark_min_time=1x"],
     )
+    if wasm:
+        wasm_cc_binary(
+            name = "%s_wasm" % name,
+            cc_target = ":%s" % name,
+            simd = True,
+            threads = "emscripten",
+            exit_runtime = True,
+            testonly = True
+        )
 
 SrcListInfo = provider("A list of source files.", fields = {"srcs": "sources"})
 


### PR DESCRIPTION
Despite some preparations for Emscripten builds XNNPACK still lacks a way of building benchmarks with Emscripten outside of google3 infrastructure. This PR closes this gap. After landing it benchmarks could be built by

```
bazel build //bench:f32_gemm_bench_wasm --config=wasm
```
