### PR TITLE
Fix the issue that Pad cannot be fused into conv2d

### DIFF
--- a/src/subgraph.c
+++ b/src/subgraph.c
@@ -1566,7 +1566,7 @@ enum xnn_status xnn_subgraph_fusion(xnn_subgraph_t subgraph) {
             ((padding_datatype == xnn_datatype_qint8 ||
               padding_datatype == xnn_datatype_quint8) &&
              padding_value ==
-                 (uint32_t)(uint8_t)subgraph->values[producer->outputs[0]]
+                 (uint32_t)subgraph->values[producer->outputs[0]]
                      .quantization.zero_point);
         switch (consumer->type) {
           case xnn_node_type_convolution_2d:


### PR DESCRIPTION
The zero point should not be coverted to uint8 if the data type is int8.