### PR TITLE
Update KleidiAI to use GitHub

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -93,10 +93,10 @@ http_archive(
 # KleidiAI library, used for ARM microkernels.
 http_archive(
     name = "KleidiAI",
-    sha256 = "f3ea4fce53f3b31076958dbff229f0048dae15bf454929673c78292a56279d52",
-    strip_prefix = "kleidiai-847ebd19d0192528659b0a0fa2c6057eed674c6a",
+    sha256 = "cb6af19d3ef21a0c683bd0c7c5b455c386dee0b7d0d4bc2cc0e14503019ff1e8",
+    strip_prefix = "kleidiai-v1.4.0",
     urls = [
-        "https://gitlab.arm.com/kleidi/kleidiai/-/archive/847ebd19d0192528659b0a0fa2c6057eed674c6a/kleidiai-847ebd19d0192528659b0a0fa2c6057eed674c6a.zip",
+        "https://github.com/ARM-software/kleidiai/archive/refs/tags/v1.4.0.zip",
     ],
 )
 # LINT.ThenChange(cmake/DownloadKleidiAI.cmake,WORKSPACE:kleidiai)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -94,7 +94,7 @@ http_archive(
 http_archive(
     name = "KleidiAI",
     sha256 = "cb6af19d3ef21a0c683bd0c7c5b455c386dee0b7d0d4bc2cc0e14503019ff1e8",
-    strip_prefix = "kleidiai-v1.4.0",
+    strip_prefix = "kleidiai-1.4.0",
     urls = [
         "https://github.com/ARM-software/kleidiai/archive/refs/tags/v1.4.0.zip",
     ],

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -107,10 +107,10 @@ http_archive(
 # KleidiAI library, used for ARM microkernels.
 http_archive(
     name = "KleidiAI",
-    sha256 = "f3ea4fce53f3b31076958dbff229f0048dae15bf454929673c78292a56279d52",
-    strip_prefix = "kleidiai-847ebd19d0192528659b0a0fa2c6057eed674c6a",
+    sha256 = "cb6af19d3ef21a0c683bd0c7c5b455c386dee0b7d0d4bc2cc0e14503019ff1e8",
+    strip_prefix = "kleidiai-v1.4.0",
     urls = [
-        "https://gitlab.arm.com/kleidi/kleidiai/-/archive/847ebd19d0192528659b0a0fa2c6057eed674c6a/kleidiai-847ebd19d0192528659b0a0fa2c6057eed674c6a.zip",
+        "https://github.com/ARM-software/kleidiai/archive/refs/tags/v1.4.0.zip",
     ],
 )
 # LINT.ThenChange(cmake/DownloadKleidiAI.cmake,MODULE.bazel:kleidiai)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -108,7 +108,7 @@ http_archive(
 http_archive(
     name = "KleidiAI",
     sha256 = "cb6af19d3ef21a0c683bd0c7c5b455c386dee0b7d0d4bc2cc0e14503019ff1e8",
-    strip_prefix = "kleidiai-v1.4.0",
+    strip_prefix = "kleidiai-1.4.0",
     urls = [
         "https://github.com/ARM-software/kleidiai/archive/refs/tags/v1.4.0.zip",
     ],

--- a/cmake/DownloadKleidiAI.cmake
+++ b/cmake/DownloadKleidiAI.cmake
@@ -18,8 +18,8 @@ ENDIF()
 # LINT.IfChange
 INCLUDE(ExternalProject)
 ExternalProject_Add(kleidiai
-  URL https://gitlab.arm.com/kleidi/kleidiai/-/archive/847ebd19d0192528659b0a0fa2c6057eed674c6a/kleidiai-847ebd19d0192528659b0a0fa2c6057eed674c6a.zip
-  URL_HASH SHA256=f3ea4fce53f3b31076958dbff229f0048dae15bf454929673c78292a56279d52
+  URL https://github.com/ARM-software/kleidiai/archive/refs/tags/v1.4.0.zip
+  URL_HASH SHA256=cb6af19d3ef21a0c683bd0c7c5b455c386dee0b7d0d4bc2cc0e14503019ff1e8
   SOURCE_DIR "${CMAKE_BINARY_DIR}/kleidiai-source"
   BINARY_DIR "${CMAKE_BINARY_DIR}/kleidiai"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
Update to release v1.4.0 and use
GitHub mirror repository