### PR TITLE
Updating GEMMBenchmark constructor to use ConstantOrFunction

### DIFF
--- a/bench/gemm-benchmark.cc
+++ b/bench/gemm-benchmark.cc
@@ -789,7 +789,7 @@ void GEMMBenchmark(benchmark::State& state,
                    xnn_init_f32_minmax_params_fn init_minmax_params,
                    xnn_pack_weights_and_biases_fn pack_weights,
                    xnn_packed_stride_weights_and_biases_fn packed_stride,
-                   size_t mr, size_t nr, size_t kr, size_t sr, size_t mr_packed,
+                   ConstantOrFunction mr, ConstantOrFunction nr, size_t kr, size_t sr, ConstantOrFunction mr_packed,
                    uint64_t arch_flags) {
   if (!benchmark::utils::CheckArchFlags(state, arch_flags)) {
     return;

--- a/bench/gemm-benchmark.h
+++ b/bench/gemm-benchmark.h
@@ -98,7 +98,7 @@ void GEMMBenchmark(benchmark::State& state,
                    xnn_init_f32_minmax_params_fn init_minmax_params,
                    xnn_pack_weights_and_biases_fn pack_weights,
                    xnn_packed_stride_weights_and_biases_fn packed_stride,
-                   size_t mr, size_t nr, size_t kr, size_t sr, size_t mr_packed,
+                   ConstantOrFunction mr, ConstantOrFunction nr, size_t kr, size_t sr, ConstantOrFunction mr_packed,
                    uint64_t arch_flags = 0);
 
 void GEMMBenchmark(benchmark::State& state,


### PR DESCRIPTION
When building XNNPACK with XNNPACK_ENABLE_ARM_SME2=ON

mkdir build && cd build
cmake .. -DXNNPACK_ENABLE_ARM_SME2=ON
cmake --build . --config Release

The build fails with a method signature mismatch in bench/gemm-benchmark.cc. This patch corrects the mismatch.