### PR TITLE
Use unaligned.h loads for qb4w scalar ksum loads

### DIFF
--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x4-minmax-scalar.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x4-minmax-scalar.c
@@ -17,6 +17,7 @@
 #include "src/xnnpack/math.h"
 #include "src/xnnpack/microparams.h"
 
+#include "src/xnnpack/unaligned.h"
 
 
 void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x4__scalar(
@@ -47,10 +48,10 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x4__scalar(
 
   kc = round_up_po2(kc, 2);
   do {
-    const float vksum0 = ((const float*) w)[0];
-    const float vksum1 = ((const float*) w)[1];
-    const float vksum2 = ((const float*) w)[2];
-    const float vksum3 = ((const float*) w)[3];
+    const float vksum0 = unaligned_indexed_load_f32(w, 0);
+    const float vksum1 = unaligned_indexed_load_f32(w, 1);
+    const float vksum2 = unaligned_indexed_load_f32(w, 2);
+    const float vksum3 = unaligned_indexed_load_f32(w, 3);
     const float vinput_zero_point0 = (const float) quantization_params[0].zero_point;
     float vout0x0 = vksum0 * vinput_zero_point0;
     float vout0x1 = vksum1 * vinput_zero_point0;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x8-minmax-scalar.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-1x8-minmax-scalar.c
@@ -17,6 +17,7 @@
 #include "src/xnnpack/math.h"
 #include "src/xnnpack/microparams.h"
 
+#include "src/xnnpack/unaligned.h"
 
 
 void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x8__scalar(
@@ -47,14 +48,14 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_1x8__scalar(
 
   kc = round_up_po2(kc, 2);
   do {
-    const float vksum0 = ((const float*) w)[0];
-    const float vksum1 = ((const float*) w)[1];
-    const float vksum2 = ((const float*) w)[2];
-    const float vksum3 = ((const float*) w)[3];
-    const float vksum4 = ((const float*) w)[4];
-    const float vksum5 = ((const float*) w)[5];
-    const float vksum6 = ((const float*) w)[6];
-    const float vksum7 = ((const float*) w)[7];
+    const float vksum0 = unaligned_indexed_load_f32(w, 0);
+    const float vksum1 = unaligned_indexed_load_f32(w, 1);
+    const float vksum2 = unaligned_indexed_load_f32(w, 2);
+    const float vksum3 = unaligned_indexed_load_f32(w, 3);
+    const float vksum4 = unaligned_indexed_load_f32(w, 4);
+    const float vksum5 = unaligned_indexed_load_f32(w, 5);
+    const float vksum6 = unaligned_indexed_load_f32(w, 6);
+    const float vksum7 = unaligned_indexed_load_f32(w, 7);
     const float vinput_zero_point0 = (const float) quantization_params[0].zero_point;
     float vout0x0 = vksum0 * vinput_zero_point0;
     float vout0x1 = vksum1 * vinput_zero_point0;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x4-minmax-scalar.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x4-minmax-scalar.c
@@ -17,6 +17,7 @@
 #include "src/xnnpack/math.h"
 #include "src/xnnpack/microparams.h"
 
+#include "src/xnnpack/unaligned.h"
 
 
 void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x4__scalar(
@@ -53,10 +54,10 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x4__scalar(
 
   kc = round_up_po2(kc, 2);
   do {
-    const float vksum0 = ((const float*) w)[0];
-    const float vksum1 = ((const float*) w)[1];
-    const float vksum2 = ((const float*) w)[2];
-    const float vksum3 = ((const float*) w)[3];
+    const float vksum0 = unaligned_indexed_load_f32(w, 0);
+    const float vksum1 = unaligned_indexed_load_f32(w, 1);
+    const float vksum2 = unaligned_indexed_load_f32(w, 2);
+    const float vksum3 = unaligned_indexed_load_f32(w, 3);
     const float vinput_zero_point0 = (const float) quantization_params[0].zero_point;
     float vout0x0 = vksum0 * vinput_zero_point0;
     float vout0x1 = vksum1 * vinput_zero_point0;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x8-minmax-scalar.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-2x8-minmax-scalar.c
@@ -17,6 +17,7 @@
 #include "src/xnnpack/math.h"
 #include "src/xnnpack/microparams.h"
 
+#include "src/xnnpack/unaligned.h"
 
 
 void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x8__scalar(
@@ -53,14 +54,14 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_2x8__scalar(
 
   kc = round_up_po2(kc, 2);
   do {
-    const float vksum0 = ((const float*) w)[0];
-    const float vksum1 = ((const float*) w)[1];
-    const float vksum2 = ((const float*) w)[2];
-    const float vksum3 = ((const float*) w)[3];
-    const float vksum4 = ((const float*) w)[4];
-    const float vksum5 = ((const float*) w)[5];
-    const float vksum6 = ((const float*) w)[6];
-    const float vksum7 = ((const float*) w)[7];
+    const float vksum0 = unaligned_indexed_load_f32(w, 0);
+    const float vksum1 = unaligned_indexed_load_f32(w, 1);
+    const float vksum2 = unaligned_indexed_load_f32(w, 2);
+    const float vksum3 = unaligned_indexed_load_f32(w, 3);
+    const float vksum4 = unaligned_indexed_load_f32(w, 4);
+    const float vksum5 = unaligned_indexed_load_f32(w, 5);
+    const float vksum6 = unaligned_indexed_load_f32(w, 6);
+    const float vksum7 = unaligned_indexed_load_f32(w, 7);
     const float vinput_zero_point0 = (const float) quantization_params[0].zero_point;
     float vout0x0 = vksum0 * vinput_zero_point0;
     float vout0x1 = vksum1 * vinput_zero_point0;

--- a/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x4-minmax-scalar.c
+++ b/src/qd8-f16-qb4w-gemm/gen/qd8-f16-qb4w-gemm-4x4-minmax-scalar.c
@@ -17,6 +17,7 @@
 #include "src/xnnpack/math.h"
 #include "src/xnnpack/microparams.h"
 
+#include "src/xnnpack/unaligned.h"
 
 
 void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x4__scalar(
@@ -65,10 +66,10 @@ void xnn_qd8_f16_qb4w_gemm_minmax_ukernel_4x4__scalar(
 
   kc = round_up_po2(kc, 2);
   do {
-    const float vksum0 = ((const float*) w)[0];
-    const float vksum1 = ((const float*) w)[1];
-    const float vksum2 = ((const float*) w)[2];
-    const float vksum3 = ((const float*) w)[3];
+    const float vksum0 = unaligned_indexed_load_f32(w, 0);
+    const float vksum1 = unaligned_indexed_load_f32(w, 1);
+    const float vksum2 = unaligned_indexed_load_f32(w, 2);
+    const float vksum3 = unaligned_indexed_load_f32(w, 3);
     const float vinput_zero_point0 = (const float) quantization_params[0].zero_point;
     float vout0x0 = vksum0 * vinput_zero_point0;
     float vout0x1 = vksum1 * vinput_zero_point0;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x4-minmax-scalar.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x4-minmax-scalar.c
@@ -17,6 +17,7 @@
 #include "src/xnnpack/math.h"
 #include "src/xnnpack/microparams.h"
 
+#include "src/xnnpack/unaligned.h"
 
 
 void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x4__scalar(
@@ -47,10 +48,10 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x4__scalar(
 
   kc = round_up_po2(kc, 2);
   do {
-    const float vksum0 = ((const float*) w)[0];
-    const float vksum1 = ((const float*) w)[1];
-    const float vksum2 = ((const float*) w)[2];
-    const float vksum3 = ((const float*) w)[3];
+    const float vksum0 = unaligned_indexed_load_f32(w, 0);
+    const float vksum1 = unaligned_indexed_load_f32(w, 1);
+    const float vksum2 = unaligned_indexed_load_f32(w, 2);
+    const float vksum3 = unaligned_indexed_load_f32(w, 3);
     const float vinput_zero_point0 = (const float) quantization_params[0].zero_point;
     float vout0x0 = vksum0 * vinput_zero_point0;
     float vout0x1 = vksum1 * vinput_zero_point0;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x8-minmax-scalar.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x8-minmax-scalar.c
@@ -17,6 +17,7 @@
 #include "src/xnnpack/math.h"
 #include "src/xnnpack/microparams.h"
 
+#include "src/xnnpack/unaligned.h"
 
 
 void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x8__scalar(
@@ -47,14 +48,14 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_1x8__scalar(
 
   kc = round_up_po2(kc, 2);
   do {
-    const float vksum0 = ((const float*) w)[0];
-    const float vksum1 = ((const float*) w)[1];
-    const float vksum2 = ((const float*) w)[2];
-    const float vksum3 = ((const float*) w)[3];
-    const float vksum4 = ((const float*) w)[4];
-    const float vksum5 = ((const float*) w)[5];
-    const float vksum6 = ((const float*) w)[6];
-    const float vksum7 = ((const float*) w)[7];
+    const float vksum0 = unaligned_indexed_load_f32(w, 0);
+    const float vksum1 = unaligned_indexed_load_f32(w, 1);
+    const float vksum2 = unaligned_indexed_load_f32(w, 2);
+    const float vksum3 = unaligned_indexed_load_f32(w, 3);
+    const float vksum4 = unaligned_indexed_load_f32(w, 4);
+    const float vksum5 = unaligned_indexed_load_f32(w, 5);
+    const float vksum6 = unaligned_indexed_load_f32(w, 6);
+    const float vksum7 = unaligned_indexed_load_f32(w, 7);
     const float vinput_zero_point0 = (const float) quantization_params[0].zero_point;
     float vout0x0 = vksum0 * vinput_zero_point0;
     float vout0x1 = vksum1 * vinput_zero_point0;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x4-minmax-scalar.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x4-minmax-scalar.c
@@ -17,6 +17,7 @@
 #include "src/xnnpack/math.h"
 #include "src/xnnpack/microparams.h"
 
+#include "src/xnnpack/unaligned.h"
 
 
 void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x4__scalar(
@@ -53,10 +54,10 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x4__scalar(
 
   kc = round_up_po2(kc, 2);
   do {
-    const float vksum0 = ((const float*) w)[0];
-    const float vksum1 = ((const float*) w)[1];
-    const float vksum2 = ((const float*) w)[2];
-    const float vksum3 = ((const float*) w)[3];
+    const float vksum0 = unaligned_indexed_load_f32(w, 0);
+    const float vksum1 = unaligned_indexed_load_f32(w, 1);
+    const float vksum2 = unaligned_indexed_load_f32(w, 2);
+    const float vksum3 = unaligned_indexed_load_f32(w, 3);
     const float vinput_zero_point0 = (const float) quantization_params[0].zero_point;
     float vout0x0 = vksum0 * vinput_zero_point0;
     float vout0x1 = vksum1 * vinput_zero_point0;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x8-minmax-scalar.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-2x8-minmax-scalar.c
@@ -17,6 +17,7 @@
 #include "src/xnnpack/math.h"
 #include "src/xnnpack/microparams.h"
 
+#include "src/xnnpack/unaligned.h"
 
 
 void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x8__scalar(
@@ -53,14 +54,14 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_2x8__scalar(
 
   kc = round_up_po2(kc, 2);
   do {
-    const float vksum0 = ((const float*) w)[0];
-    const float vksum1 = ((const float*) w)[1];
-    const float vksum2 = ((const float*) w)[2];
-    const float vksum3 = ((const float*) w)[3];
-    const float vksum4 = ((const float*) w)[4];
-    const float vksum5 = ((const float*) w)[5];
-    const float vksum6 = ((const float*) w)[6];
-    const float vksum7 = ((const float*) w)[7];
+    const float vksum0 = unaligned_indexed_load_f32(w, 0);
+    const float vksum1 = unaligned_indexed_load_f32(w, 1);
+    const float vksum2 = unaligned_indexed_load_f32(w, 2);
+    const float vksum3 = unaligned_indexed_load_f32(w, 3);
+    const float vksum4 = unaligned_indexed_load_f32(w, 4);
+    const float vksum5 = unaligned_indexed_load_f32(w, 5);
+    const float vksum6 = unaligned_indexed_load_f32(w, 6);
+    const float vksum7 = unaligned_indexed_load_f32(w, 7);
     const float vinput_zero_point0 = (const float) quantization_params[0].zero_point;
     float vout0x0 = vksum0 * vinput_zero_point0;
     float vout0x1 = vksum1 * vinput_zero_point0;

--- a/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x4-minmax-scalar.c
+++ b/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x4-minmax-scalar.c
@@ -17,6 +17,7 @@
 #include "src/xnnpack/math.h"
 #include "src/xnnpack/microparams.h"
 
+#include "src/xnnpack/unaligned.h"
 
 
 void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x4__scalar(
@@ -65,10 +66,10 @@ void xnn_qd8_f32_qb4w_gemm_minmax_ukernel_4x4__scalar(
 
   kc = round_up_po2(kc, 2);
   do {
-    const float vksum0 = ((const float*) w)[0];
-    const float vksum1 = ((const float*) w)[1];
-    const float vksum2 = ((const float*) w)[2];
-    const float vksum3 = ((const float*) w)[3];
+    const float vksum0 = unaligned_indexed_load_f32(w, 0);
+    const float vksum1 = unaligned_indexed_load_f32(w, 1);
+    const float vksum2 = unaligned_indexed_load_f32(w, 2);
+    const float vksum3 = unaligned_indexed_load_f32(w, 3);
     const float vinput_zero_point0 = (const float) quantization_params[0].zero_point;
     float vout0x0 = vksum0 * vinput_zero_point0;
     float vout0x1 = vksum1 * vinput_zero_point0;

--- a/src/qs8-gemm/scalar.c.in
+++ b/src/qs8-gemm/scalar.c.in
@@ -17,7 +17,8 @@ $if VARIANT == "LRINTF":
 #include "src/xnnpack/math.h"
 #include "src/xnnpack/microparams.h"
 
-$if NR % 4 != 0:
+$BLOCKWISE = DATATYPE in ["QB4_F16", "QB4_F32"]
+$if NR % 4 != 0 or BLOCKWISE:
   #include "src/xnnpack/unaligned.h"
 
 $#
@@ -49,7 +50,6 @@ $XINT8_T = "uint8_t" if DATATYPE == "QU8" else "int8_t"
 $OUT_T = {"QC8": "int8_t", "QS8_QC4": "int8_t", "QS8": "int8_t", "QU8": "uint8_t", "QB4_F16": "xnn_float16", "QD8": "float", "QC4": "float", "QB4_F32": "float"}[DATATYPE]
 $MIN_F32 = "__builtin_wasm_min_f32" if WASM else "math_min_f32"
 $MAX_F32 = "__builtin_wasm_max_f32" if WASM else "math_max_f32"
-$BLOCKWISE = True if DATATYPE in ["QB4_F16", "QB4_F32"] else False
 void xnn_${DATATYPE_SPEC}_gemm_minmax${REQUANTIZATION_SPEC}_ukernel_${MR}x${NR}__${"wasm" if WASM else "scalar"}${VARIANT_SPEC}(
     size_t mr,
     size_t nc,
@@ -134,17 +134,15 @@ void xnn_${DATATYPE_SPEC}_gemm_minmax${REQUANTIZATION_SPEC}_ukernel_${MR}x${NR}_
     kc = round_up_po2(kc, 2);
   do {
     $if DATATYPE in ["QD8", "QC4", "QB4_F16", "QB4_F32"]:
-      $if NR % 4 != 0:
+      $if BLOCKWISE:
         $for N in range(NR):
-          $if BLOCKWISE:
-            const float vksum${N} = unaligned_indexed_load_f32(w, ${N});
-          $else:
-            const int32_t vksum${N} = unaligned_indexed_load_s32(w, ${N});
+          const float vksum${N} = unaligned_indexed_load_f32(w, ${N});
       $else:
-        $for N in range(NR):
-          $if BLOCKWISE:
-            const float vksum${N} = ((const float*) w)[${N}];
-          $else:
+        $if NR % 4 != 0:
+          $for N in range(NR):
+            const int32_t vksum${N} = unaligned_indexed_load_s32(w, ${N});
+        $else:
+          $for N in range(NR):
             const int32_t vksum${N} = ((const int32_t*) w)[${N}];
       $for M in range(MR):
         $if BLOCKWISE:


### PR DESCRIPTION
# Summary

Update qb4w-family scalar GEMM kernels to use unaligned.h unaligned load methods to load ksums. This is likely an oversight in the initial scalar implementation, as the ksums are only guaranteed to be 16-bit aligned.

The scalar kernels should only be used as a fallback, so this change should have minimal to no impact on ARM or x86 targets. In theory, we could pad out the packed weights slightly to guarantee 32-bit alignment of the ksums, but it looks like the scalar kernel already uses unaligned loads for non-multiple-of-4 NR values. I'm happy to do a deeper analysis if desired.

# Test Plan

I locally built and ran the tests on an M4 Mac with CMake. There are two failures, but I confirmed that these failures are pre-existing on the parent commit.

```
The following tests FAILED:
        291 - f32-vgelu-test (Failed)
        433 - subgraph-fp16-test (Failed)
```