### PR TITLE
[RVV] add qs8-dwconv support for risc-v

### DIFF
--- a/bench/qs8-dwconv.cc
+++ b/bench/qs8-dwconv.cc
@@ -1660,15 +1660,8 @@ static void DWConvBenchmark(benchmark::State& state,
       xnn_init_qs8_conv_minmax_fp32_scalar_params,
        8 * (xnn_init_hardware_config()->vlenb / sizeof(int32_t)) /* channel tile */, 9 /* primary tile */, benchmark::utils::CheckRVV);
   }
-  static void qs8_dwconv_25p8vc__rvv(benchmark::State& state, const char* net) {
-    DWConvBenchmark(state,
-      xnn_qs8_dwconv_minmax_fp32_ukernel_25p8vc__rvv,
-      xnn_init_qs8_conv_minmax_fp32_scalar_params,
-       8 * (xnn_init_hardware_config()->vlenb / sizeof(int32_t)) /* channel tile */, 25 /* primary tile */, benchmark::utils::CheckRVV);
-  }
 
   BENCHMARK_DWCONV(qs8_dwconv_9p8vc__rvv);
-  BENCHMARK_DWCONV(qs8_dwconv_25p8vc__rvv);
 #endif // XNN_ARCH_RISCV && XNN_ENABLE_RISCV_VECTOR
 
 static void qs8_dwconv_9p1c__scalar_fmagic(benchmark::State& state, const char* net) {

--- a/bench/qs8-dwconv.cc
+++ b/bench/qs8-dwconv.cc
@@ -22,6 +22,7 @@
 #include "xnnpack/microparams-init.h"
 #include "xnnpack/microparams.h"
 #include "xnnpack/pack.h"
+#include "xnnpack/hardware-config.h"
 #include <benchmark/benchmark.h>
 
 static void DWConvBenchmark(
@@ -1652,6 +1653,23 @@ static void DWConvBenchmark(benchmark::State& state,
   BENCHMARK_DWCONV(qs8_dwconv_8f8m9l4c1s1r__wasm_fmagic);
 #endif  // XNN_ARCH_WASM || XNN_ARCH_WASMSIMD || XNN_ARCH_WASMRELAXEDSIMD
 
+#if XNN_ARCH_RISCV && XNN_ENABLE_RISCV_VECTOR
+  static void qs8_dwconv_9p8vc__rvv(benchmark::State& state, const char* net) {
+    DWConvBenchmark(state,
+      xnn_qs8_dwconv_minmax_fp32_ukernel_9p8vc__rvv,
+      xnn_init_qs8_conv_minmax_fp32_scalar_params,
+       8 * (xnn_init_hardware_config()->vlenb / sizeof(int32_t)) /* channel tile */, 9 /* primary tile */, benchmark::utils::CheckRVV);
+  }
+  static void qs8_dwconv_25p8vc__rvv(benchmark::State& state, const char* net) {
+    DWConvBenchmark(state,
+      xnn_qs8_dwconv_minmax_fp32_ukernel_25p8vc__rvv,
+      xnn_init_qs8_conv_minmax_fp32_scalar_params,
+       8 * (xnn_init_hardware_config()->vlenb / sizeof(int32_t)) /* channel tile */, 25 /* primary tile */, benchmark::utils::CheckRVV);
+  }
+
+  BENCHMARK_DWCONV(qs8_dwconv_9p8vc__rvv);
+  BENCHMARK_DWCONV(qs8_dwconv_25p8vc__rvv);
+#endif // XNN_ARCH_RISCV && XNN_ENABLE_RISCV_VECTOR
 
 static void qs8_dwconv_9p1c__scalar_fmagic(benchmark::State& state, const char* net) {
   DWConvBenchmark(state,

--- a/cmake/gen/rvv_microkernels.cmake
+++ b/cmake/gen/rvv_microkernels.cmake
@@ -52,6 +52,11 @@ SET(PROD_RVV_MICROKERNEL_SRCS
   src/f32-vrnd/gen/f32-vrndu-rvv-u4v.c
   src/f32-vrnd/gen/f32-vrndz-rvv-u4v.c
   src/f32-vrsqrt/gen/f32-vrsqrt-rvv-rsqrt-u4v.c
+  src/qs8-dwconv/gen/qs8-dwconv-9p8vc-minmax-fp32-rvv.c
+  src/qs8-dwconv/gen/qs8-dwconv-25p8vc-minmax-fp32-rvv.c
+  src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-3p8vc-minmax-fp32-rvv.c
+  src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-9p8vc-minmax-fp32-rvv.c
+  src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-25p8vc-minmax-fp32-rvv.c
   src/qs8-f32-vcvt/gen/qs8-f32-vcvt-rvv-u2v.c
   src/qs8-vlrelu/gen/qs8-vlrelu-rvv-u2v.c
   src/qs8-vmul/gen/qs8-vmul-minmax-f32-rvv-u2v.c

--- a/cmake/gen/rvv_microkernels.cmake
+++ b/cmake/gen/rvv_microkernels.cmake
@@ -61,6 +61,8 @@ SET(PROD_RVV_MICROKERNEL_SRCS
   src/qs8-vlrelu/gen/qs8-vlrelu-rvv-u2v.c
   src/qs8-vmul/gen/qs8-vmul-minmax-f32-rvv-u2v.c
   src/qs8-vmulc/gen/qs8-vmulc-minmax-f32-rvv-u2v.c
+  src/qu8-dwconv/gen/qu8-dwconv-9p8vc-minmax-fp32-rvv.c
+  src/qu8-dwconv/gen/qu8-dwconv-25p8vc-minmax-fp32-rvv.c
   src/qu8-f32-vcvt/gen/qu8-f32-vcvt-rvv-u2v.c
   src/qu8-vlrelu/gen/qu8-vlrelu-rvv-u2v.c
   src/qu8-vmul/gen/qu8-vmul-minmax-f32-rvv-u2v.c

--- a/scripts/generate-qs8-dwconv.sh
+++ b/scripts/generate-qs8-dwconv.sh
@@ -1033,4 +1033,12 @@ tools/xngen src/qs8-dwconv/multipass-avx512skx-mul32.c.in -D CHANNEL_TILE=32  -D
 tools/xngen src/qs8-dwconv/multipass-avx512skx-mul32.c.in -D CHANNEL_TILE=16  -D FIRST_PASS_TILE=8  -D MIDDLE_PASS_TILE=8  -D LAST_PASS_TILE=9 -D DATATYPE=QC8 -D REQUANTIZATION=FP32     -o src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-8f8m9l16c16s1r-minmax-fp32-avx512skx-mul32.c &
 tools/xngen src/qs8-dwconv/multipass-avx512skx-mul32.c.in -D CHANNEL_TILE=32  -D FIRST_PASS_TILE=8  -D MIDDLE_PASS_TILE=8  -D LAST_PASS_TILE=9 -D DATATYPE=QC8 -D REQUANTIZATION=FP32     -o src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-8f8m9l32c16s1r-minmax-fp32-avx512skx-mul32.c &
 
+################################ RISC-V Vector ################################
+tools/xngen src/qs8-dwconv/unipass-rvv.c.in -D CHANNEL_TILE=m8 -D KERNEL_TILE=3  -D DATATYPE=QC8 -D REQUANTIZATION=FP32     -o src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-3p8vc-minmax-fp32-rvv.c &
+tools/xngen src/qs8-dwconv/unipass-rvv.c.in -D CHANNEL_TILE=m8 -D KERNEL_TILE=9  -D DATATYPE=QC8 -D REQUANTIZATION=FP32     -o src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-9p8vc-minmax-fp32-rvv.c &
+tools/xngen src/qs8-dwconv/unipass-rvv.c.in -D CHANNEL_TILE=m8 -D KERNEL_TILE=25 -D DATATYPE=QC8 -D REQUANTIZATION=FP32     -o src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-25p8vc-minmax-fp32-rvv.c &
+
+tools/xngen src/qs8-dwconv/unipass-rvv.c.in -D CHANNEL_TILE=m8 -D KERNEL_TILE=9  -D DATATYPE=QS8 -D REQUANTIZATION=FP32     -o src/qs8-dwconv/gen/qs8-dwconv-9p8vc-minmax-fp32-rvv.c &
+tools/xngen src/qs8-dwconv/unipass-rvv.c.in -D CHANNEL_TILE=m8 -D KERNEL_TILE=25 -D DATATYPE=QS8 -D REQUANTIZATION=FP32     -o src/qs8-dwconv/gen/qs8-dwconv-25p8vc-minmax-fp32-rvv.c &
+
 wait

--- a/scripts/generate-qs8-dwconv.sh
+++ b/scripts/generate-qs8-dwconv.sh
@@ -1041,4 +1041,7 @@ tools/xngen src/qs8-dwconv/unipass-rvv.c.in -D CHANNEL_TILE=m8 -D KERNEL_TILE=25
 tools/xngen src/qs8-dwconv/unipass-rvv.c.in -D CHANNEL_TILE=m8 -D KERNEL_TILE=9  -D DATATYPE=QS8 -D REQUANTIZATION=FP32     -o src/qs8-dwconv/gen/qs8-dwconv-9p8vc-minmax-fp32-rvv.c &
 tools/xngen src/qs8-dwconv/unipass-rvv.c.in -D CHANNEL_TILE=m8 -D KERNEL_TILE=25 -D DATATYPE=QS8 -D REQUANTIZATION=FP32     -o src/qs8-dwconv/gen/qs8-dwconv-25p8vc-minmax-fp32-rvv.c &
 
+tools/xngen src/qs8-dwconv/unipass-rvv.c.in -D CHANNEL_TILE=m8 -D KERNEL_TILE=9  -D DATATYPE=QU8 -D REQUANTIZATION=FP32     -o src/qu8-dwconv/gen/qu8-dwconv-9p8vc-minmax-fp32-rvv.c &
+tools/xngen src/qs8-dwconv/unipass-rvv.c.in -D CHANNEL_TILE=m8 -D KERNEL_TILE=25 -D DATATYPE=QU8 -D REQUANTIZATION=FP32     -o src/qu8-dwconv/gen/qu8-dwconv-25p8vc-minmax-fp32-rvv.c &
+
 wait

--- a/src/configs/dwconv-config.c
+++ b/src/configs/dwconv-config.c
@@ -1285,7 +1285,7 @@ static void init_qu8_dwconv_config(void) {
       const struct xnn_hardware_config* hardware_config = xnn_init_hardware_config();
       qs8_dwconv_config[0].minmax.unipass = (xnn_dwconv_unipass_ukernel_fn) xnn_qu8_dwconv_minmax_fp32_ukernel_9p8vc__rvv;
       qs8_dwconv_config[0].init.qu8 = xnn_init_qu8_conv_minmax_fp32_scalar_params;
-      qs8_dwconv_config[0].channel_tile = 8* hardware_config->vlenb / sizeof(int32_t);
+      qs8_dwconv_config[0].channel_tile = 8 * hardware_config->vlenb / sizeof(int32_t);
       qs8_dwconv_config[0].channel_subtile = 8 * hardware_config->vlenb / sizeof(int32_t);
       qs8_dwconv_config[0].channel_round = 1;
       qs8_dwconv_config[0].primary_tile = 9;

--- a/src/configs/dwconv-config.c
+++ b/src/configs/dwconv-config.c
@@ -1104,7 +1104,7 @@ static void init_qs8_dwconv_config(void) {
       const struct xnn_hardware_config* hardware_config = xnn_init_hardware_config();
       qs8_dwconv_config[0].minmax.unipass = (xnn_dwconv_unipass_ukernel_fn) xnn_qs8_dwconv_minmax_fp32_ukernel_9p8vc__rvv;
       qs8_dwconv_config[0].init.qs8_qc8w = xnn_init_qs8_qc8w_conv_minmax_fp32_scalar_params;
-      qs8_dwconv_config[0].channel_tile = 8* hardware_config->vlenb / sizeof(int32_t);
+      qs8_dwconv_config[0].channel_tile = 8 * hardware_config->vlenb / sizeof(int32_t);
       qs8_dwconv_config[0].channel_subtile = 8 * hardware_config->vlenb / sizeof(int32_t);
       qs8_dwconv_config[0].channel_round = 1;
       qs8_dwconv_config[0].primary_tile = 9;

--- a/src/configs/dwconv-config.c
+++ b/src/configs/dwconv-config.c
@@ -911,20 +911,20 @@ static void init_qs8_qc8w_dwconv_config(void) {
       const struct xnn_hardware_config* hardware_config = xnn_init_hardware_config();
       qs8_qc8w_dwconv_config[0].minmax.unipass = (xnn_dwconv_unipass_ukernel_fn) xnn_qs8_qc8w_dwconv_minmax_fp32_ukernel_3p8vc__rvv;
       qs8_qc8w_dwconv_config[0].init.qs8_qc8w = xnn_init_qs8_qc8w_conv_minmax_fp32_scalar_params;
-      qs8_qc8w_dwconv_config[0].channel_tile = hardware_config->vlenb / 4 * 8;
-      qs8_qc8w_dwconv_config[0].channel_subtile = hardware_config->vlenb / 4 * 8;
+      qs8_qc8w_dwconv_config[0].channel_tile = 8 * hardware_config->vlenb / sizeof(int32_t);
+      qs8_qc8w_dwconv_config[0].channel_subtile = 8 * hardware_config->vlenb / sizeof(int32_t);
       qs8_qc8w_dwconv_config[0].channel_round = 1;
       qs8_qc8w_dwconv_config[0].primary_tile = 3;
       qs8_qc8w_dwconv_config[1].minmax.unipass = (xnn_dwconv_unipass_ukernel_fn) xnn_qs8_qc8w_dwconv_minmax_fp32_ukernel_9p8vc__rvv;
       qs8_qc8w_dwconv_config[1].init.qs8_qc8w = xnn_init_qs8_qc8w_conv_minmax_fp32_scalar_params;
-      qs8_qc8w_dwconv_config[1].channel_tile = hardware_config->vlenb / 4 * 8;
-      qs8_qc8w_dwconv_config[1].channel_subtile = hardware_config->vlenb / 4 * 8;
+      qs8_qc8w_dwconv_config[1].channel_tile = 8 * hardware_config->vlenb / sizeof(int32_t);
+      qs8_qc8w_dwconv_config[1].channel_subtile = 8 * hardware_config->vlenb / sizeof(int32_t);
       qs8_qc8w_dwconv_config[1].channel_round = 1;
       qs8_qc8w_dwconv_config[1].primary_tile = 9;
       qs8_qc8w_dwconv_config[2].minmax.unipass = (xnn_dwconv_unipass_ukernel_fn) xnn_qs8_qc8w_dwconv_minmax_fp32_ukernel_25p8vc__rvv;
       qs8_qc8w_dwconv_config[2].init.qs8_qc8w = xnn_init_qs8_qc8w_conv_minmax_fp32_scalar_params;
-      qs8_qc8w_dwconv_config[2].channel_tile = hardware_config->vlenb / 4 * 8;
-      qs8_qc8w_dwconv_config[2].channel_subtile = hardware_config->vlenb / 4 * 8;
+      qs8_qc8w_dwconv_config[2].channel_tile = 8 * hardware_config->vlenb / sizeof(int32_t);
+      qs8_qc8w_dwconv_config[2].channel_subtile = 8 * hardware_config->vlenb / sizeof(int32_t);
       qs8_qc8w_dwconv_config[2].channel_round = 1;
       qs8_qc8w_dwconv_config[2].primary_tile = 25;
   #else
@@ -1104,14 +1104,14 @@ static void init_qs8_dwconv_config(void) {
       const struct xnn_hardware_config* hardware_config = xnn_init_hardware_config();
       qs8_dwconv_config[0].minmax.unipass = (xnn_dwconv_unipass_ukernel_fn) xnn_qs8_dwconv_minmax_fp32_ukernel_9p8vc__rvv;
       qs8_dwconv_config[0].init.qs8_qc8w = xnn_init_qs8_qc8w_conv_minmax_fp32_scalar_params;
-      qs8_dwconv_config[0].channel_tile = hardware_config->vlenb / 4 * 8;
-      qs8_dwconv_config[0].channel_subtile = hardware_config->vlenb / 4 * 8;
+      qs8_dwconv_config[0].channel_tile = 8* hardware_config->vlenb / sizeof(int32_t);
+      qs8_dwconv_config[0].channel_subtile = 8 * hardware_config->vlenb / sizeof(int32_t);
       qs8_dwconv_config[0].channel_round = 1;
       qs8_dwconv_config[0].primary_tile = 9;
       qs8_dwconv_config[1].minmax.unipass = (xnn_dwconv_unipass_ukernel_fn) xnn_qs8_dwconv_minmax_fp32_ukernel_25p8vc__rvv;
       qs8_dwconv_config[1].init.qs8_qc8w = xnn_init_qs8_qc8w_conv_minmax_fp32_scalar_params;
-      qs8_dwconv_config[1].channel_tile = hardware_config->vlenb / 4 * 8;
-      qs8_dwconv_config[1].channel_subtile = hardware_config->vlenb / 4 * 8;
+      qs8_dwconv_config[1].channel_tile = 8 * hardware_config->vlenb / sizeof(int32_t);
+      qs8_dwconv_config[1].channel_subtile = 8 * hardware_config->vlenb / sizeof(int32_t);
       qs8_dwconv_config[1].channel_round = 1;
       qs8_dwconv_config[1].primary_tile = 25;
   #else
@@ -1281,6 +1281,20 @@ static void init_qu8_dwconv_config(void) {
       qu8_dwconv_config[1].channel_round = 1;
       qu8_dwconv_config[1].primary_tile = 25;
     }
+  #elif XNN_ARCH_RISCV && XNN_ENABLE_RISCV_VECTOR
+      const struct xnn_hardware_config* hardware_config = xnn_init_hardware_config();
+      qs8_dwconv_config[0].minmax.unipass = (xnn_dwconv_unipass_ukernel_fn) xnn_qu8_dwconv_minmax_fp32_ukernel_9p8vc__rvv;
+      qs8_dwconv_config[0].init.qu8 = xnn_init_qu8_conv_minmax_fp32_scalar_params;
+      qs8_dwconv_config[0].channel_tile = 8* hardware_config->vlenb / sizeof(int32_t);
+      qs8_dwconv_config[0].channel_subtile = 8 * hardware_config->vlenb / sizeof(int32_t);
+      qs8_dwconv_config[0].channel_round = 1;
+      qs8_dwconv_config[0].primary_tile = 9;
+      qs8_dwconv_config[1].minmax.unipass = (xnn_dwconv_unipass_ukernel_fn) xnn_qu8_dwconv_minmax_fp32_ukernel_25p8vc__rvv;
+      qs8_dwconv_config[1].init.qu8 = xnn_init_qu8_conv_minmax_fp32_scalar_params;
+      qs8_dwconv_config[1].channel_tile = 8 * hardware_config->vlenb / sizeof(int32_t);
+      qs8_dwconv_config[1].channel_subtile = 8 * hardware_config->vlenb / sizeof(int32_t);
+      qs8_dwconv_config[1].channel_round = 1;
+      qs8_dwconv_config[1].primary_tile = 25;
   #else
     qu8_dwconv_config[0].minmax.unipass = (xnn_dwconv_unipass_ukernel_fn) xnn_qu8_dwconv_minmax_fp32_ukernel_9p2c__scalar_lrintf;
     qu8_dwconv_config[0].init.qu8 = xnn_init_qu8_conv_minmax_fp32_scalar_params;

--- a/src/configs/dwconv-config.c
+++ b/src/configs/dwconv-config.c
@@ -907,6 +907,26 @@ static void init_qs8_qc8w_dwconv_config(void) {
       qs8_qc8w_dwconv_config[2].channel_round = 1;
       qs8_qc8w_dwconv_config[2].primary_tile = 25;
     }
+  #elif XNN_ARCH_RISCV && XNN_ENABLE_RISCV_VECTOR
+      const struct xnn_hardware_config* hardware_config = xnn_init_hardware_config();
+      qs8_qc8w_dwconv_config[0].minmax.unipass = (xnn_dwconv_unipass_ukernel_fn) xnn_qs8_qc8w_dwconv_minmax_fp32_ukernel_3p8vc__rvv;
+      qs8_qc8w_dwconv_config[0].init.qs8_qc8w = xnn_init_qs8_qc8w_conv_minmax_fp32_scalar_params;
+      qs8_qc8w_dwconv_config[0].channel_tile = hardware_config->vlenb / 4 * 8;
+      qs8_qc8w_dwconv_config[0].channel_subtile = hardware_config->vlenb / 4 * 8;
+      qs8_qc8w_dwconv_config[0].channel_round = 1;
+      qs8_qc8w_dwconv_config[0].primary_tile = 3;
+      qs8_qc8w_dwconv_config[1].minmax.unipass = (xnn_dwconv_unipass_ukernel_fn) xnn_qs8_qc8w_dwconv_minmax_fp32_ukernel_9p8vc__rvv;
+      qs8_qc8w_dwconv_config[1].init.qs8_qc8w = xnn_init_qs8_qc8w_conv_minmax_fp32_scalar_params;
+      qs8_qc8w_dwconv_config[1].channel_tile = hardware_config->vlenb / 4 * 8;
+      qs8_qc8w_dwconv_config[1].channel_subtile = hardware_config->vlenb / 4 * 8;
+      qs8_qc8w_dwconv_config[1].channel_round = 1;
+      qs8_qc8w_dwconv_config[1].primary_tile = 9;
+      qs8_qc8w_dwconv_config[2].minmax.unipass = (xnn_dwconv_unipass_ukernel_fn) xnn_qs8_qc8w_dwconv_minmax_fp32_ukernel_25p8vc__rvv;
+      qs8_qc8w_dwconv_config[2].init.qs8_qc8w = xnn_init_qs8_qc8w_conv_minmax_fp32_scalar_params;
+      qs8_qc8w_dwconv_config[2].channel_tile = hardware_config->vlenb / 4 * 8;
+      qs8_qc8w_dwconv_config[2].channel_subtile = hardware_config->vlenb / 4 * 8;
+      qs8_qc8w_dwconv_config[2].channel_round = 1;
+      qs8_qc8w_dwconv_config[2].primary_tile = 25;
   #else
     qs8_qc8w_dwconv_config[0].minmax.unipass = (xnn_dwconv_unipass_ukernel_fn) xnn_qs8_qc8w_dwconv_minmax_fp32_ukernel_3p2c__scalar_lrintf;
     qs8_qc8w_dwconv_config[0].init.qs8_qc8w = xnn_init_qs8_qc8w_conv_minmax_fp32_scalar_params;
@@ -1080,6 +1100,20 @@ static void init_qs8_dwconv_config(void) {
       qs8_dwconv_config[1].channel_round = 1;
       qs8_dwconv_config[1].primary_tile = 25;
     }
+  #elif XNN_ARCH_RISCV && XNN_ENABLE_RISCV_VECTOR
+      const struct xnn_hardware_config* hardware_config = xnn_init_hardware_config();
+      qs8_dwconv_config[0].minmax.unipass = (xnn_dwconv_unipass_ukernel_fn) xnn_qs8_dwconv_minmax_fp32_ukernel_9p8vc__rvv;
+      qs8_dwconv_config[0].init.qs8_qc8w = xnn_init_qs8_qc8w_conv_minmax_fp32_scalar_params;
+      qs8_dwconv_config[0].channel_tile = hardware_config->vlenb / 4 * 8;
+      qs8_dwconv_config[0].channel_subtile = hardware_config->vlenb / 4 * 8;
+      qs8_dwconv_config[0].channel_round = 1;
+      qs8_dwconv_config[0].primary_tile = 9;
+      qs8_dwconv_config[1].minmax.unipass = (xnn_dwconv_unipass_ukernel_fn) xnn_qs8_dwconv_minmax_fp32_ukernel_25p8vc__rvv;
+      qs8_dwconv_config[1].init.qs8_qc8w = xnn_init_qs8_qc8w_conv_minmax_fp32_scalar_params;
+      qs8_dwconv_config[1].channel_tile = hardware_config->vlenb / 4 * 8;
+      qs8_dwconv_config[1].channel_subtile = hardware_config->vlenb / 4 * 8;
+      qs8_dwconv_config[1].channel_round = 1;
+      qs8_dwconv_config[1].primary_tile = 25;
   #else
     qs8_dwconv_config[0].minmax.unipass = (xnn_dwconv_unipass_ukernel_fn) xnn_qs8_dwconv_minmax_fp32_ukernel_9p2c__scalar_lrintf;
     qs8_dwconv_config[0].init.qs8 = xnn_init_qs8_conv_minmax_fp32_scalar_params;

--- a/src/qs8-dwconv/gen/qs8-dwconv-25p8vc-minmax-fp32-rvv.c
+++ b/src/qs8-dwconv/gen/qs8-dwconv-25p8vc-minmax-fp32-rvv.c
@@ -2,7 +2,7 @@
 //   Template: src/qs8-dwconv/unipass-rvv.c.in
 //   Generator: tools/xngen
 //
-// Copyright 2024 Microchip
+// Copyright 2025 Microchip
 //
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
@@ -174,11 +174,12 @@ void xnn_qs8_dwconv_minmax_fp32_ukernel_25p8vc__rvv(
 
       for (size_t k = 0; k < 25; ++k) {
         vint8m2_t vi = __riscv_vle8_v_i8m2(i[k], vl);
-        vint8m2_t vk = __riscv_vle8_v_i8m2(w, vl);
+        vint8m2_t vk = __riscv_vle8_v_i8m2((const int8_t*) w, vl);
         w = (const void*) ((uintptr_t) w + vlmax * sizeof(int8_t));
 
         i[k] += vlmax;
-        vacc = __riscv_vwmacc_vv_i32m8(vacc, __riscv_vwcvt_x_x_v_i16m4(vi, vl), __riscv_vwcvt_x_x_v_i16m4(vk, vl), vl);
+        vint16m4_t vtmp16 =  __riscv_vwmul_vv_i16m4(vi, vk, vl);
+        vacc =  __riscv_vwadd_wv_i32m8(vacc, vtmp16, vl);
       }
 
       vfloat32m8_t vfpacc = __riscv_vfcvt_f_x_v_f32m8(vacc, vl);

--- a/src/qs8-dwconv/gen/qs8-dwconv-25p8vc-minmax-fp32-rvv.c
+++ b/src/qs8-dwconv/gen/qs8-dwconv-25p8vc-minmax-fp32-rvv.c
@@ -1,0 +1,202 @@
+// Auto-generated file. Do not edit!
+//   Template: src/qs8-dwconv/unipass-rvv.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2024 Microchip
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+#include <riscv_vector.h>
+#include "xnnpack/dwconv.h"
+
+
+void xnn_qs8_dwconv_minmax_fp32_ukernel_25p8vc__rvv(
+    size_t channels,
+    size_t output_width,
+    const int8_t** input,
+    const void* weights,
+    int8_t* output,
+    intptr_t input_stride,
+    size_t output_increment,
+    size_t input_offset,
+    const int8_t* zero,
+    const union xnn_qs8_conv_minmax_params params[restrict XNN_MIN_ELEMENTS(1)])
+{
+  assert(channels != 0);
+  assert(output_width != 0);
+
+  const float vscale = params->fp32_scalar.scale;
+  const float voutput_min_less_zero_point = (int32_t) params->fp32_scalar.output_min - (int32_t) params->fp32_scalar.output_zero_point;
+  const float voutput_max_less_zero_point = (int32_t) params->fp32_scalar.output_max - (int32_t) params->fp32_scalar.output_zero_point;
+  const int16_t voutput_zero_point = params->fp32_scalar.output_zero_point;
+
+  do {
+    const int8_t* i[25];
+    i[0] = input[0];
+    assert(i[0] != NULL);
+    if XNN_UNPREDICTABLE(i[0] != zero) {
+      i[0] = (const int8_t*) ((uintptr_t) i[0] + input_offset);
+    }
+    i[1] = input[1];
+    assert(i[1] != NULL);
+    if XNN_UNPREDICTABLE(i[1] != zero) {
+      i[1] = (const int8_t*) ((uintptr_t) i[1] + input_offset);
+    }
+    i[2] = input[2];
+    assert(i[2] != NULL);
+    if XNN_UNPREDICTABLE(i[2] != zero) {
+      i[2] = (const int8_t*) ((uintptr_t) i[2] + input_offset);
+    }
+    i[3] = input[3];
+    assert(i[3] != NULL);
+    if XNN_UNPREDICTABLE(i[3] != zero) {
+      i[3] = (const int8_t*) ((uintptr_t) i[3] + input_offset);
+    }
+    i[4] = input[4];
+    assert(i[4] != NULL);
+    if XNN_UNPREDICTABLE(i[4] != zero) {
+      i[4] = (const int8_t*) ((uintptr_t) i[4] + input_offset);
+    }
+    i[5] = input[5];
+    assert(i[5] != NULL);
+    if XNN_UNPREDICTABLE(i[5] != zero) {
+      i[5] = (const int8_t*) ((uintptr_t) i[5] + input_offset);
+    }
+    i[6] = input[6];
+    assert(i[6] != NULL);
+    if XNN_UNPREDICTABLE(i[6] != zero) {
+      i[6] = (const int8_t*) ((uintptr_t) i[6] + input_offset);
+    }
+    i[7] = input[7];
+    assert(i[7] != NULL);
+    if XNN_UNPREDICTABLE(i[7] != zero) {
+      i[7] = (const int8_t*) ((uintptr_t) i[7] + input_offset);
+    }
+    i[8] = input[8];
+    assert(i[8] != NULL);
+    if XNN_UNPREDICTABLE(i[8] != zero) {
+      i[8] = (const int8_t*) ((uintptr_t) i[8] + input_offset);
+    }
+    i[9] = input[9];
+    assert(i[9] != NULL);
+    if XNN_UNPREDICTABLE(i[9] != zero) {
+      i[9] = (const int8_t*) ((uintptr_t) i[9] + input_offset);
+    }
+    i[10] = input[10];
+    assert(i[10] != NULL);
+    if XNN_UNPREDICTABLE(i[10] != zero) {
+      i[10] = (const int8_t*) ((uintptr_t) i[10] + input_offset);
+    }
+    i[11] = input[11];
+    assert(i[11] != NULL);
+    if XNN_UNPREDICTABLE(i[11] != zero) {
+      i[11] = (const int8_t*) ((uintptr_t) i[11] + input_offset);
+    }
+    i[12] = input[12];
+    assert(i[12] != NULL);
+    if XNN_UNPREDICTABLE(i[12] != zero) {
+      i[12] = (const int8_t*) ((uintptr_t) i[12] + input_offset);
+    }
+    i[13] = input[13];
+    assert(i[13] != NULL);
+    if XNN_UNPREDICTABLE(i[13] != zero) {
+      i[13] = (const int8_t*) ((uintptr_t) i[13] + input_offset);
+    }
+    i[14] = input[14];
+    assert(i[14] != NULL);
+    if XNN_UNPREDICTABLE(i[14] != zero) {
+      i[14] = (const int8_t*) ((uintptr_t) i[14] + input_offset);
+    }
+    i[15] = input[15];
+    assert(i[15] != NULL);
+    if XNN_UNPREDICTABLE(i[15] != zero) {
+      i[15] = (const int8_t*) ((uintptr_t) i[15] + input_offset);
+    }
+    i[16] = input[16];
+    assert(i[16] != NULL);
+    if XNN_UNPREDICTABLE(i[16] != zero) {
+      i[16] = (const int8_t*) ((uintptr_t) i[16] + input_offset);
+    }
+    i[17] = input[17];
+    assert(i[17] != NULL);
+    if XNN_UNPREDICTABLE(i[17] != zero) {
+      i[17] = (const int8_t*) ((uintptr_t) i[17] + input_offset);
+    }
+    i[18] = input[18];
+    assert(i[18] != NULL);
+    if XNN_UNPREDICTABLE(i[18] != zero) {
+      i[18] = (const int8_t*) ((uintptr_t) i[18] + input_offset);
+    }
+    i[19] = input[19];
+    assert(i[19] != NULL);
+    if XNN_UNPREDICTABLE(i[19] != zero) {
+      i[19] = (const int8_t*) ((uintptr_t) i[19] + input_offset);
+    }
+    i[20] = input[20];
+    assert(i[20] != NULL);
+    if XNN_UNPREDICTABLE(i[20] != zero) {
+      i[20] = (const int8_t*) ((uintptr_t) i[20] + input_offset);
+    }
+    i[21] = input[21];
+    assert(i[21] != NULL);
+    if XNN_UNPREDICTABLE(i[21] != zero) {
+      i[21] = (const int8_t*) ((uintptr_t) i[21] + input_offset);
+    }
+    i[22] = input[22];
+    assert(i[22] != NULL);
+    if XNN_UNPREDICTABLE(i[22] != zero) {
+      i[22] = (const int8_t*) ((uintptr_t) i[22] + input_offset);
+    }
+    i[23] = input[23];
+    assert(i[23] != NULL);
+    if XNN_UNPREDICTABLE(i[23] != zero) {
+      i[23] = (const int8_t*) ((uintptr_t) i[23] + input_offset);
+    }
+    i[24] = input[24];
+    assert(i[24] != NULL);
+    if XNN_UNPREDICTABLE(i[24] != zero) {
+      i[24] = (const int8_t*) ((uintptr_t) i[24] + input_offset);
+    }
+    input = (const int8_t**) ((uintptr_t) input + input_stride);
+
+    size_t c = channels;
+    const void* w = weights;
+    const size_t vlmax = __riscv_vsetvlmax_e32m8();
+    size_t vl;
+
+    do {
+      vl = __riscv_vsetvl_e32m8(c);
+      // load bias to vacc
+      vint32m8_t vacc = __riscv_vle32_v_i32m8(w, vl);
+      w = (const void*) ((uintptr_t) w + vlmax * sizeof(int32_t));
+
+      for (int k=0; k<25; k++) {
+        vint8m2_t vi = __riscv_vle8_v_i8m2(i[k], vl);
+        vint8m2_t vk = __riscv_vle8_v_i8m2(w, vl);
+        w = (const void*) ((uintptr_t) w + vlmax * sizeof(int8_t));
+
+        i[k] += vlmax;
+        vacc = __riscv_vwmacc_vv_i32m8(vacc, __riscv_vwcvt_x_x_v_i16m4(vi, vl), __riscv_vwcvt_x_x_v_i16m4(vk, vl), vl);
+      }
+
+      vfloat32m8_t vfpacc = __riscv_vfcvt_f_x_v_f32m8(vacc, vl);
+
+      vfpacc = __riscv_vfmul_vf_f32m8(vfpacc, vscale, vl);
+
+      vfpacc = __riscv_vfmax_vf_f32m8(vfpacc, voutput_min_less_zero_point, vl);
+      vfpacc = __riscv_vfmin_vf_f32m8(vfpacc, voutput_max_less_zero_point, vl);
+
+      vint16m4_t vout16 = __riscv_vfncvt_x(vfpacc, vl);
+      vout16 = __riscv_vadd_vx_i16m4(vout16, voutput_zero_point, vl);
+      vint8m2_t vout8 = __riscv_vncvt_x_x_w_i8m2(vout16, vl);
+      __riscv_vse8_v_i8m2(output, vout8, vl);
+
+      output += vl;
+      c -= vl;
+    } while(c != 0);
+    output = (int8_t*) ((uintptr_t) output + output_increment);
+  } while (--output_width != 0);
+}
+ 

--- a/src/qs8-dwconv/gen/qs8-dwconv-9p8vc-minmax-fp32-rvv.c
+++ b/src/qs8-dwconv/gen/qs8-dwconv-9p8vc-minmax-fp32-rvv.c
@@ -1,0 +1,122 @@
+// Auto-generated file. Do not edit!
+//   Template: src/qs8-dwconv/unipass-rvv.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2024 Microchip
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+#include <riscv_vector.h>
+#include "xnnpack/dwconv.h"
+
+
+void xnn_qs8_dwconv_minmax_fp32_ukernel_9p8vc__rvv(
+    size_t channels,
+    size_t output_width,
+    const int8_t** input,
+    const void* weights,
+    int8_t* output,
+    intptr_t input_stride,
+    size_t output_increment,
+    size_t input_offset,
+    const int8_t* zero,
+    const union xnn_qs8_conv_minmax_params params[restrict XNN_MIN_ELEMENTS(1)])
+{
+  assert(channels != 0);
+  assert(output_width != 0);
+
+  const float vscale = params->fp32_scalar.scale;
+  const float voutput_min_less_zero_point = (int32_t) params->fp32_scalar.output_min - (int32_t) params->fp32_scalar.output_zero_point;
+  const float voutput_max_less_zero_point = (int32_t) params->fp32_scalar.output_max - (int32_t) params->fp32_scalar.output_zero_point;
+  const int16_t voutput_zero_point = params->fp32_scalar.output_zero_point;
+
+  do {
+    const int8_t* i[9];
+    i[0] = input[0];
+    assert(i[0] != NULL);
+    if XNN_UNPREDICTABLE(i[0] != zero) {
+      i[0] = (const int8_t*) ((uintptr_t) i[0] + input_offset);
+    }
+    i[1] = input[1];
+    assert(i[1] != NULL);
+    if XNN_UNPREDICTABLE(i[1] != zero) {
+      i[1] = (const int8_t*) ((uintptr_t) i[1] + input_offset);
+    }
+    i[2] = input[2];
+    assert(i[2] != NULL);
+    if XNN_UNPREDICTABLE(i[2] != zero) {
+      i[2] = (const int8_t*) ((uintptr_t) i[2] + input_offset);
+    }
+    i[3] = input[3];
+    assert(i[3] != NULL);
+    if XNN_UNPREDICTABLE(i[3] != zero) {
+      i[3] = (const int8_t*) ((uintptr_t) i[3] + input_offset);
+    }
+    i[4] = input[4];
+    assert(i[4] != NULL);
+    if XNN_UNPREDICTABLE(i[4] != zero) {
+      i[4] = (const int8_t*) ((uintptr_t) i[4] + input_offset);
+    }
+    i[5] = input[5];
+    assert(i[5] != NULL);
+    if XNN_UNPREDICTABLE(i[5] != zero) {
+      i[5] = (const int8_t*) ((uintptr_t) i[5] + input_offset);
+    }
+    i[6] = input[6];
+    assert(i[6] != NULL);
+    if XNN_UNPREDICTABLE(i[6] != zero) {
+      i[6] = (const int8_t*) ((uintptr_t) i[6] + input_offset);
+    }
+    i[7] = input[7];
+    assert(i[7] != NULL);
+    if XNN_UNPREDICTABLE(i[7] != zero) {
+      i[7] = (const int8_t*) ((uintptr_t) i[7] + input_offset);
+    }
+    i[8] = input[8];
+    assert(i[8] != NULL);
+    if XNN_UNPREDICTABLE(i[8] != zero) {
+      i[8] = (const int8_t*) ((uintptr_t) i[8] + input_offset);
+    }
+    input = (const int8_t**) ((uintptr_t) input + input_stride);
+
+    size_t c = channels;
+    const void* w = weights;
+    const size_t vlmax = __riscv_vsetvlmax_e32m8();
+    size_t vl;
+
+    do {
+      vl = __riscv_vsetvl_e32m8(c);
+      // load bias to vacc
+      vint32m8_t vacc = __riscv_vle32_v_i32m8(w, vl);
+      w = (const void*) ((uintptr_t) w + vlmax * sizeof(int32_t));
+
+      for (int k=0; k<9; k++) {
+        vint8m2_t vi = __riscv_vle8_v_i8m2(i[k], vl);
+        vint8m2_t vk = __riscv_vle8_v_i8m2(w, vl);
+        w = (const void*) ((uintptr_t) w + vlmax * sizeof(int8_t));
+
+        i[k] += vlmax;
+        vacc = __riscv_vwmacc_vv_i32m8(vacc, __riscv_vwcvt_x_x_v_i16m4(vi, vl), __riscv_vwcvt_x_x_v_i16m4(vk, vl), vl);
+      }
+
+      vfloat32m8_t vfpacc = __riscv_vfcvt_f_x_v_f32m8(vacc, vl);
+
+      vfpacc = __riscv_vfmul_vf_f32m8(vfpacc, vscale, vl);
+
+      vfpacc = __riscv_vfmax_vf_f32m8(vfpacc, voutput_min_less_zero_point, vl);
+      vfpacc = __riscv_vfmin_vf_f32m8(vfpacc, voutput_max_less_zero_point, vl);
+
+      vint16m4_t vout16 = __riscv_vfncvt_x(vfpacc, vl);
+      vout16 = __riscv_vadd_vx_i16m4(vout16, voutput_zero_point, vl);
+      vint8m2_t vout8 = __riscv_vncvt_x_x_w_i8m2(vout16, vl);
+      __riscv_vse8_v_i8m2(output, vout8, vl);
+
+      output += vl;
+      c -= vl;
+    } while(c != 0);
+    output = (int8_t*) ((uintptr_t) output + output_increment);
+  } while (--output_width != 0);
+}
+ 

--- a/src/qs8-dwconv/gen/qs8-dwconv-9p8vc-minmax-fp32-rvv.c
+++ b/src/qs8-dwconv/gen/qs8-dwconv-9p8vc-minmax-fp32-rvv.c
@@ -2,7 +2,7 @@
 //   Template: src/qs8-dwconv/unipass-rvv.c.in
 //   Generator: tools/xngen
 //
-// Copyright 2024 Microchip
+// Copyright 2025 Microchip
 //
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
@@ -94,11 +94,12 @@ void xnn_qs8_dwconv_minmax_fp32_ukernel_9p8vc__rvv(
 
       for (size_t k = 0; k < 9; ++k) {
         vint8m2_t vi = __riscv_vle8_v_i8m2(i[k], vl);
-        vint8m2_t vk = __riscv_vle8_v_i8m2(w, vl);
+        vint8m2_t vk = __riscv_vle8_v_i8m2((const int8_t*) w, vl);
         w = (const void*) ((uintptr_t) w + vlmax * sizeof(int8_t));
 
         i[k] += vlmax;
-        vacc = __riscv_vwmacc_vv_i32m8(vacc, __riscv_vwcvt_x_x_v_i16m4(vi, vl), __riscv_vwcvt_x_x_v_i16m4(vk, vl), vl);
+        vint16m4_t vtmp16 =  __riscv_vwmul_vv_i16m4(vi, vk, vl);
+        vacc =  __riscv_vwadd_wv_i32m8(vacc, vtmp16, vl);
       }
 
       vfloat32m8_t vfpacc = __riscv_vfcvt_f_x_v_f32m8(vacc, vl);

--- a/src/qs8-dwconv/qs8-dwconv-minmax-unipass-fp32.h
+++ b/src/qs8-dwconv/qs8-dwconv-minmax-unipass-fp32.h
@@ -101,6 +101,11 @@ XNN_DWCONV_UNIPASS(0, xnn_qs8_dwconv_minmax_fp32_ukernel_25p2c__wasm_fmagic, 2, 
 XNN_DWCONV_UNIPASS(0, xnn_qs8_dwconv_minmax_fp32_ukernel_25p4c__wasm_fmagic, 4, false, 4, 25, int8_t, void, union xnn_qs8_conv_minmax_params, xnn_init_qs8_conv_minmax_fp32_scalar_params)
 #endif  // XNN_ARCH_WASM || XNN_ARCH_WASMSIMD || XNN_ARCH_WASMRELAXEDSIMD
 
+#if XNN_ARCH_RISCV && XNN_ENABLE_RISCV_VECTOR
+XNN_DWCONV_UNIPASS(0, xnn_qs8_dwconv_minmax_fp32_ukernel_9p8vc__rvv, 8, false, 8 * (xnn_init_hardware_config()->vlenb / sizeof(int32_t)), 9, int8_t, void, union xnn_qs8_conv_minmax_params, xnn_init_qs8_conv_minmax_fp32_scalar_params)
+XNN_DWCONV_UNIPASS(0, xnn_qs8_dwconv_minmax_fp32_ukernel_25p8vc__rvv, 8, false, 8 * (xnn_init_hardware_config()->vlenb / sizeof(int32_t)), 25, int8_t, void, union xnn_qs8_conv_minmax_params, xnn_init_qs8_conv_minmax_fp32_scalar_params)
+#endif // XNN_ARCH_RISCV && XNN_ENABLE_RISCV_VECTOR
+
 XNN_DWCONV_UNIPASS(0, xnn_qs8_dwconv_minmax_fp32_ukernel_9p1c__scalar_fmagic, 1, false, 1, 9, int8_t, void, union xnn_qs8_conv_minmax_params, xnn_init_qs8_conv_minmax_fp32_scalar_params)
 XNN_DWCONV_UNIPASS(0, xnn_qs8_dwconv_minmax_fp32_ukernel_9p1c__scalar_imagic, 1, false, 1, 9, int8_t, void, union xnn_qs8_conv_minmax_params, xnn_init_qs8_conv_minmax_fp32_scalar_params)
 XNN_DWCONV_UNIPASS(0, xnn_qs8_dwconv_minmax_fp32_ukernel_9p1c__scalar_lrintf, 1, false, 1, 9, int8_t, void, union xnn_qs8_conv_minmax_params, xnn_init_qs8_conv_minmax_fp32_scalar_params)

--- a/src/qs8-dwconv/unipass-rvv.c.in
+++ b/src/qs8-dwconv/unipass-rvv.c.in
@@ -1,0 +1,100 @@
+// Copyright 2024 Microchip
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+$assert CHANNEL_TILE in ["m4", "m8"]
+$LMUL = int(CHANNEL_TILE[1])
+$LMUL2 = LMUL>>1
+$LMUL4 = LMUL>>2
+$assert KERNEL_TILE >= 2
+$assert REQUANTIZATION in ["FP32"]
+$assert DATATYPE in ["QC8", "QS8", "QU8"]
+#include <assert.h>
+#include <riscv_vector.h>
+#include "xnnpack/dwconv.h"
+
+$DATATYPE_SPEC = {"QS8": "qs8", "QC8": "qs8_qc8w", "QU8": "qu8"}[DATATYPE]
+$PARAMS_STRUCT = REQUANTIZATION.lower() + "_scalar"
+$PARAMS_TYPE = "union xnn_qs8_qc8w_conv_minmax_params" if DATATYPE == "QC8" else "union xnn_%s_conv_minmax_params" % DATATYPE.lower()
+$XINT8_T = "uint8_t" if DATATYPE == "QU8" else "int8_t"
+
+void xnn_${DATATYPE_SPEC}_dwconv_minmax_${REQUANTIZATION.lower()}_ukernel_${KERNEL_TILE}p${LMUL}vc__rvv(
+    size_t channels,
+    size_t output_width,
+    const ${XINT8_T}** input,
+    const void* weights,
+    ${XINT8_T}* output,
+    intptr_t input_stride,
+    size_t output_increment,
+    size_t input_offset,
+    const ${XINT8_T}* zero,
+    const ${PARAMS_TYPE} params[restrict XNN_MIN_ELEMENTS(1)])
+{
+  assert(channels != 0);
+  assert(output_width != 0);
+
+  $if REQUANTIZATION == "FP32":
+    $if DATATYPE != "QC8":
+      const float vscale = params->${PARAMS_STRUCT}.scale;
+    const float voutput_min_less_zero_point = (int32_t) params->${PARAMS_STRUCT}.output_min - (int32_t) params->${PARAMS_STRUCT}.output_zero_point;
+    const float voutput_max_less_zero_point = (int32_t) params->${PARAMS_STRUCT}.output_max - (int32_t) params->${PARAMS_STRUCT}.output_zero_point;
+    const int16_t voutput_zero_point = params->${PARAMS_STRUCT}.output_zero_point;
+  $if DATATYPE == "QU8":
+    const int32_t vkernel_zero_point = params->${PARAMS_STRUCT}.kernel_zero_point;
+
+  do {
+    const ${XINT8_T}* i[${KERNEL_TILE}];
+    $for K in range(KERNEL_TILE):
+      i[${K}] = input[${K}];
+      assert(i[${K}] != NULL);
+      if XNN_UNPREDICTABLE(i[${K}] != zero) {
+        i[${K}] = (const ${XINT8_T}*) ((uintptr_t) i[${K}] + input_offset);
+      }
+    input = (const ${XINT8_T}**) ((uintptr_t) input + input_stride);
+
+    size_t c = channels;
+    const void* w = weights;
+    const size_t vlmax = __riscv_vsetvlmax_e32m${LMUL}();
+    size_t vl;
+
+    do {
+      vl = __riscv_vsetvl_e32m${LMUL}(c);
+      // load bias to vacc
+      vint32m${LMUL}_t vacc = __riscv_vle32_v_i32m${LMUL}(w, vl);
+      w = (const void*) ((uintptr_t) w + vlmax * sizeof(int32_t));
+
+      for (int k=0; k<${KERNEL_TILE}; k++) {
+        vint8m${LMUL4}_t vi = __riscv_vle8_v_i8m${LMUL4}(i[k], vl);
+        vint8m${LMUL4}_t vk = __riscv_vle8_v_i8m${LMUL4}(w, vl);
+        w = (const void*) ((uintptr_t) w + vlmax * sizeof(int8_t));
+
+        i[k] += vlmax;
+        vacc = __riscv_vwmacc_vv_i32m${LMUL}(vacc, __riscv_vwcvt_x_x_v_i16m${LMUL2}(vi, vl), __riscv_vwcvt_x_x_v_i16m${LMUL2}(vk, vl), vl);
+      }
+
+      $if REQUANTIZATION == "FP32":
+        vfloat32m${LMUL}_t vfpacc = __riscv_vfcvt_f_x_v_f32m${LMUL}(vacc, vl);
+
+        $if DATATYPE == "QC8":
+          vfloat32m${LMUL}_t vscale = __riscv_vle32_v_f32m${LMUL}(w, vl);
+          w = (const void*) ((const float*) w + vl);
+          vfpacc = __riscv_vfmul_vv_f32m${LMUL}(vfpacc, vscale, vl);
+        $else:
+          vfpacc = __riscv_vfmul_vf_f32m${LMUL}(vfpacc, vscale, vl);
+
+        vfpacc = __riscv_vfmax_vf_f32m${LMUL}(vfpacc, voutput_min_less_zero_point, vl);
+        vfpacc = __riscv_vfmin_vf_f32m${LMUL}(vfpacc, voutput_max_less_zero_point, vl);
+
+        vint16m${LMUL2}_t vout16 = __riscv_vfncvt_x(vfpacc, vl);
+        vout16 = __riscv_vadd_vx_i16m${LMUL2}(vout16, voutput_zero_point, vl);
+        vint8m${LMUL4}_t vout8 = __riscv_vncvt_x_x_w_i8m${LMUL4}(vout16, vl);
+        __riscv_vse8_v_i8m${LMUL4}(output, vout8, vl);
+
+      output += vl;
+      c -= vl;
+    } while(c != 0);
+    output = (${XINT8_T}*) ((uintptr_t) output + output_increment);
+  } while (--output_width != 0);
+}
+ 

--- a/src/qs8-dwconv/unipass-rvv.c.in
+++ b/src/qs8-dwconv/unipass-rvv.c.in
@@ -64,13 +64,23 @@ void xnn_${DATATYPE_SPEC}_dwconv_minmax_${REQUANTIZATION.lower()}_ukernel_${KERN
       vint32m${LMUL}_t vacc = __riscv_vle32_v_i32m${LMUL}(w, vl);
       w = (const void*) ((uintptr_t) w + vlmax * sizeof(int32_t));
 
-      for (int k=0; k<${KERNEL_TILE}; k++) {
-        vint8m${LMUL4}_t vi = __riscv_vle8_v_i8m${LMUL4}(i[k], vl);
-        vint8m${LMUL4}_t vk = __riscv_vle8_v_i8m${LMUL4}(w, vl);
-        w = (const void*) ((uintptr_t) w + vlmax * sizeof(int8_t));
+      for (size_t k = 0; k < ${KERNEL_TILE}; ++k) {
+        $if DATATYPE != "QU8":
+          vint8m${LMUL4}_t vi = __riscv_vle8_v_i8m${LMUL4}(i[k], vl);
+          vint8m${LMUL4}_t vk = __riscv_vle8_v_i8m${LMUL4}(w, vl);
+        $else:
+          vuint8m${LMUL4}_t vi = __riscv_vle8_v_u8m${LMUL4}(i[k], vl);
+          vuint8m${LMUL4}_t vk = __riscv_vle8_v_u8m${LMUL4}(w, vl);
+        w = (const void*) ((uintptr_t) w + vlmax * sizeof(${XINT8_T}));
 
         i[k] += vlmax;
-        vacc = __riscv_vwmacc_vv_i32m${LMUL}(vacc, __riscv_vwcvt_x_x_v_i16m${LMUL2}(vi, vl), __riscv_vwcvt_x_x_v_i16m${LMUL2}(vk, vl), vl);
+        $if DATATYPE != "QU8":
+          vacc = __riscv_vwmacc_vv_i32m${LMUL}(vacc, __riscv_vwcvt_x_x_v_i16m${LMUL2}(vi, vl), __riscv_vwcvt_x_x_v_i16m${LMUL2}(vk, vl), vl);
+        $else:
+          vint32m${LMUL}_t vk32 = __riscv_vreinterpret_v_u32m${LMUL}_i32m${LMUL}(__riscv_vzext_vf4_u32m${LMUL}(vk, vl));
+          vint32m${LMUL}_t vi32 = __riscv_vreinterpret_v_u32m${LMUL}_i32m${LMUL}(__riscv_vzext_vf4_u32m${LMUL}(vi, vl));
+          vk32 = __riscv_vsub_vx_i32m${LMUL}(vk32, vkernel_zero_point, vl);
+          vacc = __riscv_vmacc_vv_i32m${LMUL}(vacc, vi32, vk32, vl);
       }
 
       $if REQUANTIZATION == "FP32":
@@ -89,7 +99,10 @@ void xnn_${DATATYPE_SPEC}_dwconv_minmax_${REQUANTIZATION.lower()}_ukernel_${KERN
         vint16m${LMUL2}_t vout16 = __riscv_vfncvt_x(vfpacc, vl);
         vout16 = __riscv_vadd_vx_i16m${LMUL2}(vout16, voutput_zero_point, vl);
         vint8m${LMUL4}_t vout8 = __riscv_vncvt_x_x_w_i8m${LMUL4}(vout16, vl);
-        __riscv_vse8_v_i8m${LMUL4}(output, vout8, vl);
+        $if DATATYPE != "QU8":
+          __riscv_vse8_v_i8m${LMUL4}(output, vout8, vl);
+        $else:
+          __riscv_vse8_v_u8m${LMUL4}(output, __riscv_vreinterpret_v_i8m${LMUL4}_u8m${LMUL4}(vout8), vl);
 
       output += vl;
       c -= vl;

--- a/src/qs8-dwconv/unipass-rvv.c.in
+++ b/src/qs8-dwconv/unipass-rvv.c.in
@@ -1,4 +1,4 @@
-// Copyright 2024 Microchip
+// Copyright 2025 Microchip
 //
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
@@ -67,15 +67,16 @@ void xnn_${DATATYPE_SPEC}_dwconv_minmax_${REQUANTIZATION.lower()}_ukernel_${KERN
       for (size_t k = 0; k < ${KERNEL_TILE}; ++k) {
         $if DATATYPE != "QU8":
           vint8m${LMUL4}_t vi = __riscv_vle8_v_i8m${LMUL4}(i[k], vl);
-          vint8m${LMUL4}_t vk = __riscv_vle8_v_i8m${LMUL4}(w, vl);
+          vint8m${LMUL4}_t vk = __riscv_vle8_v_i8m${LMUL4}((const int8_t*) w, vl);
         $else:
           vuint8m${LMUL4}_t vi = __riscv_vle8_v_u8m${LMUL4}(i[k], vl);
-          vuint8m${LMUL4}_t vk = __riscv_vle8_v_u8m${LMUL4}(w, vl);
+          vuint8m${LMUL4}_t vk = __riscv_vle8_v_u8m${LMUL4}((const uint8_t*) w, vl);
         w = (const void*) ((uintptr_t) w + vlmax * sizeof(${XINT8_T}));
 
         i[k] += vlmax;
         $if DATATYPE != "QU8":
-          vacc = __riscv_vwmacc_vv_i32m${LMUL}(vacc, __riscv_vwcvt_x_x_v_i16m${LMUL2}(vi, vl), __riscv_vwcvt_x_x_v_i16m${LMUL2}(vk, vl), vl);
+          vint16m${LMUL2}_t vtmp16 =  __riscv_vwmul_vv_i16m${LMUL2}(vi, vk, vl);
+          vacc =  __riscv_vwadd_wv_i32m${LMUL}(vacc, vtmp16, vl);
         $else:
           vint32m${LMUL}_t vk32 = __riscv_vreinterpret_v_u32m${LMUL}_i32m${LMUL}(__riscv_vzext_vf4_u32m${LMUL}(vk, vl));
           vint32m${LMUL}_t vi32 = __riscv_vreinterpret_v_u32m${LMUL}_i32m${LMUL}(__riscv_vzext_vf4_u32m${LMUL}(vi, vl));

--- a/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-25p8vc-minmax-fp32-rvv.c
+++ b/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-25p8vc-minmax-fp32-rvv.c
@@ -171,7 +171,7 @@ void xnn_qs8_qc8w_dwconv_minmax_fp32_ukernel_25p8vc__rvv(
       vint32m8_t vacc = __riscv_vle32_v_i32m8(w, vl);
       w = (const void*) ((uintptr_t) w + vlmax * sizeof(int32_t));
 
-      for (int k=0; k<25; k++) {
+      for (size_t k = 0; k < 25; ++k) {
         vint8m2_t vi = __riscv_vle8_v_i8m2(i[k], vl);
         vint8m2_t vk = __riscv_vle8_v_i8m2(w, vl);
         w = (const void*) ((uintptr_t) w + vlmax * sizeof(int8_t));

--- a/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-25p8vc-minmax-fp32-rvv.c
+++ b/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-25p8vc-minmax-fp32-rvv.c
@@ -2,7 +2,7 @@
 //   Template: src/qs8-dwconv/unipass-rvv.c.in
 //   Generator: tools/xngen
 //
-// Copyright 2024 Microchip
+// Copyright 2025 Microchip
 //
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
@@ -173,11 +173,12 @@ void xnn_qs8_qc8w_dwconv_minmax_fp32_ukernel_25p8vc__rvv(
 
       for (size_t k = 0; k < 25; ++k) {
         vint8m2_t vi = __riscv_vle8_v_i8m2(i[k], vl);
-        vint8m2_t vk = __riscv_vle8_v_i8m2(w, vl);
+        vint8m2_t vk = __riscv_vle8_v_i8m2((const int8_t*) w, vl);
         w = (const void*) ((uintptr_t) w + vlmax * sizeof(int8_t));
 
         i[k] += vlmax;
-        vacc = __riscv_vwmacc_vv_i32m8(vacc, __riscv_vwcvt_x_x_v_i16m4(vi, vl), __riscv_vwcvt_x_x_v_i16m4(vk, vl), vl);
+        vint16m4_t vtmp16 =  __riscv_vwmul_vv_i16m4(vi, vk, vl);
+        vacc =  __riscv_vwadd_wv_i32m8(vacc, vtmp16, vl);
       }
 
       vfloat32m8_t vfpacc = __riscv_vfcvt_f_x_v_f32m8(vacc, vl);

--- a/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-25p8vc-minmax-fp32-rvv.c
+++ b/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-25p8vc-minmax-fp32-rvv.c
@@ -1,0 +1,203 @@
+// Auto-generated file. Do not edit!
+//   Template: src/qs8-dwconv/unipass-rvv.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2024 Microchip
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+#include <riscv_vector.h>
+#include "xnnpack/dwconv.h"
+
+
+void xnn_qs8_qc8w_dwconv_minmax_fp32_ukernel_25p8vc__rvv(
+    size_t channels,
+    size_t output_width,
+    const int8_t** input,
+    const void* weights,
+    int8_t* output,
+    intptr_t input_stride,
+    size_t output_increment,
+    size_t input_offset,
+    const int8_t* zero,
+    const union xnn_qs8_qc8w_conv_minmax_params params[restrict XNN_MIN_ELEMENTS(1)])
+{
+  assert(channels != 0);
+  assert(output_width != 0);
+
+  const float voutput_min_less_zero_point = (int32_t) params->fp32_scalar.output_min - (int32_t) params->fp32_scalar.output_zero_point;
+  const float voutput_max_less_zero_point = (int32_t) params->fp32_scalar.output_max - (int32_t) params->fp32_scalar.output_zero_point;
+  const int16_t voutput_zero_point = params->fp32_scalar.output_zero_point;
+
+  do {
+    const int8_t* i[25];
+    i[0] = input[0];
+    assert(i[0] != NULL);
+    if XNN_UNPREDICTABLE(i[0] != zero) {
+      i[0] = (const int8_t*) ((uintptr_t) i[0] + input_offset);
+    }
+    i[1] = input[1];
+    assert(i[1] != NULL);
+    if XNN_UNPREDICTABLE(i[1] != zero) {
+      i[1] = (const int8_t*) ((uintptr_t) i[1] + input_offset);
+    }
+    i[2] = input[2];
+    assert(i[2] != NULL);
+    if XNN_UNPREDICTABLE(i[2] != zero) {
+      i[2] = (const int8_t*) ((uintptr_t) i[2] + input_offset);
+    }
+    i[3] = input[3];
+    assert(i[3] != NULL);
+    if XNN_UNPREDICTABLE(i[3] != zero) {
+      i[3] = (const int8_t*) ((uintptr_t) i[3] + input_offset);
+    }
+    i[4] = input[4];
+    assert(i[4] != NULL);
+    if XNN_UNPREDICTABLE(i[4] != zero) {
+      i[4] = (const int8_t*) ((uintptr_t) i[4] + input_offset);
+    }
+    i[5] = input[5];
+    assert(i[5] != NULL);
+    if XNN_UNPREDICTABLE(i[5] != zero) {
+      i[5] = (const int8_t*) ((uintptr_t) i[5] + input_offset);
+    }
+    i[6] = input[6];
+    assert(i[6] != NULL);
+    if XNN_UNPREDICTABLE(i[6] != zero) {
+      i[6] = (const int8_t*) ((uintptr_t) i[6] + input_offset);
+    }
+    i[7] = input[7];
+    assert(i[7] != NULL);
+    if XNN_UNPREDICTABLE(i[7] != zero) {
+      i[7] = (const int8_t*) ((uintptr_t) i[7] + input_offset);
+    }
+    i[8] = input[8];
+    assert(i[8] != NULL);
+    if XNN_UNPREDICTABLE(i[8] != zero) {
+      i[8] = (const int8_t*) ((uintptr_t) i[8] + input_offset);
+    }
+    i[9] = input[9];
+    assert(i[9] != NULL);
+    if XNN_UNPREDICTABLE(i[9] != zero) {
+      i[9] = (const int8_t*) ((uintptr_t) i[9] + input_offset);
+    }
+    i[10] = input[10];
+    assert(i[10] != NULL);
+    if XNN_UNPREDICTABLE(i[10] != zero) {
+      i[10] = (const int8_t*) ((uintptr_t) i[10] + input_offset);
+    }
+    i[11] = input[11];
+    assert(i[11] != NULL);
+    if XNN_UNPREDICTABLE(i[11] != zero) {
+      i[11] = (const int8_t*) ((uintptr_t) i[11] + input_offset);
+    }
+    i[12] = input[12];
+    assert(i[12] != NULL);
+    if XNN_UNPREDICTABLE(i[12] != zero) {
+      i[12] = (const int8_t*) ((uintptr_t) i[12] + input_offset);
+    }
+    i[13] = input[13];
+    assert(i[13] != NULL);
+    if XNN_UNPREDICTABLE(i[13] != zero) {
+      i[13] = (const int8_t*) ((uintptr_t) i[13] + input_offset);
+    }
+    i[14] = input[14];
+    assert(i[14] != NULL);
+    if XNN_UNPREDICTABLE(i[14] != zero) {
+      i[14] = (const int8_t*) ((uintptr_t) i[14] + input_offset);
+    }
+    i[15] = input[15];
+    assert(i[15] != NULL);
+    if XNN_UNPREDICTABLE(i[15] != zero) {
+      i[15] = (const int8_t*) ((uintptr_t) i[15] + input_offset);
+    }
+    i[16] = input[16];
+    assert(i[16] != NULL);
+    if XNN_UNPREDICTABLE(i[16] != zero) {
+      i[16] = (const int8_t*) ((uintptr_t) i[16] + input_offset);
+    }
+    i[17] = input[17];
+    assert(i[17] != NULL);
+    if XNN_UNPREDICTABLE(i[17] != zero) {
+      i[17] = (const int8_t*) ((uintptr_t) i[17] + input_offset);
+    }
+    i[18] = input[18];
+    assert(i[18] != NULL);
+    if XNN_UNPREDICTABLE(i[18] != zero) {
+      i[18] = (const int8_t*) ((uintptr_t) i[18] + input_offset);
+    }
+    i[19] = input[19];
+    assert(i[19] != NULL);
+    if XNN_UNPREDICTABLE(i[19] != zero) {
+      i[19] = (const int8_t*) ((uintptr_t) i[19] + input_offset);
+    }
+    i[20] = input[20];
+    assert(i[20] != NULL);
+    if XNN_UNPREDICTABLE(i[20] != zero) {
+      i[20] = (const int8_t*) ((uintptr_t) i[20] + input_offset);
+    }
+    i[21] = input[21];
+    assert(i[21] != NULL);
+    if XNN_UNPREDICTABLE(i[21] != zero) {
+      i[21] = (const int8_t*) ((uintptr_t) i[21] + input_offset);
+    }
+    i[22] = input[22];
+    assert(i[22] != NULL);
+    if XNN_UNPREDICTABLE(i[22] != zero) {
+      i[22] = (const int8_t*) ((uintptr_t) i[22] + input_offset);
+    }
+    i[23] = input[23];
+    assert(i[23] != NULL);
+    if XNN_UNPREDICTABLE(i[23] != zero) {
+      i[23] = (const int8_t*) ((uintptr_t) i[23] + input_offset);
+    }
+    i[24] = input[24];
+    assert(i[24] != NULL);
+    if XNN_UNPREDICTABLE(i[24] != zero) {
+      i[24] = (const int8_t*) ((uintptr_t) i[24] + input_offset);
+    }
+    input = (const int8_t**) ((uintptr_t) input + input_stride);
+
+    size_t c = channels;
+    const void* w = weights;
+    const size_t vlmax = __riscv_vsetvlmax_e32m8();
+    size_t vl;
+
+    do {
+      vl = __riscv_vsetvl_e32m8(c);
+      // load bias to vacc
+      vint32m8_t vacc = __riscv_vle32_v_i32m8(w, vl);
+      w = (const void*) ((uintptr_t) w + vlmax * sizeof(int32_t));
+
+      for (int k=0; k<25; k++) {
+        vint8m2_t vi = __riscv_vle8_v_i8m2(i[k], vl);
+        vint8m2_t vk = __riscv_vle8_v_i8m2(w, vl);
+        w = (const void*) ((uintptr_t) w + vlmax * sizeof(int8_t));
+
+        i[k] += vlmax;
+        vacc = __riscv_vwmacc_vv_i32m8(vacc, __riscv_vwcvt_x_x_v_i16m4(vi, vl), __riscv_vwcvt_x_x_v_i16m4(vk, vl), vl);
+      }
+
+      vfloat32m8_t vfpacc = __riscv_vfcvt_f_x_v_f32m8(vacc, vl);
+
+      vfloat32m8_t vscale = __riscv_vle32_v_f32m8(w, vl);
+      w = (const void*) ((const float*) w + vl);
+      vfpacc = __riscv_vfmul_vv_f32m8(vfpacc, vscale, vl);
+
+      vfpacc = __riscv_vfmax_vf_f32m8(vfpacc, voutput_min_less_zero_point, vl);
+      vfpacc = __riscv_vfmin_vf_f32m8(vfpacc, voutput_max_less_zero_point, vl);
+
+      vint16m4_t vout16 = __riscv_vfncvt_x(vfpacc, vl);
+      vout16 = __riscv_vadd_vx_i16m4(vout16, voutput_zero_point, vl);
+      vint8m2_t vout8 = __riscv_vncvt_x_x_w_i8m2(vout16, vl);
+      __riscv_vse8_v_i8m2(output, vout8, vl);
+
+      output += vl;
+      c -= vl;
+    } while(c != 0);
+    output = (int8_t*) ((uintptr_t) output + output_increment);
+  } while (--output_width != 0);
+}
+ 

--- a/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-3p8vc-minmax-fp32-rvv.c
+++ b/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-3p8vc-minmax-fp32-rvv.c
@@ -2,7 +2,7 @@
 //   Template: src/qs8-dwconv/unipass-rvv.c.in
 //   Generator: tools/xngen
 //
-// Copyright 2024 Microchip
+// Copyright 2025 Microchip
 //
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
@@ -63,11 +63,12 @@ void xnn_qs8_qc8w_dwconv_minmax_fp32_ukernel_3p8vc__rvv(
 
       for (size_t k = 0; k < 3; ++k) {
         vint8m2_t vi = __riscv_vle8_v_i8m2(i[k], vl);
-        vint8m2_t vk = __riscv_vle8_v_i8m2(w, vl);
+        vint8m2_t vk = __riscv_vle8_v_i8m2((const int8_t*) w, vl);
         w = (const void*) ((uintptr_t) w + vlmax * sizeof(int8_t));
 
         i[k] += vlmax;
-        vacc = __riscv_vwmacc_vv_i32m8(vacc, __riscv_vwcvt_x_x_v_i16m4(vi, vl), __riscv_vwcvt_x_x_v_i16m4(vk, vl), vl);
+        vint16m4_t vtmp16 =  __riscv_vwmul_vv_i16m4(vi, vk, vl);
+        vacc =  __riscv_vwadd_wv_i32m8(vacc, vtmp16, vl);
       }
 
       vfloat32m8_t vfpacc = __riscv_vfcvt_f_x_v_f32m8(vacc, vl);

--- a/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-3p8vc-minmax-fp32-rvv.c
+++ b/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-3p8vc-minmax-fp32-rvv.c
@@ -1,0 +1,93 @@
+// Auto-generated file. Do not edit!
+//   Template: src/qs8-dwconv/unipass-rvv.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2024 Microchip
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+#include <riscv_vector.h>
+#include "xnnpack/dwconv.h"
+
+
+void xnn_qs8_qc8w_dwconv_minmax_fp32_ukernel_3p8vc__rvv(
+    size_t channels,
+    size_t output_width,
+    const int8_t** input,
+    const void* weights,
+    int8_t* output,
+    intptr_t input_stride,
+    size_t output_increment,
+    size_t input_offset,
+    const int8_t* zero,
+    const union xnn_qs8_qc8w_conv_minmax_params params[restrict XNN_MIN_ELEMENTS(1)])
+{
+  assert(channels != 0);
+  assert(output_width != 0);
+
+  const float voutput_min_less_zero_point = (int32_t) params->fp32_scalar.output_min - (int32_t) params->fp32_scalar.output_zero_point;
+  const float voutput_max_less_zero_point = (int32_t) params->fp32_scalar.output_max - (int32_t) params->fp32_scalar.output_zero_point;
+  const int16_t voutput_zero_point = params->fp32_scalar.output_zero_point;
+
+  do {
+    const int8_t* i[3];
+    i[0] = input[0];
+    assert(i[0] != NULL);
+    if XNN_UNPREDICTABLE(i[0] != zero) {
+      i[0] = (const int8_t*) ((uintptr_t) i[0] + input_offset);
+    }
+    i[1] = input[1];
+    assert(i[1] != NULL);
+    if XNN_UNPREDICTABLE(i[1] != zero) {
+      i[1] = (const int8_t*) ((uintptr_t) i[1] + input_offset);
+    }
+    i[2] = input[2];
+    assert(i[2] != NULL);
+    if XNN_UNPREDICTABLE(i[2] != zero) {
+      i[2] = (const int8_t*) ((uintptr_t) i[2] + input_offset);
+    }
+    input = (const int8_t**) ((uintptr_t) input + input_stride);
+
+    size_t c = channels;
+    const void* w = weights;
+    const size_t vlmax = __riscv_vsetvlmax_e32m8();
+    size_t vl;
+
+    do {
+      vl = __riscv_vsetvl_e32m8(c);
+      // load bias to vacc
+      vint32m8_t vacc = __riscv_vle32_v_i32m8(w, vl);
+      w = (const void*) ((uintptr_t) w + vlmax * sizeof(int32_t));
+
+      for (int k=0; k<3; k++) {
+        vint8m2_t vi = __riscv_vle8_v_i8m2(i[k], vl);
+        vint8m2_t vk = __riscv_vle8_v_i8m2(w, vl);
+        w = (const void*) ((uintptr_t) w + vlmax * sizeof(int8_t));
+
+        i[k] += vlmax;
+        vacc = __riscv_vwmacc_vv_i32m8(vacc, __riscv_vwcvt_x_x_v_i16m4(vi, vl), __riscv_vwcvt_x_x_v_i16m4(vk, vl), vl);
+      }
+
+      vfloat32m8_t vfpacc = __riscv_vfcvt_f_x_v_f32m8(vacc, vl);
+
+      vfloat32m8_t vscale = __riscv_vle32_v_f32m8(w, vl);
+      w = (const void*) ((const float*) w + vl);
+      vfpacc = __riscv_vfmul_vv_f32m8(vfpacc, vscale, vl);
+
+      vfpacc = __riscv_vfmax_vf_f32m8(vfpacc, voutput_min_less_zero_point, vl);
+      vfpacc = __riscv_vfmin_vf_f32m8(vfpacc, voutput_max_less_zero_point, vl);
+
+      vint16m4_t vout16 = __riscv_vfncvt_x(vfpacc, vl);
+      vout16 = __riscv_vadd_vx_i16m4(vout16, voutput_zero_point, vl);
+      vint8m2_t vout8 = __riscv_vncvt_x_x_w_i8m2(vout16, vl);
+      __riscv_vse8_v_i8m2(output, vout8, vl);
+
+      output += vl;
+      c -= vl;
+    } while(c != 0);
+    output = (int8_t*) ((uintptr_t) output + output_increment);
+  } while (--output_width != 0);
+}
+ 

--- a/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-3p8vc-minmax-fp32-rvv.c
+++ b/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-3p8vc-minmax-fp32-rvv.c
@@ -61,7 +61,7 @@ void xnn_qs8_qc8w_dwconv_minmax_fp32_ukernel_3p8vc__rvv(
       vint32m8_t vacc = __riscv_vle32_v_i32m8(w, vl);
       w = (const void*) ((uintptr_t) w + vlmax * sizeof(int32_t));
 
-      for (int k=0; k<3; k++) {
+      for (size_t k = 0; k < 3; ++k) {
         vint8m2_t vi = __riscv_vle8_v_i8m2(i[k], vl);
         vint8m2_t vk = __riscv_vle8_v_i8m2(w, vl);
         w = (const void*) ((uintptr_t) w + vlmax * sizeof(int8_t));

--- a/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-9p8vc-minmax-fp32-rvv.c
+++ b/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-9p8vc-minmax-fp32-rvv.c
@@ -91,7 +91,7 @@ void xnn_qs8_qc8w_dwconv_minmax_fp32_ukernel_9p8vc__rvv(
       vint32m8_t vacc = __riscv_vle32_v_i32m8(w, vl);
       w = (const void*) ((uintptr_t) w + vlmax * sizeof(int32_t));
 
-      for (int k=0; k<9; k++) {
+      for (size_t k = 0; k < 9; ++k) {
         vint8m2_t vi = __riscv_vle8_v_i8m2(i[k], vl);
         vint8m2_t vk = __riscv_vle8_v_i8m2(w, vl);
         w = (const void*) ((uintptr_t) w + vlmax * sizeof(int8_t));

--- a/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-9p8vc-minmax-fp32-rvv.c
+++ b/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-9p8vc-minmax-fp32-rvv.c
@@ -1,0 +1,123 @@
+// Auto-generated file. Do not edit!
+//   Template: src/qs8-dwconv/unipass-rvv.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2024 Microchip
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+#include <riscv_vector.h>
+#include "xnnpack/dwconv.h"
+
+
+void xnn_qs8_qc8w_dwconv_minmax_fp32_ukernel_9p8vc__rvv(
+    size_t channels,
+    size_t output_width,
+    const int8_t** input,
+    const void* weights,
+    int8_t* output,
+    intptr_t input_stride,
+    size_t output_increment,
+    size_t input_offset,
+    const int8_t* zero,
+    const union xnn_qs8_qc8w_conv_minmax_params params[restrict XNN_MIN_ELEMENTS(1)])
+{
+  assert(channels != 0);
+  assert(output_width != 0);
+
+  const float voutput_min_less_zero_point = (int32_t) params->fp32_scalar.output_min - (int32_t) params->fp32_scalar.output_zero_point;
+  const float voutput_max_less_zero_point = (int32_t) params->fp32_scalar.output_max - (int32_t) params->fp32_scalar.output_zero_point;
+  const int16_t voutput_zero_point = params->fp32_scalar.output_zero_point;
+
+  do {
+    const int8_t* i[9];
+    i[0] = input[0];
+    assert(i[0] != NULL);
+    if XNN_UNPREDICTABLE(i[0] != zero) {
+      i[0] = (const int8_t*) ((uintptr_t) i[0] + input_offset);
+    }
+    i[1] = input[1];
+    assert(i[1] != NULL);
+    if XNN_UNPREDICTABLE(i[1] != zero) {
+      i[1] = (const int8_t*) ((uintptr_t) i[1] + input_offset);
+    }
+    i[2] = input[2];
+    assert(i[2] != NULL);
+    if XNN_UNPREDICTABLE(i[2] != zero) {
+      i[2] = (const int8_t*) ((uintptr_t) i[2] + input_offset);
+    }
+    i[3] = input[3];
+    assert(i[3] != NULL);
+    if XNN_UNPREDICTABLE(i[3] != zero) {
+      i[3] = (const int8_t*) ((uintptr_t) i[3] + input_offset);
+    }
+    i[4] = input[4];
+    assert(i[4] != NULL);
+    if XNN_UNPREDICTABLE(i[4] != zero) {
+      i[4] = (const int8_t*) ((uintptr_t) i[4] + input_offset);
+    }
+    i[5] = input[5];
+    assert(i[5] != NULL);
+    if XNN_UNPREDICTABLE(i[5] != zero) {
+      i[5] = (const int8_t*) ((uintptr_t) i[5] + input_offset);
+    }
+    i[6] = input[6];
+    assert(i[6] != NULL);
+    if XNN_UNPREDICTABLE(i[6] != zero) {
+      i[6] = (const int8_t*) ((uintptr_t) i[6] + input_offset);
+    }
+    i[7] = input[7];
+    assert(i[7] != NULL);
+    if XNN_UNPREDICTABLE(i[7] != zero) {
+      i[7] = (const int8_t*) ((uintptr_t) i[7] + input_offset);
+    }
+    i[8] = input[8];
+    assert(i[8] != NULL);
+    if XNN_UNPREDICTABLE(i[8] != zero) {
+      i[8] = (const int8_t*) ((uintptr_t) i[8] + input_offset);
+    }
+    input = (const int8_t**) ((uintptr_t) input + input_stride);
+
+    size_t c = channels;
+    const void* w = weights;
+    const size_t vlmax = __riscv_vsetvlmax_e32m8();
+    size_t vl;
+
+    do {
+      vl = __riscv_vsetvl_e32m8(c);
+      // load bias to vacc
+      vint32m8_t vacc = __riscv_vle32_v_i32m8(w, vl);
+      w = (const void*) ((uintptr_t) w + vlmax * sizeof(int32_t));
+
+      for (int k=0; k<9; k++) {
+        vint8m2_t vi = __riscv_vle8_v_i8m2(i[k], vl);
+        vint8m2_t vk = __riscv_vle8_v_i8m2(w, vl);
+        w = (const void*) ((uintptr_t) w + vlmax * sizeof(int8_t));
+
+        i[k] += vlmax;
+        vacc = __riscv_vwmacc_vv_i32m8(vacc, __riscv_vwcvt_x_x_v_i16m4(vi, vl), __riscv_vwcvt_x_x_v_i16m4(vk, vl), vl);
+      }
+
+      vfloat32m8_t vfpacc = __riscv_vfcvt_f_x_v_f32m8(vacc, vl);
+
+      vfloat32m8_t vscale = __riscv_vle32_v_f32m8(w, vl);
+      w = (const void*) ((const float*) w + vl);
+      vfpacc = __riscv_vfmul_vv_f32m8(vfpacc, vscale, vl);
+
+      vfpacc = __riscv_vfmax_vf_f32m8(vfpacc, voutput_min_less_zero_point, vl);
+      vfpacc = __riscv_vfmin_vf_f32m8(vfpacc, voutput_max_less_zero_point, vl);
+
+      vint16m4_t vout16 = __riscv_vfncvt_x(vfpacc, vl);
+      vout16 = __riscv_vadd_vx_i16m4(vout16, voutput_zero_point, vl);
+      vint8m2_t vout8 = __riscv_vncvt_x_x_w_i8m2(vout16, vl);
+      __riscv_vse8_v_i8m2(output, vout8, vl);
+
+      output += vl;
+      c -= vl;
+    } while(c != 0);
+    output = (int8_t*) ((uintptr_t) output + output_increment);
+  } while (--output_width != 0);
+}
+ 

--- a/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-9p8vc-minmax-fp32-rvv.c
+++ b/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-9p8vc-minmax-fp32-rvv.c
@@ -2,7 +2,7 @@
 //   Template: src/qs8-dwconv/unipass-rvv.c.in
 //   Generator: tools/xngen
 //
-// Copyright 2024 Microchip
+// Copyright 2025 Microchip
 //
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
@@ -93,11 +93,12 @@ void xnn_qs8_qc8w_dwconv_minmax_fp32_ukernel_9p8vc__rvv(
 
       for (size_t k = 0; k < 9; ++k) {
         vint8m2_t vi = __riscv_vle8_v_i8m2(i[k], vl);
-        vint8m2_t vk = __riscv_vle8_v_i8m2(w, vl);
+        vint8m2_t vk = __riscv_vle8_v_i8m2((const int8_t*) w, vl);
         w = (const void*) ((uintptr_t) w + vlmax * sizeof(int8_t));
 
         i[k] += vlmax;
-        vacc = __riscv_vwmacc_vv_i32m8(vacc, __riscv_vwcvt_x_x_v_i16m4(vi, vl), __riscv_vwcvt_x_x_v_i16m4(vk, vl), vl);
+        vint16m4_t vtmp16 =  __riscv_vwmul_vv_i16m4(vi, vk, vl);
+        vacc =  __riscv_vwadd_wv_i32m8(vacc, vtmp16, vl);
       }
 
       vfloat32m8_t vfpacc = __riscv_vfcvt_f_x_v_f32m8(vacc, vl);

--- a/src/qs8-qc8w-dwconv/qs8-qc8w-dwconv-minmax-unipass-fp32.h
+++ b/src/qs8-qc8w-dwconv/qs8-qc8w-dwconv-minmax-unipass-fp32.h
@@ -150,6 +150,12 @@ XNN_DWCONV_UNIPASS(0, xnn_qs8_qc8w_dwconv_minmax_fp32_ukernel_25p2c__wasm_fmagic
 XNN_DWCONV_UNIPASS(0, xnn_qs8_qc8w_dwconv_minmax_fp32_ukernel_25p4c__wasm_fmagic, 4, false, 4, 25, int8_t, void, union xnn_qs8_qc8w_conv_minmax_params, xnn_init_qs8_qc8w_conv_minmax_fp32_scalar_params)
 #endif  // XNN_ARCH_WASM || XNN_ARCH_WASMSIMD || XNN_ARCH_WASMRELAXEDSIMD
 
+#if XNN_ARCH_RISCV && XNN_ENABLE_RISCV_VECTOR
+XNN_DWCONV_UNIPASS(0, xnn_qs8_qc8w_dwconv_minmax_fp32_ukernel_3p8vc__rvv, 8, false, 8 * (xnn_init_hardware_config()->vlenb / sizeof(int32_t)), 3, int8_t, void, union xnn_qs8_qc8w_conv_minmax_params, xnn_init_qs8_qc8w_conv_minmax_fp32_scalar_params)
+XNN_DWCONV_UNIPASS(0, xnn_qs8_qc8w_dwconv_minmax_fp32_ukernel_9p8vc__rvv, 8, false, 8 * (xnn_init_hardware_config()->vlenb / sizeof(int32_t)), 9, int8_t, void, union xnn_qs8_qc8w_conv_minmax_params, xnn_init_qs8_qc8w_conv_minmax_fp32_scalar_params)
+XNN_DWCONV_UNIPASS(0, xnn_qs8_qc8w_dwconv_minmax_fp32_ukernel_25p8vc__rvv, 8, false, 8 * (xnn_init_hardware_config()->vlenb / sizeof(int32_t)), 25, int8_t, void, union xnn_qs8_qc8w_conv_minmax_params, xnn_init_qs8_qc8w_conv_minmax_fp32_scalar_params)
+#endif // XNN_ARCH_RISCV && XNN_ENABLE_RISCV_VECTOR
+
 XNN_DWCONV_UNIPASS(0, xnn_qs8_qc8w_dwconv_minmax_fp32_ukernel_3p1c__scalar_fmagic, 1, false, 1, 3, int8_t, void, union xnn_qs8_qc8w_conv_minmax_params, xnn_init_qs8_qc8w_conv_minmax_fp32_scalar_params)
 XNN_DWCONV_UNIPASS(0, xnn_qs8_qc8w_dwconv_minmax_fp32_ukernel_3p2c__scalar_imagic, 2, false, 2, 3, int8_t, void, union xnn_qs8_qc8w_conv_minmax_params, xnn_init_qs8_qc8w_conv_minmax_fp32_scalar_params)
 XNN_DWCONV_UNIPASS(0, xnn_qs8_qc8w_dwconv_minmax_fp32_ukernel_3p2c__scalar_lrintf, 2, false, 2, 3, int8_t, void, union xnn_qs8_qc8w_conv_minmax_params, xnn_init_qs8_qc8w_conv_minmax_fp32_scalar_params)

--- a/src/qu8-dwconv/gen/qu8-dwconv-25p8vc-minmax-fp32-rvv.c
+++ b/src/qu8-dwconv/gen/qu8-dwconv-25p8vc-minmax-fp32-rvv.c
@@ -2,7 +2,7 @@
 //   Template: src/qs8-dwconv/unipass-rvv.c.in
 //   Generator: tools/xngen
 //
-// Copyright 2024 Microchip
+// Copyright 2025 Microchip
 //
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
@@ -175,7 +175,7 @@ void xnn_qu8_dwconv_minmax_fp32_ukernel_25p8vc__rvv(
 
       for (size_t k = 0; k < 25; ++k) {
         vuint8m2_t vi = __riscv_vle8_v_u8m2(i[k], vl);
-        vuint8m2_t vk = __riscv_vle8_v_u8m2(w, vl);
+        vuint8m2_t vk = __riscv_vle8_v_u8m2((const uint8_t*) w, vl);
         w = (const void*) ((uintptr_t) w + vlmax * sizeof(uint8_t));
 
         i[k] += vlmax;

--- a/src/qu8-dwconv/gen/qu8-dwconv-25p8vc-minmax-fp32-rvv.c
+++ b/src/qu8-dwconv/gen/qu8-dwconv-25p8vc-minmax-fp32-rvv.c
@@ -12,17 +12,17 @@
 #include "xnnpack/dwconv.h"
 
 
-void xnn_qs8_dwconv_minmax_fp32_ukernel_25p8vc__rvv(
+void xnn_qu8_dwconv_minmax_fp32_ukernel_25p8vc__rvv(
     size_t channels,
     size_t output_width,
-    const int8_t** input,
+    const uint8_t** input,
     const void* weights,
-    int8_t* output,
+    uint8_t* output,
     intptr_t input_stride,
     size_t output_increment,
     size_t input_offset,
-    const int8_t* zero,
-    const union xnn_qs8_conv_minmax_params params[restrict XNN_MIN_ELEMENTS(1)])
+    const uint8_t* zero,
+    const union xnn_qu8_conv_minmax_params params[restrict XNN_MIN_ELEMENTS(1)])
 {
   assert(channels != 0);
   assert(output_width != 0);
@@ -31,135 +31,136 @@ void xnn_qs8_dwconv_minmax_fp32_ukernel_25p8vc__rvv(
   const float voutput_min_less_zero_point = (int32_t) params->fp32_scalar.output_min - (int32_t) params->fp32_scalar.output_zero_point;
   const float voutput_max_less_zero_point = (int32_t) params->fp32_scalar.output_max - (int32_t) params->fp32_scalar.output_zero_point;
   const int16_t voutput_zero_point = params->fp32_scalar.output_zero_point;
+  const int32_t vkernel_zero_point = params->fp32_scalar.kernel_zero_point;
 
   do {
-    const int8_t* i[25];
+    const uint8_t* i[25];
     i[0] = input[0];
     assert(i[0] != NULL);
     if XNN_UNPREDICTABLE(i[0] != zero) {
-      i[0] = (const int8_t*) ((uintptr_t) i[0] + input_offset);
+      i[0] = (const uint8_t*) ((uintptr_t) i[0] + input_offset);
     }
     i[1] = input[1];
     assert(i[1] != NULL);
     if XNN_UNPREDICTABLE(i[1] != zero) {
-      i[1] = (const int8_t*) ((uintptr_t) i[1] + input_offset);
+      i[1] = (const uint8_t*) ((uintptr_t) i[1] + input_offset);
     }
     i[2] = input[2];
     assert(i[2] != NULL);
     if XNN_UNPREDICTABLE(i[2] != zero) {
-      i[2] = (const int8_t*) ((uintptr_t) i[2] + input_offset);
+      i[2] = (const uint8_t*) ((uintptr_t) i[2] + input_offset);
     }
     i[3] = input[3];
     assert(i[3] != NULL);
     if XNN_UNPREDICTABLE(i[3] != zero) {
-      i[3] = (const int8_t*) ((uintptr_t) i[3] + input_offset);
+      i[3] = (const uint8_t*) ((uintptr_t) i[3] + input_offset);
     }
     i[4] = input[4];
     assert(i[4] != NULL);
     if XNN_UNPREDICTABLE(i[4] != zero) {
-      i[4] = (const int8_t*) ((uintptr_t) i[4] + input_offset);
+      i[4] = (const uint8_t*) ((uintptr_t) i[4] + input_offset);
     }
     i[5] = input[5];
     assert(i[5] != NULL);
     if XNN_UNPREDICTABLE(i[5] != zero) {
-      i[5] = (const int8_t*) ((uintptr_t) i[5] + input_offset);
+      i[5] = (const uint8_t*) ((uintptr_t) i[5] + input_offset);
     }
     i[6] = input[6];
     assert(i[6] != NULL);
     if XNN_UNPREDICTABLE(i[6] != zero) {
-      i[6] = (const int8_t*) ((uintptr_t) i[6] + input_offset);
+      i[6] = (const uint8_t*) ((uintptr_t) i[6] + input_offset);
     }
     i[7] = input[7];
     assert(i[7] != NULL);
     if XNN_UNPREDICTABLE(i[7] != zero) {
-      i[7] = (const int8_t*) ((uintptr_t) i[7] + input_offset);
+      i[7] = (const uint8_t*) ((uintptr_t) i[7] + input_offset);
     }
     i[8] = input[8];
     assert(i[8] != NULL);
     if XNN_UNPREDICTABLE(i[8] != zero) {
-      i[8] = (const int8_t*) ((uintptr_t) i[8] + input_offset);
+      i[8] = (const uint8_t*) ((uintptr_t) i[8] + input_offset);
     }
     i[9] = input[9];
     assert(i[9] != NULL);
     if XNN_UNPREDICTABLE(i[9] != zero) {
-      i[9] = (const int8_t*) ((uintptr_t) i[9] + input_offset);
+      i[9] = (const uint8_t*) ((uintptr_t) i[9] + input_offset);
     }
     i[10] = input[10];
     assert(i[10] != NULL);
     if XNN_UNPREDICTABLE(i[10] != zero) {
-      i[10] = (const int8_t*) ((uintptr_t) i[10] + input_offset);
+      i[10] = (const uint8_t*) ((uintptr_t) i[10] + input_offset);
     }
     i[11] = input[11];
     assert(i[11] != NULL);
     if XNN_UNPREDICTABLE(i[11] != zero) {
-      i[11] = (const int8_t*) ((uintptr_t) i[11] + input_offset);
+      i[11] = (const uint8_t*) ((uintptr_t) i[11] + input_offset);
     }
     i[12] = input[12];
     assert(i[12] != NULL);
     if XNN_UNPREDICTABLE(i[12] != zero) {
-      i[12] = (const int8_t*) ((uintptr_t) i[12] + input_offset);
+      i[12] = (const uint8_t*) ((uintptr_t) i[12] + input_offset);
     }
     i[13] = input[13];
     assert(i[13] != NULL);
     if XNN_UNPREDICTABLE(i[13] != zero) {
-      i[13] = (const int8_t*) ((uintptr_t) i[13] + input_offset);
+      i[13] = (const uint8_t*) ((uintptr_t) i[13] + input_offset);
     }
     i[14] = input[14];
     assert(i[14] != NULL);
     if XNN_UNPREDICTABLE(i[14] != zero) {
-      i[14] = (const int8_t*) ((uintptr_t) i[14] + input_offset);
+      i[14] = (const uint8_t*) ((uintptr_t) i[14] + input_offset);
     }
     i[15] = input[15];
     assert(i[15] != NULL);
     if XNN_UNPREDICTABLE(i[15] != zero) {
-      i[15] = (const int8_t*) ((uintptr_t) i[15] + input_offset);
+      i[15] = (const uint8_t*) ((uintptr_t) i[15] + input_offset);
     }
     i[16] = input[16];
     assert(i[16] != NULL);
     if XNN_UNPREDICTABLE(i[16] != zero) {
-      i[16] = (const int8_t*) ((uintptr_t) i[16] + input_offset);
+      i[16] = (const uint8_t*) ((uintptr_t) i[16] + input_offset);
     }
     i[17] = input[17];
     assert(i[17] != NULL);
     if XNN_UNPREDICTABLE(i[17] != zero) {
-      i[17] = (const int8_t*) ((uintptr_t) i[17] + input_offset);
+      i[17] = (const uint8_t*) ((uintptr_t) i[17] + input_offset);
     }
     i[18] = input[18];
     assert(i[18] != NULL);
     if XNN_UNPREDICTABLE(i[18] != zero) {
-      i[18] = (const int8_t*) ((uintptr_t) i[18] + input_offset);
+      i[18] = (const uint8_t*) ((uintptr_t) i[18] + input_offset);
     }
     i[19] = input[19];
     assert(i[19] != NULL);
     if XNN_UNPREDICTABLE(i[19] != zero) {
-      i[19] = (const int8_t*) ((uintptr_t) i[19] + input_offset);
+      i[19] = (const uint8_t*) ((uintptr_t) i[19] + input_offset);
     }
     i[20] = input[20];
     assert(i[20] != NULL);
     if XNN_UNPREDICTABLE(i[20] != zero) {
-      i[20] = (const int8_t*) ((uintptr_t) i[20] + input_offset);
+      i[20] = (const uint8_t*) ((uintptr_t) i[20] + input_offset);
     }
     i[21] = input[21];
     assert(i[21] != NULL);
     if XNN_UNPREDICTABLE(i[21] != zero) {
-      i[21] = (const int8_t*) ((uintptr_t) i[21] + input_offset);
+      i[21] = (const uint8_t*) ((uintptr_t) i[21] + input_offset);
     }
     i[22] = input[22];
     assert(i[22] != NULL);
     if XNN_UNPREDICTABLE(i[22] != zero) {
-      i[22] = (const int8_t*) ((uintptr_t) i[22] + input_offset);
+      i[22] = (const uint8_t*) ((uintptr_t) i[22] + input_offset);
     }
     i[23] = input[23];
     assert(i[23] != NULL);
     if XNN_UNPREDICTABLE(i[23] != zero) {
-      i[23] = (const int8_t*) ((uintptr_t) i[23] + input_offset);
+      i[23] = (const uint8_t*) ((uintptr_t) i[23] + input_offset);
     }
     i[24] = input[24];
     assert(i[24] != NULL);
     if XNN_UNPREDICTABLE(i[24] != zero) {
-      i[24] = (const int8_t*) ((uintptr_t) i[24] + input_offset);
+      i[24] = (const uint8_t*) ((uintptr_t) i[24] + input_offset);
     }
-    input = (const int8_t**) ((uintptr_t) input + input_stride);
+    input = (const uint8_t**) ((uintptr_t) input + input_stride);
 
     size_t c = channels;
     const void* w = weights;
@@ -173,12 +174,15 @@ void xnn_qs8_dwconv_minmax_fp32_ukernel_25p8vc__rvv(
       w = (const void*) ((uintptr_t) w + vlmax * sizeof(int32_t));
 
       for (size_t k = 0; k < 25; ++k) {
-        vint8m2_t vi = __riscv_vle8_v_i8m2(i[k], vl);
-        vint8m2_t vk = __riscv_vle8_v_i8m2(w, vl);
-        w = (const void*) ((uintptr_t) w + vlmax * sizeof(int8_t));
+        vuint8m2_t vi = __riscv_vle8_v_u8m2(i[k], vl);
+        vuint8m2_t vk = __riscv_vle8_v_u8m2(w, vl);
+        w = (const void*) ((uintptr_t) w + vlmax * sizeof(uint8_t));
 
         i[k] += vlmax;
-        vacc = __riscv_vwmacc_vv_i32m8(vacc, __riscv_vwcvt_x_x_v_i16m4(vi, vl), __riscv_vwcvt_x_x_v_i16m4(vk, vl), vl);
+        vint32m8_t vk32 = __riscv_vreinterpret_v_u32m8_i32m8(__riscv_vzext_vf4_u32m8(vk, vl));
+        vint32m8_t vi32 = __riscv_vreinterpret_v_u32m8_i32m8(__riscv_vzext_vf4_u32m8(vi, vl));
+        vk32 = __riscv_vsub_vx_i32m8(vk32, vkernel_zero_point, vl);
+        vacc = __riscv_vmacc_vv_i32m8(vacc, vi32, vk32, vl);
       }
 
       vfloat32m8_t vfpacc = __riscv_vfcvt_f_x_v_f32m8(vacc, vl);
@@ -191,12 +195,12 @@ void xnn_qs8_dwconv_minmax_fp32_ukernel_25p8vc__rvv(
       vint16m4_t vout16 = __riscv_vfncvt_x(vfpacc, vl);
       vout16 = __riscv_vadd_vx_i16m4(vout16, voutput_zero_point, vl);
       vint8m2_t vout8 = __riscv_vncvt_x_x_w_i8m2(vout16, vl);
-      __riscv_vse8_v_i8m2(output, vout8, vl);
+      __riscv_vse8_v_u8m2(output, __riscv_vreinterpret_v_i8m2_u8m2(vout8), vl);
 
       output += vl;
       c -= vl;
     } while(c != 0);
-    output = (int8_t*) ((uintptr_t) output + output_increment);
+    output = (uint8_t*) ((uintptr_t) output + output_increment);
   } while (--output_width != 0);
 }
  

--- a/src/qu8-dwconv/gen/qu8-dwconv-9p8vc-minmax-fp32-rvv.c
+++ b/src/qu8-dwconv/gen/qu8-dwconv-9p8vc-minmax-fp32-rvv.c
@@ -12,17 +12,17 @@
 #include "xnnpack/dwconv.h"
 
 
-void xnn_qs8_dwconv_minmax_fp32_ukernel_9p8vc__rvv(
+void xnn_qu8_dwconv_minmax_fp32_ukernel_9p8vc__rvv(
     size_t channels,
     size_t output_width,
-    const int8_t** input,
+    const uint8_t** input,
     const void* weights,
-    int8_t* output,
+    uint8_t* output,
     intptr_t input_stride,
     size_t output_increment,
     size_t input_offset,
-    const int8_t* zero,
-    const union xnn_qs8_conv_minmax_params params[restrict XNN_MIN_ELEMENTS(1)])
+    const uint8_t* zero,
+    const union xnn_qu8_conv_minmax_params params[restrict XNN_MIN_ELEMENTS(1)])
 {
   assert(channels != 0);
   assert(output_width != 0);
@@ -31,55 +31,56 @@ void xnn_qs8_dwconv_minmax_fp32_ukernel_9p8vc__rvv(
   const float voutput_min_less_zero_point = (int32_t) params->fp32_scalar.output_min - (int32_t) params->fp32_scalar.output_zero_point;
   const float voutput_max_less_zero_point = (int32_t) params->fp32_scalar.output_max - (int32_t) params->fp32_scalar.output_zero_point;
   const int16_t voutput_zero_point = params->fp32_scalar.output_zero_point;
+  const int32_t vkernel_zero_point = params->fp32_scalar.kernel_zero_point;
 
   do {
-    const int8_t* i[9];
+    const uint8_t* i[9];
     i[0] = input[0];
     assert(i[0] != NULL);
     if XNN_UNPREDICTABLE(i[0] != zero) {
-      i[0] = (const int8_t*) ((uintptr_t) i[0] + input_offset);
+      i[0] = (const uint8_t*) ((uintptr_t) i[0] + input_offset);
     }
     i[1] = input[1];
     assert(i[1] != NULL);
     if XNN_UNPREDICTABLE(i[1] != zero) {
-      i[1] = (const int8_t*) ((uintptr_t) i[1] + input_offset);
+      i[1] = (const uint8_t*) ((uintptr_t) i[1] + input_offset);
     }
     i[2] = input[2];
     assert(i[2] != NULL);
     if XNN_UNPREDICTABLE(i[2] != zero) {
-      i[2] = (const int8_t*) ((uintptr_t) i[2] + input_offset);
+      i[2] = (const uint8_t*) ((uintptr_t) i[2] + input_offset);
     }
     i[3] = input[3];
     assert(i[3] != NULL);
     if XNN_UNPREDICTABLE(i[3] != zero) {
-      i[3] = (const int8_t*) ((uintptr_t) i[3] + input_offset);
+      i[3] = (const uint8_t*) ((uintptr_t) i[3] + input_offset);
     }
     i[4] = input[4];
     assert(i[4] != NULL);
     if XNN_UNPREDICTABLE(i[4] != zero) {
-      i[4] = (const int8_t*) ((uintptr_t) i[4] + input_offset);
+      i[4] = (const uint8_t*) ((uintptr_t) i[4] + input_offset);
     }
     i[5] = input[5];
     assert(i[5] != NULL);
     if XNN_UNPREDICTABLE(i[5] != zero) {
-      i[5] = (const int8_t*) ((uintptr_t) i[5] + input_offset);
+      i[5] = (const uint8_t*) ((uintptr_t) i[5] + input_offset);
     }
     i[6] = input[6];
     assert(i[6] != NULL);
     if XNN_UNPREDICTABLE(i[6] != zero) {
-      i[6] = (const int8_t*) ((uintptr_t) i[6] + input_offset);
+      i[6] = (const uint8_t*) ((uintptr_t) i[6] + input_offset);
     }
     i[7] = input[7];
     assert(i[7] != NULL);
     if XNN_UNPREDICTABLE(i[7] != zero) {
-      i[7] = (const int8_t*) ((uintptr_t) i[7] + input_offset);
+      i[7] = (const uint8_t*) ((uintptr_t) i[7] + input_offset);
     }
     i[8] = input[8];
     assert(i[8] != NULL);
     if XNN_UNPREDICTABLE(i[8] != zero) {
-      i[8] = (const int8_t*) ((uintptr_t) i[8] + input_offset);
+      i[8] = (const uint8_t*) ((uintptr_t) i[8] + input_offset);
     }
-    input = (const int8_t**) ((uintptr_t) input + input_stride);
+    input = (const uint8_t**) ((uintptr_t) input + input_stride);
 
     size_t c = channels;
     const void* w = weights;
@@ -93,12 +94,15 @@ void xnn_qs8_dwconv_minmax_fp32_ukernel_9p8vc__rvv(
       w = (const void*) ((uintptr_t) w + vlmax * sizeof(int32_t));
 
       for (size_t k = 0; k < 9; ++k) {
-        vint8m2_t vi = __riscv_vle8_v_i8m2(i[k], vl);
-        vint8m2_t vk = __riscv_vle8_v_i8m2(w, vl);
-        w = (const void*) ((uintptr_t) w + vlmax * sizeof(int8_t));
+        vuint8m2_t vi = __riscv_vle8_v_u8m2(i[k], vl);
+        vuint8m2_t vk = __riscv_vle8_v_u8m2(w, vl);
+        w = (const void*) ((uintptr_t) w + vlmax * sizeof(uint8_t));
 
         i[k] += vlmax;
-        vacc = __riscv_vwmacc_vv_i32m8(vacc, __riscv_vwcvt_x_x_v_i16m4(vi, vl), __riscv_vwcvt_x_x_v_i16m4(vk, vl), vl);
+        vint32m8_t vk32 = __riscv_vreinterpret_v_u32m8_i32m8(__riscv_vzext_vf4_u32m8(vk, vl));
+        vint32m8_t vi32 = __riscv_vreinterpret_v_u32m8_i32m8(__riscv_vzext_vf4_u32m8(vi, vl));
+        vk32 = __riscv_vsub_vx_i32m8(vk32, vkernel_zero_point, vl);
+        vacc = __riscv_vmacc_vv_i32m8(vacc, vi32, vk32, vl);
       }
 
       vfloat32m8_t vfpacc = __riscv_vfcvt_f_x_v_f32m8(vacc, vl);
@@ -111,12 +115,12 @@ void xnn_qs8_dwconv_minmax_fp32_ukernel_9p8vc__rvv(
       vint16m4_t vout16 = __riscv_vfncvt_x(vfpacc, vl);
       vout16 = __riscv_vadd_vx_i16m4(vout16, voutput_zero_point, vl);
       vint8m2_t vout8 = __riscv_vncvt_x_x_w_i8m2(vout16, vl);
-      __riscv_vse8_v_i8m2(output, vout8, vl);
+      __riscv_vse8_v_u8m2(output, __riscv_vreinterpret_v_i8m2_u8m2(vout8), vl);
 
       output += vl;
       c -= vl;
     } while(c != 0);
-    output = (int8_t*) ((uintptr_t) output + output_increment);
+    output = (uint8_t*) ((uintptr_t) output + output_increment);
   } while (--output_width != 0);
 }
  

--- a/src/qu8-dwconv/gen/qu8-dwconv-9p8vc-minmax-fp32-rvv.c
+++ b/src/qu8-dwconv/gen/qu8-dwconv-9p8vc-minmax-fp32-rvv.c
@@ -2,7 +2,7 @@
 //   Template: src/qs8-dwconv/unipass-rvv.c.in
 //   Generator: tools/xngen
 //
-// Copyright 2024 Microchip
+// Copyright 2025 Microchip
 //
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
@@ -95,7 +95,7 @@ void xnn_qu8_dwconv_minmax_fp32_ukernel_9p8vc__rvv(
 
       for (size_t k = 0; k < 9; ++k) {
         vuint8m2_t vi = __riscv_vle8_v_u8m2(i[k], vl);
-        vuint8m2_t vk = __riscv_vle8_v_u8m2(w, vl);
+        vuint8m2_t vk = __riscv_vle8_v_u8m2((const uint8_t*) w, vl);
         w = (const void*) ((uintptr_t) w + vlmax * sizeof(uint8_t));
 
         i[k] += vlmax;

--- a/src/qu8-dwconv/qu8-dwconv-minmax-unipass-fp32.h
+++ b/src/qu8-dwconv/qu8-dwconv-minmax-unipass-fp32.h
@@ -73,6 +73,11 @@ XNN_DWCONV_UNIPASS(0, xnn_qu8_dwconv_minmax_fp32_ukernel_25p2c__wasm_fmagic, 2, 
 XNN_DWCONV_UNIPASS(0, xnn_qu8_dwconv_minmax_fp32_ukernel_25p4c__wasm_fmagic, 4, false, 4, 25, uint8_t, void, union xnn_qu8_conv_minmax_params, xnn_init_qu8_conv_minmax_fp32_scalar_params)
 #endif  // XNN_ARCH_WASM || XNN_ARCH_WASMSIMD || XNN_ARCH_WASMRELAXEDSIMD
 
+#if XNN_ARCH_RISCV && XNN_ENABLE_RISCV_VECTOR
+XNN_DWCONV_UNIPASS(0, xnn_qu8_dwconv_minmax_fp32_ukernel_9p8vc__rvv, 8, false, 8 * (xnn_init_hardware_config()->vlenb / sizeof(int32_t)), 9, uint8_t, void, union xnn_qu8_conv_minmax_params, xnn_init_qu8_conv_minmax_fp32_scalar_params)
+XNN_DWCONV_UNIPASS(0, xnn_qu8_dwconv_minmax_fp32_ukernel_25p8vc__rvv, 8, false, 8 * (xnn_init_hardware_config()->vlenb / sizeof(int32_t)), 25, uint8_t, void, union xnn_qu8_conv_minmax_params, xnn_init_qu8_conv_minmax_fp32_scalar_params)
+#endif // XNN_ARCH_RISCV && XNN_ENABLE_RISCV_VECTOR
+
 XNN_DWCONV_UNIPASS(0, xnn_qu8_dwconv_minmax_fp32_ukernel_9p1c__scalar_fmagic, 1, false, 1, 9, uint8_t, void, union xnn_qu8_conv_minmax_params, xnn_init_qu8_conv_minmax_fp32_scalar_params)
 XNN_DWCONV_UNIPASS(0, xnn_qu8_dwconv_minmax_fp32_ukernel_9p1c__scalar_imagic, 1, false, 1, 9, uint8_t, void, union xnn_qu8_conv_minmax_params, xnn_init_qu8_conv_minmax_fp32_scalar_params)
 XNN_DWCONV_UNIPASS(0, xnn_qu8_dwconv_minmax_fp32_ukernel_9p1c__scalar_lrintf, 1, false, 1, 9, uint8_t, void, union xnn_qu8_conv_minmax_params, xnn_init_qu8_conv_minmax_fp32_scalar_params)


### PR DESCRIPTION
- Added support for qs8-dwconv and qs8-qc8w-dwconv for RVV
- Generator script can support qu8 but I've left those kernels out given past comments on qu8 being deprecated.
- Tested on qemu and Spacemit K1.