### PR TITLE
Explicit type arg in std::max for Hexagon build

### DIFF
--- a/bench/subgraph/fp32-transformer.cc
+++ b/bench/subgraph/fp32-transformer.cc
@@ -860,8 +860,8 @@ xnn_subgraph_t FP32TransformerBlock(size_t batch_size, size_t sequence_length,
   }
 
   std::array<size_t, 4> shape_v7_w43_v8 = {
-      (size_t)std::max(w43_data[0], 0), (size_t)std::max(w43_data[1], 0),
-      (size_t)std::max(w43_data[2], 0), (size_t)std::max(w43_data[3], 0)};
+      (size_t)std::max<int32_t>(w43_data[0], 0), (size_t)std::max<int32_t>(w43_data[1], 0),
+      (size_t)std::max<int32_t>(w43_data[2], 0), (size_t)std::max<int32_t>(w43_data[3], 0)};
   status = xnn_define_static_reshape(subgraph,
                                      /*num_dims=*/shape_v7_w43_v8.size(),
                                      /*new_shape=*/shape_v7_w43_v8.data(),
@@ -902,9 +902,9 @@ xnn_subgraph_t FP32TransformerBlock(size_t batch_size, size_t sequence_length,
   }
 
   std::array<size_t, 5> shape_v10_w46_v11 = {
-      (size_t)std::max(w46_data[0], 0), (size_t)std::max(w46_data[1], 0),
-      (size_t)std::max(w46_data[2], 0), (size_t)std::max(w46_data[3], 0),
-      (size_t)std::max(w46_data[4], 0)};
+      (size_t)std::max<int32_t>(w46_data[0], 0), (size_t)std::max<int32_t>(w46_data[1], 0),
+      (size_t)std::max<int32_t>(w46_data[2], 0), (size_t)std::max<int32_t>(w46_data[3], 0),
+      (size_t)std::max<int32_t>(w46_data[4], 0)};
   status = xnn_define_static_reshape(subgraph,
                                      /*num_dims=*/shape_v10_w46_v11.size(),
                                      /*new_shape=*/shape_v10_w46_v11.data(),
@@ -931,8 +931,8 @@ xnn_subgraph_t FP32TransformerBlock(size_t batch_size, size_t sequence_length,
   }
 
   std::array<size_t, 4> shape_v12_w48_v13 = {
-      (size_t)std::max(w48_data[0], 0), (size_t)std::max(w48_data[1], 0),
-      (size_t)std::max(w48_data[2], 0), (size_t)std::max(w48_data[3], 0)};
+      (size_t)std::max<int32_t>(w48_data[0], 0), (size_t)std::max<int32_t>(w48_data[1], 0),
+      (size_t)std::max<int32_t>(w48_data[2], 0), (size_t)std::max<int32_t>(w48_data[3], 0)};
   status = xnn_define_static_reshape(subgraph,
                                      /*num_dims=*/shape_v12_w48_v13.size(),
                                      /*new_shape=*/shape_v12_w48_v13.data(),
@@ -955,9 +955,9 @@ xnn_subgraph_t FP32TransformerBlock(size_t batch_size, size_t sequence_length,
   }
 
   std::array<size_t, 5> shape_v14_w49_v15 = {
-      (size_t)std::max(w49_data[0], 0), (size_t)std::max(w49_data[1], 0),
-      (size_t)std::max(w49_data[2], 0), (size_t)std::max(w49_data[3], 0),
-      (size_t)std::max(w49_data[4], 0)};
+      (size_t)std::max<int32_t>(w49_data[0], 0), (size_t)std::max<int32_t>(w49_data[1], 0),
+      (size_t)std::max<int32_t>(w49_data[2], 0), (size_t)std::max<int32_t>(w49_data[3], 0),
+      (size_t)std::max<int32_t>(w49_data[4], 0)};
   status = xnn_define_static_reshape(subgraph,
                                      /*num_dims=*/shape_v14_w49_v15.size(),
                                      /*new_shape=*/shape_v14_w49_v15.data(),
@@ -1001,8 +1001,8 @@ xnn_subgraph_t FP32TransformerBlock(size_t batch_size, size_t sequence_length,
   }
 
   std::array<size_t, 4> shape_v18_w52_v19 = {
-      (size_t)std::max(w52_data[0], 0), (size_t)std::max(w52_data[1], 0),
-      (size_t)std::max(w52_data[2], 0), (size_t)std::max(w52_data[3], 0)};
+      (size_t)std::max<int32_t>(w52_data[0], 0), (size_t)std::max<int32_t>(w52_data[1], 0),
+      (size_t)std::max<int32_t>(w52_data[2], 0), (size_t)std::max<int32_t>(w52_data[3], 0)};
   status = xnn_define_static_reshape(subgraph,
                                      /*num_dims=*/shape_v18_w52_v19.size(),
                                      /*new_shape=*/shape_v18_w52_v19.data(),
@@ -1015,8 +1015,8 @@ xnn_subgraph_t FP32TransformerBlock(size_t batch_size, size_t sequence_length,
   }
 
   std::array<size_t, 4> shape_v7_w53_v20 = {
-      (size_t)std::max(w53_data[0], 0), (size_t)std::max(w53_data[1], 0),
-      (size_t)std::max(w53_data[2], 0), (size_t)std::max(w53_data[3], 0)};
+      (size_t)std::max<int32_t>(w53_data[0], 0), (size_t)std::max<int32_t>(w53_data[1], 0),
+      (size_t)std::max<int32_t>(w53_data[2], 0), (size_t)std::max<int32_t>(w53_data[3], 0)};
   status = xnn_define_static_reshape(subgraph,
                                      /*num_dims=*/shape_v7_w53_v20.size(),
                                      /*new_shape=*/shape_v7_w53_v20.data(),
@@ -1039,9 +1039,9 @@ xnn_subgraph_t FP32TransformerBlock(size_t batch_size, size_t sequence_length,
   }
 
   std::array<size_t, 5> shape_v21_w54_v22 = {
-      (size_t)std::max(w54_data[0], 0), (size_t)std::max(w54_data[1], 0),
-      (size_t)std::max(w54_data[2], 0), (size_t)std::max(w54_data[3], 0),
-      (size_t)std::max(w54_data[4], 0)};
+      (size_t)std::max<int32_t>(w54_data[0], 0), (size_t)std::max<int32_t>(w54_data[1], 0),
+      (size_t)std::max<int32_t>(w54_data[2], 0), (size_t)std::max<int32_t>(w54_data[3], 0),
+      (size_t)std::max<int32_t>(w54_data[4], 0)};
   status = xnn_define_static_reshape(subgraph,
                                      /*num_dims=*/shape_v21_w54_v22.size(),
                                      /*new_shape=*/shape_v21_w54_v22.data(),
@@ -1067,9 +1067,9 @@ xnn_subgraph_t FP32TransformerBlock(size_t batch_size, size_t sequence_length,
     return nullptr;
   }
 
-  std::array<size_t, 3> shape_v23_w56_v24 = {(size_t)std::max(w56_data[0], 0),
-                                             (size_t)std::max(w56_data[1], 0),
-                                             (size_t)std::max(w56_data[2], 0)};
+  std::array<size_t, 3> shape_v23_w56_v24 = {(size_t)std::max<int32_t>(w56_data[0], 0),
+                                             (size_t)std::max<int32_t>(w56_data[1], 0),
+                                             (size_t)std::max<int32_t>(w56_data[2], 0)};
   status = xnn_define_static_reshape(subgraph,
                                      /*num_dims=*/shape_v23_w56_v24.size(),
                                      /*new_shape=*/shape_v23_w56_v24.data(),

--- a/bench/subgraph/qd8-transformer.cc
+++ b/bench/subgraph/qd8-transformer.cc
@@ -935,8 +935,8 @@ xnn_subgraph_t QD8TransformerBlock(size_t batch_size, size_t sequence_length,
   }
 
   std::array<size_t, 4> shape_v7_w43_v8 = {
-      (size_t)std::max(w43_data[0], 0), (size_t)std::max(w43_data[1], 0),
-      (size_t)std::max(w43_data[2], 0), (size_t)std::max(w43_data[3], 0)};
+      (size_t)std::max<int32_t>(w43_data[0], 0), (size_t)std::max<int32_t>(w43_data[1], 0),
+      (size_t)std::max<int32_t>(w43_data[2], 0), (size_t)std::max<int32_t>(w43_data[3], 0)};
   status = xnn_define_static_reshape(subgraph,
                                      /*num_dims=*/shape_v7_w43_v8.size(),
                                      /*new_shape=*/shape_v7_w43_v8.data(),
@@ -997,9 +997,9 @@ xnn_subgraph_t QD8TransformerBlock(size_t batch_size, size_t sequence_length,
   }
 
   std::array<size_t, 5> shape_v10_w46_v11 = {
-      (size_t)std::max(w46_data[0], 0), (size_t)std::max(w46_data[1], 0),
-      (size_t)std::max(w46_data[2], 0), (size_t)std::max(w46_data[3], 0),
-      (size_t)std::max(w46_data[4], 0)};
+      (size_t)std::max<int32_t>(w46_data[0], 0), (size_t)std::max<int32_t>(w46_data[1], 0),
+      (size_t)std::max<int32_t>(w46_data[2], 0), (size_t)std::max<int32_t>(w46_data[3], 0),
+      (size_t)std::max<int32_t>(w46_data[4], 0)};
   status = xnn_define_static_reshape(subgraph,
                                      /*num_dims=*/shape_v10_w46_v11.size(),
                                      /*new_shape=*/shape_v10_w46_v11.data(),
@@ -1026,8 +1026,8 @@ xnn_subgraph_t QD8TransformerBlock(size_t batch_size, size_t sequence_length,
   }
 
   std::array<size_t, 4> shape_v12_w48_v13 = {
-      (size_t)std::max(w48_data[0], 0), (size_t)std::max(w48_data[1], 0),
-      (size_t)std::max(w48_data[2], 0), (size_t)std::max(w48_data[3], 0)};
+      (size_t)std::max<int32_t>(w48_data[0], 0), (size_t)std::max<int32_t>(w48_data[1], 0),
+      (size_t)std::max<int32_t>(w48_data[2], 0), (size_t)std::max<int32_t>(w48_data[3], 0)};
   status = xnn_define_static_reshape(subgraph,
                                      /*num_dims=*/shape_v12_w48_v13.size(),
                                      /*new_shape=*/shape_v12_w48_v13.data(),
@@ -1050,9 +1050,9 @@ xnn_subgraph_t QD8TransformerBlock(size_t batch_size, size_t sequence_length,
   }
 
   std::array<size_t, 5> shape_v14_w49_v15 = {
-      (size_t)std::max(w49_data[0], 0), (size_t)std::max(w49_data[1], 0),
-      (size_t)std::max(w49_data[2], 0), (size_t)std::max(w49_data[3], 0),
-      (size_t)std::max(w49_data[4], 0)};
+      (size_t)std::max<int32_t>(w49_data[0], 0), (size_t)std::max<int32_t>(w49_data[1], 0),
+      (size_t)std::max<int32_t>(w49_data[2], 0), (size_t)std::max<int32_t>(w49_data[3], 0),
+      (size_t)std::max<int32_t>(w49_data[4], 0)};
   status = xnn_define_static_reshape(subgraph,
                                      /*num_dims=*/shape_v14_w49_v15.size(),
                                      /*new_shape=*/shape_v14_w49_v15.data(),
@@ -1096,8 +1096,8 @@ xnn_subgraph_t QD8TransformerBlock(size_t batch_size, size_t sequence_length,
   }
 
   std::array<size_t, 4> shape_v18_w52_v19 = {
-      (size_t)std::max(w52_data[0], 0), (size_t)std::max(w52_data[1], 0),
-      (size_t)std::max(w52_data[2], 0), (size_t)std::max(w52_data[3], 0)};
+      (size_t)std::max<int32_t>(w52_data[0], 0), (size_t)std::max<int32_t>(w52_data[1], 0),
+      (size_t)std::max<int32_t>(w52_data[2], 0), (size_t)std::max<int32_t>(w52_data[3], 0)};
   status = xnn_define_static_reshape(subgraph,
                                      /*num_dims=*/shape_v18_w52_v19.size(),
                                      /*new_shape=*/shape_v18_w52_v19.data(),
@@ -1110,8 +1110,8 @@ xnn_subgraph_t QD8TransformerBlock(size_t batch_size, size_t sequence_length,
   }
 
   std::array<size_t, 4> shape_v7_w53_v20 = {
-      (size_t)std::max(w53_data[0], 0), (size_t)std::max(w53_data[1], 0),
-      (size_t)std::max(w53_data[2], 0), (size_t)std::max(w53_data[3], 0)};
+      (size_t)std::max<int32_t>(w53_data[0], 0), (size_t)std::max<int32_t>(w53_data[1], 0),
+      (size_t)std::max<int32_t>(w53_data[2], 0), (size_t)std::max<int32_t>(w53_data[3], 0)};
   status = xnn_define_static_reshape(subgraph,
                                      /*num_dims=*/shape_v7_w53_v20.size(),
                                      /*new_shape=*/shape_v7_w53_v20.data(),
@@ -1134,9 +1134,9 @@ xnn_subgraph_t QD8TransformerBlock(size_t batch_size, size_t sequence_length,
   }
 
   std::array<size_t, 5> shape_v21_w54_v22 = {
-      (size_t)std::max(w54_data[0], 0), (size_t)std::max(w54_data[1], 0),
-      (size_t)std::max(w54_data[2], 0), (size_t)std::max(w54_data[3], 0),
-      (size_t)std::max(w54_data[4], 0)};
+      (size_t)std::max<int32_t>(w54_data[0], 0), (size_t)std::max<int32_t>(w54_data[1], 0),
+      (size_t)std::max<int32_t>(w54_data[2], 0), (size_t)std::max<int32_t>(w54_data[3], 0),
+      (size_t)std::max<int32_t>(w54_data[4], 0)};
   status = xnn_define_static_reshape(subgraph,
                                      /*num_dims=*/shape_v21_w54_v22.size(),
                                      /*new_shape=*/shape_v21_w54_v22.data(),
@@ -1162,9 +1162,9 @@ xnn_subgraph_t QD8TransformerBlock(size_t batch_size, size_t sequence_length,
     return nullptr;
   }
 
-  std::array<size_t, 3> shape_v23_w56_v24 = {(size_t)std::max(w56_data[0], 0),
-                                             (size_t)std::max(w56_data[1], 0),
-                                             (size_t)std::max(w56_data[2], 0)};
+  std::array<size_t, 3> shape_v23_w56_v24 = {(size_t)std::max<int32_t>(w56_data[0], 0),
+                                             (size_t)std::max<int32_t>(w56_data[1], 0),
+                                             (size_t)std::max<int32_t>(w56_data[2], 0)};
   status = xnn_define_static_reshape(subgraph,
                                      /*num_dims=*/shape_v23_w56_v24.size(),
                                      /*new_shape=*/shape_v23_w56_v24.data(),


### PR DESCRIPTION
`std::max` to `std::max<int32_t>` to avoid build error.