### PR TITLE
Fix hexagon build issue for unary test

### DIFF
--- a/src/xnnpack/simd/f32-hvx.h
+++ b/src/xnnpack/simd/f32-hvx.h
@@ -9,12 +9,13 @@
 
 #include <assert.h>
 #include <stddef.h>
+#include <string.h>  // for memcpy
 
 #include <hvx_hexagon_protos.h>
 #include <hexagon_protos.h>
 #include <hexagon_types.h>
-#include "xnnpack/common.h"
-#include "xnnpack/intrinsics-polyfill.h"
+#include "src/xnnpack/common.h"
+#include "src/xnnpack/intrinsics-polyfill.h"
 
 
 // SIMD vector type for f32 using HVX.
@@ -33,7 +34,7 @@ typedef HVX_Vector xnn_simd_f32_t;
 
 // Include the header for generic functions _after_ declaring the arch-specific
 // types and sizes.
-#include "xnnpack/simd/f32-generic-functions.h"
+#include "src/xnnpack/simd/f32-generic-functions.h"
 
 // Arithmetic operations.
 
@@ -67,7 +68,7 @@ static XNN_INLINE xnn_simd_f32_t xnn_fmadd_f32(xnn_simd_f32_t a,
 static XNN_INLINE xnn_simd_f32_t xnn_fnmadd_f32(xnn_simd_f32_t a,
                                                 xnn_simd_f32_t b,
                                                 xnn_simd_f32_t c) {
-  return Q6_Vsf_equals_Vqf32(Q6_Vqf32_vsub_VsfVsf(c, xnn_mul_qf32(a, b)));
+  return Q6_Vsf_equals_Vqf32(Q6_Vqf32_vsub_VsfVsf(c, xnn_mul_f32(a, b)));
 }
 
 static XNN_INLINE xnn_simd_f32_t xnn_sub_f32(xnn_simd_f32_t a,
@@ -92,6 +93,12 @@ static XNN_INLINE xnn_simd_f32_t xnn_abs_f32(xnn_simd_f32_t a) {
 static XNN_INLINE xnn_simd_f32_t xnn_neg_f32(xnn_simd_f32_t a) {
   XNN_SIMD_CONST_F32(v0, 0);
   return Q6_Vsf_vsub_VsfVsf(v0, a);
+}
+
+static XNN_INLINE xnn_simd_f32_t xnn_round_f32(xnn_simd_f32_t a) {
+  XNN_UNREACHABLE;
+  XNN_SIMD_CONST_F32(v0, 0);
+  return v0;
 }
 
 // Logical operations.

--- a/src/xnnpack/simd/f32-hvx.h
+++ b/src/xnnpack/simd/f32-hvx.h
@@ -9,13 +9,12 @@
 
 #include <assert.h>
 #include <stddef.h>
-#include <string.h>  // for memcpy
 
 #include <hvx_hexagon_protos.h>
 #include <hexagon_protos.h>
 #include <hexagon_types.h>
-#include "src/xnnpack/common.h"
-#include "src/xnnpack/intrinsics-polyfill.h"
+#include "xnnpack/common.h"
+#include "xnnpack/intrinsics-polyfill.h"
 
 
 // SIMD vector type for f32 using HVX.
@@ -34,41 +33,45 @@ typedef HVX_Vector xnn_simd_f32_t;
 
 // Include the header for generic functions _after_ declaring the arch-specific
 // types and sizes.
-#include "src/xnnpack/simd/f32-generic-functions.h"
+#include "xnnpack/simd/f32-generic-functions.h"
 
 // Arithmetic operations.
 
 static XNN_INLINE xnn_simd_f32_t xnn_zero_f32() { return Q6_V_vsplat_R(0); }
 
 static XNN_INLINE xnn_simd_f32_t xnn_add_f32(xnn_simd_f32_t a,
-                                              xnn_simd_f32_t b) {
+                                             xnn_simd_f32_t b) {
   return Q6_Vsf_equals_Vqf32(Q6_Vqf32_vadd_VsfVsf(a, b));
 }
 
 static XNN_INLINE xnn_simd_f32_t xnn_mul_f32(xnn_simd_f32_t a,
-                                              xnn_simd_f32_t b) {
+                                             xnn_simd_f32_t b) {
   return Q6_Vsf_equals_Vqf32(Q6_Vqf32_vmpy_VsfVsf(a, b));
+}
+
+static XNN_INLINE xnn_simd_f32_t xnn_rcp_f32(xnn_simd_f32_t a){
+  return fast_inverse__vsf(a);
 }
 
 static XNN_INLINE xnn_simd_f32_t xnn_div_f32(xnn_simd_f32_t a,
                                              xnn_simd_f32_t b) {
-  return Q6_Vsf_vdiv_VsfVsf(a, b);
+  return Q6_Vsf_equals_Vqf32(Q6_Vqf32_vmpy_VsfVsf(a, xnn_rcp_f32(b)));
 }
 
 static XNN_INLINE xnn_simd_f32_t xnn_fmadd_f32(xnn_simd_f32_t a,
-                                                xnn_simd_f32_t b,
-                                                xnn_simd_f32_t c) {
+                                               xnn_simd_f32_t b,
+                                               xnn_simd_f32_t c) {
   return Q6_Vsf_equals_Vqf32(Q6_Vqf32_vadd_Vqf32Vsf(Q6_Vqf32_vmpy_VsfVsf(a, b), c));
 }
 
 static XNN_INLINE xnn_simd_f32_t xnn_fnmadd_f32(xnn_simd_f32_t a,
-                                                 xnn_simd_f32_t b,
-                                                 xnn_simd_f32_t c) {
-  return Q6_Vsf_equals_Vqf32(Q6_Vqf32_vsub_VsfVsf(c, xnn_mul_f32(a, b)));
+                                                xnn_simd_f32_t b,
+                                                xnn_simd_f32_t c) {
+  return Q6_Vsf_equals_Vqf32(Q6_Vqf32_vsub_VsfVsf(c, xnn_mul_qf32(a, b)));
 }
 
 static XNN_INLINE xnn_simd_f32_t xnn_sub_f32(xnn_simd_f32_t a,
-                                              xnn_simd_f32_t b) {
+                                             xnn_simd_f32_t b) {
   return Q6_Vsf_equals_Vqf32(Q6_Vqf32_vsub_VsfVsf(a, b));
 }
 
@@ -89,12 +92,6 @@ static XNN_INLINE xnn_simd_f32_t xnn_abs_f32(xnn_simd_f32_t a) {
 static XNN_INLINE xnn_simd_f32_t xnn_neg_f32(xnn_simd_f32_t a) {
   XNN_SIMD_CONST_F32(v0, 0);
   return Q6_Vsf_vsub_VsfVsf(v0, a);
-}
-
-static XNN_INLINE xnn_simd_f32_t xnn_round_f32(xnn_simd_f32_t a) {
-  XNN_UNREACHABLE;
-  XNN_SIMD_CONST_F32(v0, 0);
-  return v0;
 }
 
 // Logical operations.
@@ -146,7 +143,7 @@ static XNN_INLINE xnn_simd_f32_t xnn_loadu_f32(const float* ptr) {
 }
 
 static XNN_INLINE xnn_simd_f32_t xnn_load_f32(const float* ptr) {
-  return *((HVX_Vector*) ptr);
+  return *((HVX_UVector*) ptr);
 }
 
 static XNN_INLINE void xnn_storeu_f32(float* ptr, xnn_simd_f32_t v) {

--- a/src/xnnpack/simd/f32-hvx.h
+++ b/src/xnnpack/simd/f32-hvx.h
@@ -50,7 +50,7 @@ static XNN_INLINE xnn_simd_f32_t xnn_mul_f32(xnn_simd_f32_t a,
   return Q6_Vsf_equals_Vqf32(Q6_Vqf32_vmpy_VsfVsf(a, b));
 }
 
-static XNN_INLINE xnn_simd_f32_t xnn_rcp_f32(xnn_simd_f32_t a){
+static XNN_INLINE xnn_simd_f32_t xnn_rcp_f32(xnn_simd_f32_t a) {
   return fast_inverse__vsf(a);
 }
 
@@ -150,7 +150,7 @@ static XNN_INLINE xnn_simd_f32_t xnn_loadu_f32(const float* ptr) {
 }
 
 static XNN_INLINE xnn_simd_f32_t xnn_load_f32(const float* ptr) {
-  return *((HVX_UVector*) ptr);
+  return *((HVX_Vector*) ptr);
 }
 
 static XNN_INLINE void xnn_storeu_f32(float* ptr, xnn_simd_f32_t v) {

--- a/test/unary-ops.h
+++ b/test/unary-ops.h
@@ -77,7 +77,7 @@ struct UnaryOpInfo {
   virtual float ReferenceImpl(float x, const xnn_unary_params& params) const {
     XNN_UNREACHABLE;
   }
-  virtual int ReferenceImpl(int x, const xnn_unary_params& params) const {
+  virtual int32_t ReferenceImpl(int32_t x, const xnn_unary_params& params) const {
     XNN_UNREACHABLE;
   }
 
@@ -125,7 +125,7 @@ struct Convert : public UnaryOpInfo {
   float ReferenceImpl(float x, const xnn_unary_params&) const override {
     return x;
   }
-  int ReferenceImpl(int x, const xnn_unary_params&) const override { return x; }
+  int32_t ReferenceImpl(int32_t x, const xnn_unary_params&) const override { return x; }
 
   float Tolerance(float y_ref, xnn_datatype datatype) const override {
     return xnn_datatype_is_quantized(datatype)
@@ -138,8 +138,8 @@ struct ReLU : public UnaryOpInfo {
   float ReferenceImpl(float x, const xnn_unary_params&) const override {
     return std::max(x, 0.0f);
   }
-  int ReferenceImpl(int x, const xnn_unary_params&) const override {
-    return std::max(x, 0);
+  int32_t ReferenceImpl(int32_t x, const xnn_unary_params&) const override {
+    return std::max<int32_t>(x, 0);
   }
 };
 
@@ -147,7 +147,7 @@ struct Abs : public UnaryOpInfo {
   float ReferenceImpl(float x, const xnn_unary_params&) const override {
     return std::abs(x);
   }
-  int ReferenceImpl(int x, const xnn_unary_params&) const override {
+  int32_t ReferenceImpl(int32_t x, const xnn_unary_params&) const override {
     return std::abs(x);
   }
 };
@@ -156,7 +156,7 @@ struct Negate : public UnaryOpInfo {
   float ReferenceImpl(float x, const xnn_unary_params&) const override {
     return -x;
   }
-  int ReferenceImpl(int x, const xnn_unary_params&) const override {
+  int32_t ReferenceImpl(int32_t x, const xnn_unary_params&) const override {
     return -x;
   }
 };
@@ -173,8 +173,8 @@ struct Clamp : public UnaryOpInfo {
     return std::min<float>(std::max<float>(x, params.clamp.min),
                            params.clamp.max);
   }
-  int ReferenceImpl(int x, const xnn_unary_params& params) const override {
-    return std::min<int>(std::max<int>(x, params.clamp.min), params.clamp.max);
+  int32_t ReferenceImpl(int32_t x, const xnn_unary_params& params) const override {
+    return std::min<int32_t>(std::max<int32_t>(x, params.clamp.min), params.clamp.max);
   }
 
   xnn_quantization_params InputQuantizationParams(
@@ -419,8 +419,8 @@ struct Square : public UnaryOpInfo {
   float ReferenceImpl(float x, const xnn_unary_params&) const override {
     return x * x;
   }
-  int ReferenceImpl(int x, const xnn_unary_params&) const override {
-    return static_cast<int>(static_cast<int64_t>(x) * static_cast<int64_t>(x));
+  int32_t ReferenceImpl(int32_t x, const xnn_unary_params&) const override {
+    return static_cast<int32_t>(static_cast<int64_t>(x) * static_cast<int64_t>(x));
   }
 
   float Tolerance(float y_ref, xnn_datatype datatype) const override {
@@ -605,7 +605,7 @@ struct CountLeadingZeros : public UnaryOpInfo {
   float ReferenceImpl(float x, const xnn_unary_params&) const override {
     return (float)math_clz_u32((int)x);
   }
-  int ReferenceImpl(int x, const xnn_unary_params&) const override {
+  int32_t ReferenceImpl(int32_t x, const xnn_unary_params&) const override {
     return math_clz_u32(x);
   }
 };
@@ -614,7 +614,7 @@ struct BitwiseNot : public UnaryOpInfo {
   float ReferenceImpl(float x, const xnn_unary_params&) const override {
     return ~(int)x;
   }
-  int ReferenceImpl(int x, const xnn_unary_params&) const override {
+  int32_t ReferenceImpl(int32_t x, const xnn_unary_params&) const override {
     return ~x;
   }
 };
@@ -623,7 +623,7 @@ struct Popcount : public UnaryOpInfo {
   float ReferenceImpl(float x, const xnn_unary_params&) const override {
     return (float)math_popcount_u32((int)x);
   }
-  int ReferenceImpl(int x, const xnn_unary_params&) const override {
+  int32_t ReferenceImpl(int32_t x, const xnn_unary_params&) const override {
     return math_popcount_u32(x);
   }
 };
@@ -632,7 +632,7 @@ struct Sign : public UnaryOpInfo {
   float ReferenceImpl(float x, const xnn_unary_params&) const override {
     return x < 0.0f ? -1.0f : x > 0.0f ? 1.0f : 0.0f;
   }
-  int ReferenceImpl(int x, const xnn_unary_params&) const override {
+  int32_t ReferenceImpl(int32_t x, const xnn_unary_params&) const override {
     return x < 0 ? -1 : x > 0 ? 1 : 0;
   }
 };
@@ -735,10 +735,10 @@ void UnaryReferenceImpl(
   for (size_t i = 0; i < n; i++) {
     float y_i;
     if (std::is_integral<In>::value && std::is_integral<Out>::value) {
-      y[i] = op_info.ReferenceImpl((int)x[i], params);
+      y[i] = op_info.ReferenceImpl((int32_t)x[i], params);
     } else {
       if (std::is_integral<In>::value) {
-        y_i = op_info.ReferenceImpl((int)x[i], params);
+        y_i = op_info.ReferenceImpl((int32_t)x[i], params);
       } else {
         y_i = op_info.ReferenceImpl(static_cast<float>(x[i]), params);
       }


### PR DESCRIPTION
We needed to use `int32_t` instead of `int` for hexagon build. 
If there is any better fix, please feel free to let me know!
