### PR TITLE
SME2 IGEMM QS8 integration prototype

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -93,10 +93,10 @@ http_archive(
 # KleidiAI library, used for ARM microkernels.
 http_archive(
     name = "KleidiAI",
-    sha256 = "ca8b8ee0c3dd2284c1eae3ac07f7064ce92317ac7c3cfcd1d511662e0594cdb8",
-    strip_prefix = "kleidiai-fb4caf0937a45002861cc12788b6018bfb89ae58",
+    sha256 = "61768c695aa119424947b5668f39a8d4761aa5b540808cd19ddb0d24bcbd5296",
+    strip_prefix = "kleidiai-3d3d1ced4849cfcf0d685f79acfa6adef50f13d2",
     urls = [
-        "https://github.com/ARM-software/kleidiai/archive/fb4caf0937a45002861cc12788b6018bfb89ae58.zip",
+        "https://github.com/ARM-software/kleidiai/archive/3d3d1ced4849cfcf0d685f79acfa6adef50f13d2.zip",
     ],
 )
 # LINT.ThenChange(cmake/DownloadKleidiAI.cmake,WORKSPACE:kleidiai)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -107,10 +107,10 @@ http_archive(
 # KleidiAI library, used for ARM microkernels.
 http_archive(
     name = "KleidiAI",
-    sha256 = "ca8b8ee0c3dd2284c1eae3ac07f7064ce92317ac7c3cfcd1d511662e0594cdb8",
-    strip_prefix = "kleidiai-fb4caf0937a45002861cc12788b6018bfb89ae58",
+    sha256 = "61768c695aa119424947b5668f39a8d4761aa5b540808cd19ddb0d24bcbd5296",
+    strip_prefix = "kleidiai-3d3d1ced4849cfcf0d685f79acfa6adef50f13d2",
     urls = [
-        "https://github.com/ARM-software/kleidiai/archive/fb4caf0937a45002861cc12788b6018bfb89ae58.zip",
+        "https://github.com/ARM-software/kleidiai/archive/3d3d1ced4849cfcf0d685f79acfa6adef50f13d2.zip",
     ],
 )
 # LINT.ThenChange(cmake/DownloadKleidiAI.cmake,MODULE.bazel:kleidiai)

--- a/cmake/DownloadKleidiAI.cmake
+++ b/cmake/DownloadKleidiAI.cmake
@@ -18,8 +18,8 @@ ENDIF()
 # LINT.IfChange
 INCLUDE(ExternalProject)
 ExternalProject_Add(kleidiai
-  URL https://github.com/ARM-software/kleidiai/archive/fb4caf0937a45002861cc12788b6018bfb89ae58.zip
-  URL_HASH SHA256=ca8b8ee0c3dd2284c1eae3ac07f7064ce92317ac7c3cfcd1d511662e0594cdb8
+  URL https://github.com/ARM-software/kleidiai/archive/3d3d1ced4849cfcf0d685f79acfa6adef50f13d2.zip
+  URL_HASH SHA256=61768c695aa119424947b5668f39a8d4761aa5b540808cd19ddb0d24bcbd5296
   SOURCE_DIR "${CMAKE_BINARY_DIR}/kleidiai-source"
   BINARY_DIR "${CMAKE_BINARY_DIR}/kleidiai"
   CONFIGURE_COMMAND ""

--- a/cmake/gen/neonsme2_microkernels.cmake
+++ b/cmake/gen/neonsme2_microkernels.cmake
@@ -16,6 +16,7 @@ SET(PROD_NEONSME2_MICROKERNEL_SRCS
   src/pqs8-qc8w-gemm/pqs8-qc8w-gemm-32x32-minmax-neonsme2.c
   src/qp8-f32-qc4w-gemm/qp8-f32-qc4w-gemm-minmax-1x128c4-neonsme2.c
   src/qp8-f32-qc4w-gemm/qp8-f32-qc4w-gemm-minmax-32x128c4-neonsme2.c
+  src/qs8-qc8w-igemm/qs8-qc8w-igemm-32x32-minmax-fp32-neonsme2.c
   src/x8-pack-lh/x8--packlh-neonsme2.c
   src/x16-pack-lh/x16-packlh-neonsme2.c
   src/x32-pack-lh/x32-packlh-neonsme2.c)

--- a/gen/neonsme2_microkernels.bzl
+++ b/gen/neonsme2_microkernels.bzl
@@ -12,6 +12,7 @@ PROD_NEONSME2_MICROKERNEL_SRCS = [
     "src/pqs8-qc8w-gemm/pqs8-qc8w-gemm-32x32-minmax-neonsme2.c",
     "src/qp8-f32-qc4w-gemm/qp8-f32-qc4w-gemm-minmax-1x128c4-neonsme2.c",
     "src/qp8-f32-qc4w-gemm/qp8-f32-qc4w-gemm-minmax-32x128c4-neonsme2.c",
+    "src/qs8-qc8w-igemm/qs8-qc8w-igemm-32x32-minmax-fp32-neonsme2.c",
     "src/x8-pack-lh/x8--packlh-neonsme2.c",
     "src/x16-pack-lh/x16-packlh-neonsme2.c",
     "src/x32-pack-lh/x32-packlh-neonsme2.c",

--- a/src/configs/gemm-config.c
+++ b/src/configs/gemm-config.c
@@ -4177,7 +4177,21 @@ static void init_qs8_qc8w_gemm_config(void) {
     (void) hardware_config;  // May be unused.
     #if XNN_PLATFORM_IOS || XNN_PLATFORM_MAC || XNN_PLATFORM_WINDOWS
       #if XNN_ENABLE_ASSEMBLY
-        if (XNN_ENABLE_ARM_I8MM && hardware_config->use_arm_neon_i8mm) {
+        if (XNN_ENABLE_ARM_SME2 && hardware_config->use_arm_sme2) {
+          #if XNN_ENABLE_ARM_SME2
+            const size_t mr = xnn_qs8_qc8w_igemm_minmax_fp32_ukernel_32x32__neonsme2_get_mr();
+            const size_t nr = xnn_qs8_qc8w_igemm_minmax_fp32_ukernel_32x32__neonsme2_get_nr();
+            qs8_qc8w_gemm_config.minmax.igemm[XNN_MR_TO_INDEX(mr)] = xnn_init_hmp_igemm_ukernel((xnn_igemm_ukernel_fn) xnn_qs8_qc8w_igemm_minmax_fp32_ukernel_32x32__neonsme2);
+            qs8_qc8w_gemm_config.init.qs8_qc8w = xnn_init_qs8_qc8w_conv_minmax_fp32_neonv8_params;
+            qs8_qc8w_gemm_config.pack_igemm_goki = (xnn_pack_conv_goki_w_fn) xnn_pack_kai_qs8_conv_goki_w_sme2;
+            qs8_qc8w_gemm_config.pack_igemm_kgo = (xnn_pack_conv_kgo_w_fn) xnn_pack_qs8_conv_kgo_w;
+            qs8_qc8w_gemm_config.pack_deconv_goki = (xnn_pack_deconv_goki_w_fn) xnn_pack_qs8_deconv_goki_w;
+            qs8_qc8w_gemm_config.mr = mr;
+            qs8_qc8w_gemm_config.mr_packed = mr;
+            qs8_qc8w_gemm_config.nr = nr;
+            qs8_qc8w_gemm_config.log2_kr = 2;
+          #endif  // XNN_ENABLE_ARM_SME2
+        } else if (XNN_ENABLE_ARM_I8MM && hardware_config->use_arm_neon_i8mm) {
           #if XNN_ENABLE_ARM_I8MM
             qs8_qc8w_gemm_config.minmax.gemm[XNN_MR_TO_INDEX(1)] = xnn_init_hmp_gemm_ukernel((xnn_gemm_ukernel_fn) xnn_qs8_qc8w_gemm_minmax_fp32_ukernel_1x16c8__neoni8mm);
             qs8_qc8w_gemm_config.minmax.gemm[XNN_MR_TO_INDEX(4)] = xnn_init_hmp_gemm_ukernel((xnn_gemm_ukernel_fn) xnn_qs8_qc8w_gemm_minmax_fp32_ukernel_4x16c8__neoni8mm);

--- a/src/qs8-qc8w-igemm/qs8-qc8w-igemm-32x32-minmax-fp32-neonsme2.c
+++ b/src/qs8-qc8w-igemm/qs8-qc8w-igemm-32x32-minmax-fp32-neonsme2.c
@@ -1,0 +1,57 @@
+#include <stddef.h>
+
+#include "kai/kai_common.h"
+#include "kai/ukernels/matmul/matmul_clamp_qai8_qai8p_qsi8cxp/kai_matmul_clamp_qai8_qai8p2vlx4_qsi8cxpsb2vlx4_2vlx2vl_sme2_mopa.h"
+#include "kai/ukernels/matmul/pack/kai_lhs_imatmul_pack_x8p2vlx4_x8p_sme.h"
+#include "src/xnnpack/igemm.h"
+#include "src/xnnpack/math.h"
+#include <arm_neon.h>
+
+size_t xnn_qs8_qc8w_igemm_minmax_fp32_ukernel_32x32__neonsme2_get_mr(void)
+{
+  return kai_get_mr_matmul_clamp_qai8_qai8p2vlx4_qsi8cxpsb2vlx4_2vlx2vl_sme2_mopa();
+}
+
+size_t xnn_qs8_qc8w_igemm_minmax_fp32_ukernel_32x32__neonsme2_get_nr(void)
+{
+  return kai_get_nr_matmul_clamp_qai8_qai8p2vlx4_qsi8cxpsb2vlx4_2vlx2vl_sme2_mopa();
+}
+
+void xnn_qs8_qc8w_igemm_minmax_fp32_ukernel_32x32__neonsme2(
+  size_t mr,
+  size_t nc,
+  size_t kc,
+  size_t ks,
+  const int8_t** restrict a,
+  const void* restrict w,
+  int8_t* restrict c,
+  size_t cm_stride,
+  size_t cn_stride,
+  size_t a_offset,
+  const int8_t* zero,
+  const union xnn_qs8_qc8w_conv_minmax_params params[restrict XNN_MIN_ELEMENTS(1)]) XNN_OOB_READS
+{
+  const size_t kai_mr = kai_get_mr_matmul_clamp_qai8_qai8p2vlx4_qsi8cxpsb2vlx4_2vlx2vl_sme2_mopa();
+  const size_t k_chunk_count = ks / sizeof(void*) / kai_mr;
+  const size_t k_chunk_length = kc;
+  const size_t kai_kr = 4;
+  const size_t k = k_chunk_count * round_up(k_chunk_length, kai_kr);
+
+  // Packs LHS.
+  const size_t packed_lhs_size =
+    kai_get_lhs_packed_size_lhs_imatmul_pack_x8p2vlx4_x8p_sme(mr, k_chunk_count, k_chunk_length);
+  void* packed_lhs = malloc(packed_lhs_size);
+
+  kai_run_lhs_imatmul_pack_x8p2vlx4_x8p_sme(mr, k_chunk_count, k_chunk_length, a, a_offset, zero, packed_lhs);
+
+  // GEMM.
+  struct kai_matmul_requantize32_params kai_params;
+  kai_params.output_zero_point = params->fp32_neonv8.output_zero_point;
+  kai_params.min_value = (int8_t) params->fp32_neonv8.output_min;
+  kai_params.max_value = (int8_t) params->fp32_neonv8.output_max;
+
+  kai_run_matmul_clamp_qai8_qai8p2vlx4_qsi8cxpsb2vlx4_2vlx2vl_sme2_mopa(
+    mr, nc, k, packed_lhs, w, c, cm_stride, sizeof(int8_t), &kai_params);
+
+  free(packed_lhs);
+}

--- a/src/xnnpack/igemm.h
+++ b/src/xnnpack/igemm.h
@@ -2256,6 +2256,12 @@ DECLARE_QS8_QC8W_IGEMM_MINMAX_UKERNEL_FUNCTION(
 DECLARE_QS8_QC8W_IGEMM_MINMAX_UKERNEL_FUNCTION(
     xnn_qs8_qc8w_igemm_minmax_fp32_ukernel_4x8__asm_aarch32_neonv8_mlal_lane_ld64_prfm)
 
+XNN_INTERNAL size_t xnn_qs8_qc8w_igemm_minmax_fp32_ukernel_32x32__neonsme2_get_mr(void);
+XNN_INTERNAL size_t xnn_qs8_qc8w_igemm_minmax_fp32_ukernel_32x32__neonsme2_get_nr(void);
+
+DECLARE_QS8_QC8W_IGEMM_MINMAX_UKERNEL_FUNCTION(
+    xnn_qs8_qc8w_igemm_minmax_fp32_ukernel_32x32__neonsme2)
+
 DECLARE_QS8_QC8W_IGEMM_MINMAX_UKERNEL_FUNCTION(
     xnn_qs8_qc8w_igemm_minmax_fp32_ukernel_1x4c2__sse2_ld64)
 DECLARE_QS8_QC8W_IGEMM_MINMAX_UKERNEL_FUNCTION(

--- a/src/xnnpack/pack.h
+++ b/src/xnnpack/pack.h
@@ -420,6 +420,13 @@ void xnn_pack_kai_qs8_qc8w_weights_and_biases_sme2(
     size_t extra_data1_element_size, void* packed_weights_ptr,
     const void* params);
 
+void xnn_pack_kai_qs8_conv_goki_w_sme2(
+    size_t g, size_t nc, size_t ks, size_t kc,
+    size_t nr, size_t kr, size_t sr, const int8_t* k,
+    const int32_t* b, const float* scale,
+    void* packed_weights, size_t extra_bytes,
+    const struct xnn_qs8_packing_params* params);
+
 void xnn_pack_kai_f16_weights_and_biases(
     uint32_t flags,                                //
     const struct xnn_gemm_config* gemm_config,     //

--- a/test/qs8-qc8w-igemm-minmax-fp32.cc
+++ b/test/qs8-qc8w-igemm-minmax-fp32.cc
@@ -875,6 +875,28 @@ std::vector<GemmTestParams> CreateTests1(
       });
 
   INSTANTIATE_TEST_SUITE_P(
+      QS8_QC8W_IGEMM_MINMAX_FP32_32X32__NEONSME2, GemmTest,
+      testing::ValuesIn(CreateTests1(
+          /*k_block=*/4,
+          /*adj_k_block=*/4,
+          /*mr=*/32, /*nr=*/32, /*kr=*/4, /*sr=*/1,
+          /*is_igemm=*/false,
+          /*unsigned_inputs=*/false,
+          /*planes=*/1,
+          [](GemmMicrokernelTester& tester) {
+            tester.Test(xnn_qs8_qc8w_igemm_minmax_fp32_ukernel_32x32__neonsme2,
+                        xnn_init_qs8_qc8w_conv_minmax_fp32_neonv8_params,
+                        xnn_pack_qs8_conv_goki_w,
+                        xnn_qs8_requantize_fp32);
+          },
+          []() {
+            TEST_REQUIRES_ARM_NEON_I8MM;
+          })),
+      [](const testing::TestParamInfo<GemmTest::ParamType>& info) {
+        return info.param.test_name;
+      });
+
+  INSTANTIATE_TEST_SUITE_P(
       QS8_QC8W_IGEMM_MINMAX_FP32_6X8C8__NEONI8MM, GemmTest,
       testing::ValuesIn(CreateTests1(
           /*k_block=*/16,


### PR DESCRIPTION
* This patch demonstrates the use of SME2 IGEMM QS8 kernels.
* The LHS packing and the main kernel are combined to emulate the existing IGEMM kernel interface which doesn't support LHS packing.

Signed-off-by: Viet-Hoa Do <viet-hoa.do@arm.com>
