### PR TITLE
Fix of `xnn_andnot_f32` function for Hexagon (HVX)

### DIFF
--- a/src/xnnpack/simd/f32-hvx.h
+++ b/src/xnnpack/simd/f32-hvx.h
@@ -243,8 +243,9 @@ static XNN_INLINE xnn_simd_f32_t xnn_xor_f32(xnn_simd_f32_t a,
   return Q6_V_vxor_VV(a, b);
 }
 
-static XNN_INLINE xnn_simd_f32_t xnn_andnot_f32(xnn_simd_f32_t a) {
-  return Q6_V_vand_VV(Q6_V_vnot_VV(a), b);
+static XNN_INLINE xnn_simd_f32_t xnn_andnot_f32(xnn_simd_f32_t a,
+                                                xnn_simd_f32_t b) {
+  return Q6_V_vand_VV(Q6_V_vnot_V(a), b);
 }
 
 static XNN_INLINE xnn_simd_f32_t xnn_sll_f32(xnn_simd_f32_t a, uint8_t bits) {


### PR DESCRIPTION
- `Q6_V_vnot_VV` -> `Q6_V_vnot_V`
- Add function parameter `xnn_simd_f32_t b`