### PR TITLE
Fix static_assert not be supported on VS2019.

### DIFF
--- a/src/reference/binary-elementwise.cc
+++ b/src/reference/binary-elementwise.cc
@@ -66,7 +66,7 @@ void rbinaryc_ukernel_unquantized(size_t batch_size_bytes, const T* a,
 
 template <typename Operator, typename T>
 const xnn_binary_elementwise_config* get_config(T) {
-  static_assert(!xnnpack::is_quantized<T>::value);
+  assert(!xnnpack::is_quantized<T>::value);
   static xnn_binary_elementwise_config config = {
       (xnn_vbinary_ukernel_fn)binary_ukernel_unquantized<T, Operator>,
       (xnn_vbinary_ukernel_fn)binaryc_ukernel_unquantized<T, Operator>,

--- a/src/reference/unary-elementwise.cc
+++ b/src/reference/unary-elementwise.cc
@@ -98,7 +98,7 @@ size_t init_reference_unary_params(
 
 template <typename Operator, typename T>
 const xnn_unary_elementwise_config* get_config(T) {
-  static_assert(!xnnpack::is_quantized<T>::value, "");
+  assert(!xnnpack::is_quantized<T>::value, "");
   static xnn_unary_elementwise_config config = {
       (xnn_vunary_ukernel_fn)unary_ukernel_unquantized<T, T, Operator>,
       init_reference_unary_params,
@@ -153,7 +153,7 @@ const xnn_unary_elementwise_config* get_convert_config(
 template <typename TIn, typename TOut>
 const xnn_unary_elementwise_config* get_convert_config(xnnpack::quantized<TIn>,
                                                        TOut) {
-  static_assert(!xnnpack::is_quantized<TOut>::value, "");
+  assert(!xnnpack::is_quantized<TOut>::value, "");
   static xnn_unary_elementwise_config config = {
       (xnn_vunary_ukernel_fn)unary_ukernel_quantized_input<
           xnnpack::quantized<TIn>, TOut, ConvertOp<float, TOut>>,
@@ -165,7 +165,7 @@ const xnn_unary_elementwise_config* get_convert_config(xnnpack::quantized<TIn>,
 template <typename TIn, typename TOut>
 const xnn_unary_elementwise_config* get_convert_config(
     TIn, xnnpack::quantized<TOut>) {
-  static_assert(!xnnpack::is_quantized<TIn>::value, "");
+  assert(!xnnpack::is_quantized<TIn>::value, "");
   static xnn_unary_elementwise_config config = {
       (xnn_vunary_ukernel_fn)unary_ukernel_quantized_output<
           TIn, xnnpack::quantized<TOut>, ConvertOp<TIn, float>>,
@@ -176,8 +176,8 @@ const xnn_unary_elementwise_config* get_convert_config(
 
 template <typename TIn, typename TOut>
 const xnn_unary_elementwise_config* get_convert_config(TIn, TOut) {
-  static_assert(!xnnpack::is_quantized<TIn>::value, "");
-  static_assert(!xnnpack::is_quantized<TOut>::value, "");
+  assert(!xnnpack::is_quantized<TIn>::value, "");
+  assert(!xnnpack::is_quantized<TOut>::value, "");
   static xnn_unary_elementwise_config config = {
       (xnn_vunary_ukernel_fn)
           unary_ukernel_unquantized<TIn, TOut, ConvertOp<TIn, TOut>>,

--- a/src/xnnpack/buffer.h
+++ b/src/xnnpack/buffer.h
@@ -52,7 +52,7 @@ class NumericLimits<quantized<T>> {
 // the client code to see the unpadded data, and the padding was hidden.
 template <typename T, size_t Alignment = alignof(T)>
 class Buffer {
-  static_assert(std::is_trivial<T>::value, "");
+  assert(std::is_trivial<T>::value, "");
   T* data_;
   size_t size_;
 

--- a/test/binary-elementwise-nd.cc
+++ b/test/binary-elementwise-nd.cc
@@ -497,7 +497,7 @@ class BinaryElementwiseOperatorTester {
       const std::array<size_t, XNN_MAX_TENSOR_DIMS>& output_strides,
       const std::array<size_t, XNN_MAX_TENSOR_DIMS>& output_dims) {
     // Verify results.
-    static_assert(!xnnpack::is_quantized<T>::value);
+    assert(!xnnpack::is_quantized<T>::value);
     MinMaxLow limits = DatatypeMinMaxLow(datatype());
     for (size_t i = 0; i < output_dims[0]; i++) {
       for (size_t j = 0; j < output_dims[1]; j++) {
@@ -557,7 +557,7 @@ class BinaryElementwiseOperatorTester {
       const std::array<size_t, XNN_MAX_TENSOR_DIMS>& output_strides,
       const std::array<size_t, XNN_MAX_TENSOR_DIMS>& output_dims) {
     // Verify results.
-    static_assert(!xnnpack::is_quantized<T>::value);
+    assert(!xnnpack::is_quantized<T>::value);
     MinMaxLow limits = DatatypeMinMaxLow(datatype());
     for (size_t i = 0; i < output_dims[0]; i++) {
       for (size_t j = 0; j < output_dims[1]; j++) {

--- a/test/slice-nd-eager.cc
+++ b/test/slice-nd-eager.cc
@@ -21,37 +21,37 @@ constexpr size_t kDim6 = 9;
 // 1. offset = 0, size = full dimension
 // 2. offset = 1, size = full dimension - 3 (skip first and last 2 elements)
 // 3. offset > 0 && offset < size, size = 1 (copy 1 element from the middle)
-static_assert(kDim1 > 3, "kDim1 must be more than 3");
+assert(kDim1 > 3, "kDim1 must be more than 3");
 constexpr std::array<std::pair<size_t, size_t>, 3> kDim1TestCases = {{
     {0, kDim1},
     {1, kDim1 - 3},
     {kDim1 - 1, 1},
 }};
-static_assert(kDim2 > 3, "kDim2 must be more than 3");
+assert(kDim2 > 3, "kDim2 must be more than 3");
 constexpr std::array<std::pair<size_t, size_t>, 3> kDim2TestCases = {{
     {0, kDim2},
     {1, kDim2 - 3},
     {kDim2 - 2, 1},
 }};
-static_assert(kDim3 > 3, "kDim3 must be more than 3");
+assert(kDim3 > 3, "kDim3 must be more than 3");
 constexpr std::array<std::pair<size_t, size_t>, 3> kDim3TestCases = {{
     {0, kDim3},
     {1, kDim3 - 3},
     {kDim3 - 3, 1},
 }};
-static_assert(kDim4 > 4, "kDim4 must be more than 4");
+assert(kDim4 > 4, "kDim4 must be more than 4");
 constexpr std::array<std::pair<size_t, size_t>, 3> kDim4TestCases = {{
     {0, kDim4},
     {1, kDim4 - 3},
     {kDim4 - 4, 1},
 }};
-static_assert(kDim5 > 5, "kDim5 must be more than 5");
+assert(kDim5 > 5, "kDim5 must be more than 5");
 constexpr std::array<std::pair<size_t, size_t>, 3> kDim5TestCases = {{
     {0, kDim5},
     {1, kDim5 - 3},
     {kDim5 - 5, 1},
 }};
-static_assert(kDim6 > 6, "kDim6 must be more than 6");
+assert(kDim6 > 6, "kDim6 must be more than 6");
 constexpr std::array<std::pair<size_t, size_t>, 3> kDim6TestCases = {{
     {0, kDim6},
     {1, kDim6 - 3},

--- a/test/slice-nd.cc
+++ b/test/slice-nd.cc
@@ -21,37 +21,37 @@ constexpr size_t kDim6 = 9;
 // 1. offset = 0, size = full dimension
 // 2. offset = 1, size = full dimension - 3 (skip first and last 2 elements)
 // 3. offset > 0 && offset < size, size = 1 (copy 1 element from the middle)
-static_assert(kDim1 > 3, "kDim1 must be more than 3");
+assert(kDim1 > 3, "kDim1 must be more than 3");
 constexpr std::array<std::pair<size_t, size_t>, 3> kDim1TestCases = {{
     {0, kDim1},
     {1, kDim1 - 3},
     {kDim1 - 1, 1},
 }};
-static_assert(kDim2 > 3, "kDim2 must be more than 3");
+assert(kDim2 > 3, "kDim2 must be more than 3");
 constexpr std::array<std::pair<size_t, size_t>, 3> kDim2TestCases = {{
     {0, kDim2},
     {1, kDim2 - 3},
     {kDim2 - 2, 1},
 }};
-static_assert(kDim3 > 3, "kDim3 must be more than 3");
+assert(kDim3 > 3, "kDim3 must be more than 3");
 constexpr std::array<std::pair<size_t, size_t>, 3> kDim3TestCases = {{
     {0, kDim3},
     {1, kDim3 - 3},
     {kDim3 - 3, 1},
 }};
-static_assert(kDim4 > 4, "kDim4 must be more than 4");
+assert(kDim4 > 4, "kDim4 must be more than 4");
 constexpr std::array<std::pair<size_t, size_t>, 3> kDim4TestCases = {{
     {0, kDim4},
     {1, kDim4 - 3},
     {kDim4 - 4, 1},
 }};
-static_assert(kDim5 > 5, "kDim5 must be more than 5");
+assert(kDim5 > 5, "kDim5 must be more than 5");
 constexpr std::array<std::pair<size_t, size_t>, 3> kDim5TestCases = {{
     {0, kDim5},
     {1, kDim5 - 3},
     {kDim5 - 5, 1},
 }};
-static_assert(kDim6 > 6, "kDim6 must be more than 6");
+assert(kDim6 > 6, "kDim6 must be more than 6");
 constexpr std::array<std::pair<size_t, size_t>, 3> kDim6TestCases = {{
     {0, kDim6},
     {1, kDim6 - 3},

--- a/test/unary-ops.h
+++ b/test/unary-ops.h
@@ -613,7 +613,7 @@ void UnaryReferenceImpl(
     const xnn_quantization_params& input_quantization = {0, 1.0f},
     const xnn_quantization_params& output_quantization = {0, 1.0f},
     const xnn_unary_params& params = xnn_unary_params()) {
-  static_assert(!xnnpack::is_quantized<In>::value, "");
+  assert(!xnnpack::is_quantized<In>::value, "");
   for (size_t i = 0; i < n; i++) {
     float y_i = op_info.ReferenceImpl(static_cast<float>(x[i]), params);
     y_i = y_i / output_quantization.scale + output_quantization.zero_point;
@@ -628,7 +628,7 @@ void UnaryReferenceImpl(
     const xnn_quantization_params& input_quantization = {0, 1.0f},
     const xnn_quantization_params& output_quantization = {0, 1.0f},
     const xnn_unary_params& params = xnn_unary_params()) {
-  static_assert(!xnnpack::is_quantized<Out>::value, "");
+  assert(!xnnpack::is_quantized<Out>::value, "");
   for (size_t i = 0; i < n; i++) {
     float x_i = (x[i] - input_quantization.zero_point) * input_quantization.scale;
     float y_i = op_info.ReferenceImpl(x_i, params);
@@ -647,8 +647,8 @@ void UnaryReferenceImpl(
     const xnn_quantization_params& input_quantization = {0, 1.0f},
     const xnn_quantization_params& output_quantization = {0, 1.0f},
     const xnn_unary_params& params = xnn_unary_params()) {
-  static_assert(!xnnpack::is_quantized<In>::value, "");
-  static_assert(!xnnpack::is_quantized<Out>::value, "");
+  assert(!xnnpack::is_quantized<In>::value, "");
+  assert(!xnnpack::is_quantized<Out>::value, "");
   for (size_t i = 0; i < n; i++) {
     float y_i;
     if (std::is_integral<In>::value && std::is_integral<Out>::value) {


### PR DESCRIPTION
My pervious PR to add build option to turn off `libm`, link: https://github.com/google/XNNPACK/pull/7522 

After that, I tried to upgrade `XNNPACK` of `PyTorch`, but I found `static_assert` was not supported on MSVC 2019, error CI link: https://hud.pytorch.org/pr/141754. 
