### PR TITLE
fix:Incorrect boundary checks using output dimensions instead of input dimensions in the implementation of Im2col

### DIFF
--- a/bench/f32-im2col-gemm.cc
+++ b/bench/f32-im2col-gemm.cc
@@ -103,7 +103,7 @@ static void Im2ColGEMMBenchmark(benchmark::State& state,
         kernel_height, kernel_width,
         subsampling, subsampling,
         dilation, dilation,
-        input_width, padding_top, padding_left,
+        input_width, input_height, padding_top, padding_left,
         group_input_channels * sizeof(float) /* input channels */,
         group_input_channels * sizeof(float) /* input stride */,
         a.data(), im2col_buffer.data());

--- a/src/im2col.c
+++ b/src/im2col.c
@@ -20,6 +20,7 @@ void xnn_im2col_conv2d(
   size_t dilation_height,
   size_t dilation_width,
   size_t input_width,
+  size_t input_height,
   size_t input_padding_top,
   size_t input_padding_left,
   size_t group_input_channels_in_bytes,
@@ -31,10 +32,10 @@ void xnn_im2col_conv2d(
     for (size_t output_x = 0; output_x < output_width; output_x++) {
       for (size_t kernel_y = 0; kernel_y < kernel_height; kernel_y++) {
         const size_t input_y = output_y * subsampling_height + kernel_y * dilation_height - input_padding_top;
-        if (input_y < output_height) {
+        if (input_y < input_height) {
           for (size_t kernel_x = 0; kernel_x < kernel_width; kernel_x++) {
             const size_t input_x = output_x * subsampling_width + kernel_x * dilation_width - input_padding_left;
-            if (input_x < output_width) {
+            if (input_x < input_width) {
               memcpy(output,
                 (const void*) ((uintptr_t) input + (input_y * input_width + input_x) * input_pixel_stride_in_bytes),
                 group_input_channels_in_bytes);

--- a/src/xnnpack/im2col.h
+++ b/src/xnnpack/im2col.h
@@ -23,6 +23,7 @@ XNN_INTERNAL void xnn_im2col_conv2d(
   size_t dilation_height,
   size_t dilation_width,
   size_t input_width,
+  size_t input_height,
   size_t input_padding_top,
   size_t input_padding_left,
   size_t group_input_channels_in_bytes,


### PR DESCRIPTION
 Hi XNNPACK developers,
This pull request fixes incorrect boundary checks in the `xnn_im2col_conv2d` function. Previously, the code compared `input_y` and `input_x` against `output_height` and `output_width`, causing out-of-bounds accesses (or incorrect zero-padding). The fix changes these checks to use the actual `input_height` and `input_width`.

Best regards,
Chi-Wei