### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/build-linux-windows.yml
+++ b/.github/workflows/build-linux-windows.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Update apt
         run: sudo apt update
       - name: Install ninja
@@ -30,7 +30,7 @@ jobs:
         run: scripts/build-local.sh
         working-directory: ${{ github.workspace }}
       - name: Upload Build Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: build-artifacts-linux-x86_64
           path: build/local
@@ -42,7 +42,7 @@ jobs:
       matrix:
         arch: [x86, x64]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
@@ -63,7 +63,7 @@ jobs:
           CFLAGS: "/UNDEBUG"
           CXXFLAGS: "/UNDEBUG"
       - name: Upload Build Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: build-artifacts-windows-${{ matrix.arch }}
           path: build/windows/${{ matrix.arch }}/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: 'ubuntu-24.04-8core'
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Update apt
         run: |
           echo 'set man-db/auto-update false' | sudo debconf-communicate >/dev/null
@@ -49,7 +49,7 @@ jobs:
     runs-on: arm-ubuntu-arm-22.04-8core
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Update apt
         run: |
           echo 'set man-db/auto-update false' | sudo debconf-communicate >/dev/null
@@ -75,7 +75,7 @@ jobs:
     runs-on: arm-ubuntu-arm-22.04-8core
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Update apt
         run: |
           echo 'set man-db/auto-update false' | sudo debconf-communicate >/dev/null
@@ -107,7 +107,7 @@ jobs:
     runs-on: 'ubuntu-24.04-16core'
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Update apt
         run: |
           echo 'set man-db/auto-update false' | sudo debconf-communicate >/dev/null
@@ -137,7 +137,7 @@ jobs:
     runs-on: 'ubuntu-24.04-16core'
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Update apt
         run: |
           echo 'set man-db/auto-update false' | sudo debconf-communicate >/dev/null
@@ -158,7 +158,7 @@ jobs:
           save: ${{ inputs.update-caches }}
       - name: Check for cached qemu build
         id: cached-qemu
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/bin/qemu-riscv64
           key: ${{ runner.os }}-qemu-riscv64
@@ -192,7 +192,7 @@ jobs:
     runs-on: windows-2022-32core
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
@@ -217,7 +217,7 @@ jobs:
     runs-on: windows-2022-32core
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
@@ -246,7 +246,7 @@ jobs:
     runs-on: windows-2022-32core
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
@@ -275,7 +275,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install ninja
         run: brew install ninja
       - name: Create output directory
@@ -311,7 +311,7 @@ jobs:
     runs-on: 'ubuntu-24.04-8core'
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Update apt
         run: |
           echo 'set man-db/auto-update false' | sudo debconf-communicate >/dev/null
@@ -350,7 +350,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Create output directory
         run: mkdir -p build/ios/arm64
         working-directory: ${{ github.workspace }}
@@ -365,7 +365,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Create output directory
         run: mkdir -p build/ios/x86_64
         working-directory: ${{ github.workspace }}
@@ -380,7 +380,7 @@ jobs:
     runs-on: 'ubuntu-24.04-8core'
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Update apt
         run: |
           echo 'set man-db/auto-update false' | sudo debconf-communicate >/dev/null
@@ -452,7 +452,7 @@ jobs:
         --define=ynn_enable_x86_avx512fp16=false
         --define=ynn_enable_x86_avx512bf16=false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Update apt
         run: |
           echo 'set man-db/auto-update false' | sudo debconf-communicate >/dev/null
@@ -504,7 +504,7 @@ jobs:
     runs-on: arm-ubuntu-arm-22.04-8core
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Update apt
         run: |
           echo 'set man-db/auto-update false' | sudo debconf-communicate >/dev/null
@@ -569,7 +569,7 @@ jobs:
         --define=ynn_enable_arm64_sme=false
         --define=ynn_enable_arm_neonbf16=false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Add repository ppa:ubuntu-toolchain-r/test for gcc-13 and g++-13
         working-directory: ${{ github.workspace }}
         run: |
@@ -625,7 +625,7 @@ jobs:
     env:
       QEMU_ARGS: -cpu max
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Update apt
         run: |
           echo 'set man-db/auto-update false' | sudo debconf-communicate >/dev/null
@@ -756,7 +756,7 @@ jobs:
             --local_test_jobs=$(nproc)
         working-directory: ${{ github.workspace }}
       - name: Upload binary artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: binaries
           path: |
@@ -766,7 +766,7 @@ jobs:
             !${{ github.workspace }}/bazel-bin/test/**/_objs
           overwrite: true
       - name: Upload log artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test_logs
           path:  ~/.cache/bazel/**/test.log

--- a/.github/workflows/sde-tests-linux-windows.yml
+++ b/.github/workflows/sde-tests-linux-windows.yml
@@ -64,7 +64,7 @@ jobs:
         shell: bash
 
       - name: Download Build Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: build-artifacts-${{ matrix.arch }}
           path: ${{ env.BUILD_PATH }}


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/cache` | [`v4`](https://github.com/actions/cache/releases/tag/v4) | [`v5`](https://github.com/actions/cache/releases/tag/v5) | [Release](https://github.com/actions/cache/releases/tag/v5) | build.yml |
| `actions/checkout` | [`v4`](https://github.com/actions/checkout/releases/tag/v4) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) | build-linux-windows.yml, build.yml |
| `actions/download-artifact` | [`v4`](https://github.com/actions/download-artifact/releases/tag/v4) | [`v7`](https://github.com/actions/download-artifact/releases/tag/v7) | [Release](https://github.com/actions/download-artifact/releases/tag/v7) | sde-tests-linux-windows.yml |
| `actions/upload-artifact` | [`v4`](https://github.com/actions/upload-artifact/releases/tag/v4) | [`v6`](https://github.com/actions/upload-artifact/releases/tag/v6) | [Release](https://github.com/actions/upload-artifact/releases/tag/v6) | build-linux-windows.yml, build.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
