### PR TITLE
[RVV] f32-vrnd fix for issue #8087

### DIFF
--- a/src/f32-vrnd/gen/f32-vrndd-rvv-u1v.c
+++ b/src/f32-vrnd/gen/f32-vrndd-rvv-u1v.c
@@ -33,12 +33,14 @@ void xnn_f32_vrndd_ukernel__rvv_u1v(
   do {
     const size_t n = __riscv_vsetvl_e32m1(batch);
     vfloat32m1_t x_f32v = __riscv_vle32_v_f32m1(input, n); input += n;
-    // We need to remember which values are infinity, so we can preserve them
-    // after rounding.
-    // TODO: We should also preserve NaN.
-    vbool32_t inf_bv = __riscv_vmfeq_vf_f32m1_b32(x_f32v, INFINITY, n);
-    vbool32_t ninf_bv = __riscv_vmfeq_vf_f32m1_b32(x_f32v, -INFINITY, n);
-    vbool32_t mask_bv = __riscv_vmor_mm_b32(inf_bv, ninf_bv, n);
+
+    // preserve NaN
+    vbool32_t nan_bv = __riscv_vmfeq_vv_f32m1_b32(x_f32v, x_f32v, n);
+    // magnitude < (1 << FLT_MANT_DIG)
+    vfloat32m1_t mag = __riscv_vfabs_v_f32m1(x_f32v, n);
+    vbool32_t mag_bv = __riscv_vmflt_vf_f32m1_b32(mag, (1 << __FLT_MANT_DIG__), n);
+    vbool32_t mask_bv = __riscv_vmnand_mm_b32(nan_bv, mag_bv, n);
+
     vint32m1_t x_rnd_i32v = __riscv_vfcvt_x_f_v_i32m1_rm(x_f32v, __RISCV_FRM_RDN, n);
     vfloat32m1_t out_f32v = __riscv_vfcvt_f_x_v_f32m1(x_rnd_i32v, n);
     out_f32v = __riscv_vmerge_vvm_f32m1(out_f32v, x_f32v, mask_bv, n);

--- a/src/f32-vrnd/gen/f32-vrndd-rvv-u2v.c
+++ b/src/f32-vrnd/gen/f32-vrndd-rvv-u2v.c
@@ -33,12 +33,14 @@ void xnn_f32_vrndd_ukernel__rvv_u2v(
   do {
     const size_t n = __riscv_vsetvl_e32m2(batch);
     vfloat32m2_t x_f32v = __riscv_vle32_v_f32m2(input, n); input += n;
-    // We need to remember which values are infinity, so we can preserve them
-    // after rounding.
-    // TODO: We should also preserve NaN.
-    vbool16_t inf_bv = __riscv_vmfeq_vf_f32m2_b16(x_f32v, INFINITY, n);
-    vbool16_t ninf_bv = __riscv_vmfeq_vf_f32m2_b16(x_f32v, -INFINITY, n);
-    vbool16_t mask_bv = __riscv_vmor_mm_b16(inf_bv, ninf_bv, n);
+
+    // preserve NaN
+    vbool16_t nan_bv = __riscv_vmfeq_vv_f32m2_b16(x_f32v, x_f32v, n);
+    // magnitude < (1 << FLT_MANT_DIG)
+    vfloat32m2_t mag = __riscv_vfabs_v_f32m2(x_f32v, n);
+    vbool16_t mag_bv = __riscv_vmflt_vf_f32m2_b16(mag, (1 << __FLT_MANT_DIG__), n);
+    vbool16_t mask_bv = __riscv_vmnand_mm_b16(nan_bv, mag_bv, n);
+
     vint32m2_t x_rnd_i32v = __riscv_vfcvt_x_f_v_i32m2_rm(x_f32v, __RISCV_FRM_RDN, n);
     vfloat32m2_t out_f32v = __riscv_vfcvt_f_x_v_f32m2(x_rnd_i32v, n);
     out_f32v = __riscv_vmerge_vvm_f32m2(out_f32v, x_f32v, mask_bv, n);

--- a/src/f32-vrnd/gen/f32-vrndne-rvv-u1v.c
+++ b/src/f32-vrnd/gen/f32-vrndne-rvv-u1v.c
@@ -33,12 +33,14 @@ void xnn_f32_vrndne_ukernel__rvv_u1v(
   do {
     const size_t n = __riscv_vsetvl_e32m1(batch);
     vfloat32m1_t x_f32v = __riscv_vle32_v_f32m1(input, n); input += n;
-    // We need to remember which values are infinity, so we can preserve them
-    // after rounding.
-    // TODO: We should also preserve NaN.
-    vbool32_t inf_bv = __riscv_vmfeq_vf_f32m1_b32(x_f32v, INFINITY, n);
-    vbool32_t ninf_bv = __riscv_vmfeq_vf_f32m1_b32(x_f32v, -INFINITY, n);
-    vbool32_t mask_bv = __riscv_vmor_mm_b32(inf_bv, ninf_bv, n);
+
+    // preserve NaN
+    vbool32_t nan_bv = __riscv_vmfeq_vv_f32m1_b32(x_f32v, x_f32v, n);
+    // magnitude < (1 << FLT_MANT_DIG)
+    vfloat32m1_t mag = __riscv_vfabs_v_f32m1(x_f32v, n);
+    vbool32_t mag_bv = __riscv_vmflt_vf_f32m1_b32(mag, (1 << __FLT_MANT_DIG__), n);
+    vbool32_t mask_bv = __riscv_vmnand_mm_b32(nan_bv, mag_bv, n);
+
     vint32m1_t x_rnd_i32v = __riscv_vfcvt_x_f_v_i32m1_rm(x_f32v, __RISCV_FRM_RNE, n);
     vfloat32m1_t out_f32v = __riscv_vfcvt_f_x_v_f32m1(x_rnd_i32v, n);
     out_f32v = __riscv_vmerge_vvm_f32m1(out_f32v, x_f32v, mask_bv, n);

--- a/src/f32-vrnd/gen/f32-vrndne-rvv-u2v.c
+++ b/src/f32-vrnd/gen/f32-vrndne-rvv-u2v.c
@@ -33,12 +33,14 @@ void xnn_f32_vrndne_ukernel__rvv_u2v(
   do {
     const size_t n = __riscv_vsetvl_e32m2(batch);
     vfloat32m2_t x_f32v = __riscv_vle32_v_f32m2(input, n); input += n;
-    // We need to remember which values are infinity, so we can preserve them
-    // after rounding.
-    // TODO: We should also preserve NaN.
-    vbool16_t inf_bv = __riscv_vmfeq_vf_f32m2_b16(x_f32v, INFINITY, n);
-    vbool16_t ninf_bv = __riscv_vmfeq_vf_f32m2_b16(x_f32v, -INFINITY, n);
-    vbool16_t mask_bv = __riscv_vmor_mm_b16(inf_bv, ninf_bv, n);
+
+    // preserve NaN
+    vbool16_t nan_bv = __riscv_vmfeq_vv_f32m2_b16(x_f32v, x_f32v, n);
+    // magnitude < (1 << FLT_MANT_DIG)
+    vfloat32m2_t mag = __riscv_vfabs_v_f32m2(x_f32v, n);
+    vbool16_t mag_bv = __riscv_vmflt_vf_f32m2_b16(mag, (1 << __FLT_MANT_DIG__), n);
+    vbool16_t mask_bv = __riscv_vmnand_mm_b16(nan_bv, mag_bv, n);
+
     vint32m2_t x_rnd_i32v = __riscv_vfcvt_x_f_v_i32m2_rm(x_f32v, __RISCV_FRM_RNE, n);
     vfloat32m2_t out_f32v = __riscv_vfcvt_f_x_v_f32m2(x_rnd_i32v, n);
     out_f32v = __riscv_vmerge_vvm_f32m2(out_f32v, x_f32v, mask_bv, n);

--- a/src/f32-vrnd/gen/f32-vrndne-rvv-u4v.c
+++ b/src/f32-vrnd/gen/f32-vrndne-rvv-u4v.c
@@ -33,12 +33,14 @@ void xnn_f32_vrndne_ukernel__rvv_u4v(
   do {
     const size_t n = __riscv_vsetvl_e32m4(batch);
     vfloat32m4_t x_f32v = __riscv_vle32_v_f32m4(input, n); input += n;
-    // We need to remember which values are infinity, so we can preserve them
-    // after rounding.
-    // TODO: We should also preserve NaN.
-    vbool8_t inf_bv = __riscv_vmfeq_vf_f32m4_b8(x_f32v, INFINITY, n);
-    vbool8_t ninf_bv = __riscv_vmfeq_vf_f32m4_b8(x_f32v, -INFINITY, n);
-    vbool8_t mask_bv = __riscv_vmor_mm_b8(inf_bv, ninf_bv, n);
+
+    // preserve NaN
+    vbool8_t nan_bv = __riscv_vmfeq_vv_f32m4_b8(x_f32v, x_f32v, n);
+    // magnitude < (1 << FLT_MANT_DIG)
+    vfloat32m4_t mag = __riscv_vfabs_v_f32m4(x_f32v, n);
+    vbool8_t mag_bv = __riscv_vmflt_vf_f32m4_b8(mag, (1 << __FLT_MANT_DIG__), n);
+    vbool8_t mask_bv = __riscv_vmnand_mm_b8(nan_bv, mag_bv, n);
+
     vint32m4_t x_rnd_i32v = __riscv_vfcvt_x_f_v_i32m4_rm(x_f32v, __RISCV_FRM_RNE, n);
     vfloat32m4_t out_f32v = __riscv_vfcvt_f_x_v_f32m4(x_rnd_i32v, n);
     out_f32v = __riscv_vmerge_vvm_f32m4(out_f32v, x_f32v, mask_bv, n);

--- a/src/f32-vrnd/gen/f32-vrndne-rvv-u8v.c
+++ b/src/f32-vrnd/gen/f32-vrndne-rvv-u8v.c
@@ -33,12 +33,14 @@ void xnn_f32_vrndne_ukernel__rvv_u8v(
   do {
     const size_t n = __riscv_vsetvl_e32m8(batch);
     vfloat32m8_t x_f32v = __riscv_vle32_v_f32m8(input, n); input += n;
-    // We need to remember which values are infinity, so we can preserve them
-    // after rounding.
-    // TODO: We should also preserve NaN.
-    vbool4_t inf_bv = __riscv_vmfeq_vf_f32m8_b4(x_f32v, INFINITY, n);
-    vbool4_t ninf_bv = __riscv_vmfeq_vf_f32m8_b4(x_f32v, -INFINITY, n);
-    vbool4_t mask_bv = __riscv_vmor_mm_b4(inf_bv, ninf_bv, n);
+
+    // preserve NaN
+    vbool4_t nan_bv = __riscv_vmfeq_vv_f32m8_b4(x_f32v, x_f32v, n);
+    // magnitude < (1 << FLT_MANT_DIG)
+    vfloat32m8_t mag = __riscv_vfabs_v_f32m8(x_f32v, n);
+    vbool4_t mag_bv = __riscv_vmflt_vf_f32m8_b4(mag, (1 << __FLT_MANT_DIG__), n);
+    vbool4_t mask_bv = __riscv_vmnand_mm_b4(nan_bv, mag_bv, n);
+
     vint32m8_t x_rnd_i32v = __riscv_vfcvt_x_f_v_i32m8_rm(x_f32v, __RISCV_FRM_RNE, n);
     vfloat32m8_t out_f32v = __riscv_vfcvt_f_x_v_f32m8(x_rnd_i32v, n);
     out_f32v = __riscv_vmerge_vvm_f32m8(out_f32v, x_f32v, mask_bv, n);

--- a/src/f32-vrnd/gen/f32-vrndu-rvv-u1v.c
+++ b/src/f32-vrnd/gen/f32-vrndu-rvv-u1v.c
@@ -33,12 +33,14 @@ void xnn_f32_vrndu_ukernel__rvv_u1v(
   do {
     const size_t n = __riscv_vsetvl_e32m1(batch);
     vfloat32m1_t x_f32v = __riscv_vle32_v_f32m1(input, n); input += n;
-    // We need to remember which values are infinity, so we can preserve them
-    // after rounding.
-    // TODO: We should also preserve NaN.
-    vbool32_t inf_bv = __riscv_vmfeq_vf_f32m1_b32(x_f32v, INFINITY, n);
-    vbool32_t ninf_bv = __riscv_vmfeq_vf_f32m1_b32(x_f32v, -INFINITY, n);
-    vbool32_t mask_bv = __riscv_vmor_mm_b32(inf_bv, ninf_bv, n);
+
+    // preserve NaN
+    vbool32_t nan_bv = __riscv_vmfeq_vv_f32m1_b32(x_f32v, x_f32v, n);
+    // magnitude < (1 << FLT_MANT_DIG)
+    vfloat32m1_t mag = __riscv_vfabs_v_f32m1(x_f32v, n);
+    vbool32_t mag_bv = __riscv_vmflt_vf_f32m1_b32(mag, (1 << __FLT_MANT_DIG__), n);
+    vbool32_t mask_bv = __riscv_vmnand_mm_b32(nan_bv, mag_bv, n);
+
     vint32m1_t x_rnd_i32v = __riscv_vfcvt_x_f_v_i32m1_rm(x_f32v, __RISCV_FRM_RUP, n);
     vfloat32m1_t out_f32v = __riscv_vfcvt_f_x_v_f32m1(x_rnd_i32v, n);
     out_f32v = __riscv_vmerge_vvm_f32m1(out_f32v, x_f32v, mask_bv, n);

--- a/src/f32-vrnd/gen/f32-vrndu-rvv-u2v.c
+++ b/src/f32-vrnd/gen/f32-vrndu-rvv-u2v.c
@@ -33,12 +33,14 @@ void xnn_f32_vrndu_ukernel__rvv_u2v(
   do {
     const size_t n = __riscv_vsetvl_e32m2(batch);
     vfloat32m2_t x_f32v = __riscv_vle32_v_f32m2(input, n); input += n;
-    // We need to remember which values are infinity, so we can preserve them
-    // after rounding.
-    // TODO: We should also preserve NaN.
-    vbool16_t inf_bv = __riscv_vmfeq_vf_f32m2_b16(x_f32v, INFINITY, n);
-    vbool16_t ninf_bv = __riscv_vmfeq_vf_f32m2_b16(x_f32v, -INFINITY, n);
-    vbool16_t mask_bv = __riscv_vmor_mm_b16(inf_bv, ninf_bv, n);
+
+    // preserve NaN
+    vbool16_t nan_bv = __riscv_vmfeq_vv_f32m2_b16(x_f32v, x_f32v, n);
+    // magnitude < (1 << FLT_MANT_DIG)
+    vfloat32m2_t mag = __riscv_vfabs_v_f32m2(x_f32v, n);
+    vbool16_t mag_bv = __riscv_vmflt_vf_f32m2_b16(mag, (1 << __FLT_MANT_DIG__), n);
+    vbool16_t mask_bv = __riscv_vmnand_mm_b16(nan_bv, mag_bv, n);
+
     vint32m2_t x_rnd_i32v = __riscv_vfcvt_x_f_v_i32m2_rm(x_f32v, __RISCV_FRM_RUP, n);
     vfloat32m2_t out_f32v = __riscv_vfcvt_f_x_v_f32m2(x_rnd_i32v, n);
     out_f32v = __riscv_vmerge_vvm_f32m2(out_f32v, x_f32v, mask_bv, n);

--- a/src/f32-vrnd/gen/f32-vrndu-rvv-u4v.c
+++ b/src/f32-vrnd/gen/f32-vrndu-rvv-u4v.c
@@ -33,12 +33,14 @@ void xnn_f32_vrndu_ukernel__rvv_u4v(
   do {
     const size_t n = __riscv_vsetvl_e32m4(batch);
     vfloat32m4_t x_f32v = __riscv_vle32_v_f32m4(input, n); input += n;
-    // We need to remember which values are infinity, so we can preserve them
-    // after rounding.
-    // TODO: We should also preserve NaN.
-    vbool8_t inf_bv = __riscv_vmfeq_vf_f32m4_b8(x_f32v, INFINITY, n);
-    vbool8_t ninf_bv = __riscv_vmfeq_vf_f32m4_b8(x_f32v, -INFINITY, n);
-    vbool8_t mask_bv = __riscv_vmor_mm_b8(inf_bv, ninf_bv, n);
+
+    // preserve NaN
+    vbool8_t nan_bv = __riscv_vmfeq_vv_f32m4_b8(x_f32v, x_f32v, n);
+    // magnitude < (1 << FLT_MANT_DIG)
+    vfloat32m4_t mag = __riscv_vfabs_v_f32m4(x_f32v, n);
+    vbool8_t mag_bv = __riscv_vmflt_vf_f32m4_b8(mag, (1 << __FLT_MANT_DIG__), n);
+    vbool8_t mask_bv = __riscv_vmnand_mm_b8(nan_bv, mag_bv, n);
+
     vint32m4_t x_rnd_i32v = __riscv_vfcvt_x_f_v_i32m4_rm(x_f32v, __RISCV_FRM_RUP, n);
     vfloat32m4_t out_f32v = __riscv_vfcvt_f_x_v_f32m4(x_rnd_i32v, n);
     out_f32v = __riscv_vmerge_vvm_f32m4(out_f32v, x_f32v, mask_bv, n);

--- a/src/f32-vrnd/gen/f32-vrndu-rvv-u8v.c
+++ b/src/f32-vrnd/gen/f32-vrndu-rvv-u8v.c
@@ -33,12 +33,14 @@ void xnn_f32_vrndu_ukernel__rvv_u8v(
   do {
     const size_t n = __riscv_vsetvl_e32m8(batch);
     vfloat32m8_t x_f32v = __riscv_vle32_v_f32m8(input, n); input += n;
-    // We need to remember which values are infinity, so we can preserve them
-    // after rounding.
-    // TODO: We should also preserve NaN.
-    vbool4_t inf_bv = __riscv_vmfeq_vf_f32m8_b4(x_f32v, INFINITY, n);
-    vbool4_t ninf_bv = __riscv_vmfeq_vf_f32m8_b4(x_f32v, -INFINITY, n);
-    vbool4_t mask_bv = __riscv_vmor_mm_b4(inf_bv, ninf_bv, n);
+
+    // preserve NaN
+    vbool4_t nan_bv = __riscv_vmfeq_vv_f32m8_b4(x_f32v, x_f32v, n);
+    // magnitude < (1 << FLT_MANT_DIG)
+    vfloat32m8_t mag = __riscv_vfabs_v_f32m8(x_f32v, n);
+    vbool4_t mag_bv = __riscv_vmflt_vf_f32m8_b4(mag, (1 << __FLT_MANT_DIG__), n);
+    vbool4_t mask_bv = __riscv_vmnand_mm_b4(nan_bv, mag_bv, n);
+
     vint32m8_t x_rnd_i32v = __riscv_vfcvt_x_f_v_i32m8_rm(x_f32v, __RISCV_FRM_RUP, n);
     vfloat32m8_t out_f32v = __riscv_vfcvt_f_x_v_f32m8(x_rnd_i32v, n);
     out_f32v = __riscv_vmerge_vvm_f32m8(out_f32v, x_f32v, mask_bv, n);

--- a/src/f32-vrnd/gen/f32-vrndz-rvv-u1v.c
+++ b/src/f32-vrnd/gen/f32-vrndz-rvv-u1v.c
@@ -33,12 +33,14 @@ void xnn_f32_vrndz_ukernel__rvv_u1v(
   do {
     const size_t n = __riscv_vsetvl_e32m1(batch);
     vfloat32m1_t x_f32v = __riscv_vle32_v_f32m1(input, n); input += n;
-    // We need to remember which values are infinity, so we can preserve them
-    // after rounding.
-    // TODO: We should also preserve NaN.
-    vbool32_t inf_bv = __riscv_vmfeq_vf_f32m1_b32(x_f32v, INFINITY, n);
-    vbool32_t ninf_bv = __riscv_vmfeq_vf_f32m1_b32(x_f32v, -INFINITY, n);
-    vbool32_t mask_bv = __riscv_vmor_mm_b32(inf_bv, ninf_bv, n);
+
+    // preserve NaN
+    vbool32_t nan_bv = __riscv_vmfeq_vv_f32m1_b32(x_f32v, x_f32v, n);
+    // magnitude < (1 << FLT_MANT_DIG)
+    vfloat32m1_t mag = __riscv_vfabs_v_f32m1(x_f32v, n);
+    vbool32_t mag_bv = __riscv_vmflt_vf_f32m1_b32(mag, (1 << __FLT_MANT_DIG__), n);
+    vbool32_t mask_bv = __riscv_vmnand_mm_b32(nan_bv, mag_bv, n);
+
     vint32m1_t x_rnd_i32v = __riscv_vfcvt_x_f_v_i32m1_rm(x_f32v, __RISCV_FRM_RTZ, n);
     vfloat32m1_t out_f32v = __riscv_vfcvt_f_x_v_f32m1(x_rnd_i32v, n);
     out_f32v = __riscv_vmerge_vvm_f32m1(out_f32v, x_f32v, mask_bv, n);

--- a/src/f32-vrnd/gen/f32-vrndz-rvv-u2v.c
+++ b/src/f32-vrnd/gen/f32-vrndz-rvv-u2v.c
@@ -33,12 +33,14 @@ void xnn_f32_vrndz_ukernel__rvv_u2v(
   do {
     const size_t n = __riscv_vsetvl_e32m2(batch);
     vfloat32m2_t x_f32v = __riscv_vle32_v_f32m2(input, n); input += n;
-    // We need to remember which values are infinity, so we can preserve them
-    // after rounding.
-    // TODO: We should also preserve NaN.
-    vbool16_t inf_bv = __riscv_vmfeq_vf_f32m2_b16(x_f32v, INFINITY, n);
-    vbool16_t ninf_bv = __riscv_vmfeq_vf_f32m2_b16(x_f32v, -INFINITY, n);
-    vbool16_t mask_bv = __riscv_vmor_mm_b16(inf_bv, ninf_bv, n);
+
+    // preserve NaN
+    vbool16_t nan_bv = __riscv_vmfeq_vv_f32m2_b16(x_f32v, x_f32v, n);
+    // magnitude < (1 << FLT_MANT_DIG)
+    vfloat32m2_t mag = __riscv_vfabs_v_f32m2(x_f32v, n);
+    vbool16_t mag_bv = __riscv_vmflt_vf_f32m2_b16(mag, (1 << __FLT_MANT_DIG__), n);
+    vbool16_t mask_bv = __riscv_vmnand_mm_b16(nan_bv, mag_bv, n);
+
     vint32m2_t x_rnd_i32v = __riscv_vfcvt_x_f_v_i32m2_rm(x_f32v, __RISCV_FRM_RTZ, n);
     vfloat32m2_t out_f32v = __riscv_vfcvt_f_x_v_f32m2(x_rnd_i32v, n);
     out_f32v = __riscv_vmerge_vvm_f32m2(out_f32v, x_f32v, mask_bv, n);

--- a/src/f32-vrnd/gen/f32-vrndz-rvv-u4v.c
+++ b/src/f32-vrnd/gen/f32-vrndz-rvv-u4v.c
@@ -33,12 +33,14 @@ void xnn_f32_vrndz_ukernel__rvv_u4v(
   do {
     const size_t n = __riscv_vsetvl_e32m4(batch);
     vfloat32m4_t x_f32v = __riscv_vle32_v_f32m4(input, n); input += n;
-    // We need to remember which values are infinity, so we can preserve them
-    // after rounding.
-    // TODO: We should also preserve NaN.
-    vbool8_t inf_bv = __riscv_vmfeq_vf_f32m4_b8(x_f32v, INFINITY, n);
-    vbool8_t ninf_bv = __riscv_vmfeq_vf_f32m4_b8(x_f32v, -INFINITY, n);
-    vbool8_t mask_bv = __riscv_vmor_mm_b8(inf_bv, ninf_bv, n);
+
+    // preserve NaN
+    vbool8_t nan_bv = __riscv_vmfeq_vv_f32m4_b8(x_f32v, x_f32v, n);
+    // magnitude < (1 << FLT_MANT_DIG)
+    vfloat32m4_t mag = __riscv_vfabs_v_f32m4(x_f32v, n);
+    vbool8_t mag_bv = __riscv_vmflt_vf_f32m4_b8(mag, (1 << __FLT_MANT_DIG__), n);
+    vbool8_t mask_bv = __riscv_vmnand_mm_b8(nan_bv, mag_bv, n);
+
     vint32m4_t x_rnd_i32v = __riscv_vfcvt_x_f_v_i32m4_rm(x_f32v, __RISCV_FRM_RTZ, n);
     vfloat32m4_t out_f32v = __riscv_vfcvt_f_x_v_f32m4(x_rnd_i32v, n);
     out_f32v = __riscv_vmerge_vvm_f32m4(out_f32v, x_f32v, mask_bv, n);

--- a/src/f32-vrnd/gen/f32-vrndz-rvv-u8v.c
+++ b/src/f32-vrnd/gen/f32-vrndz-rvv-u8v.c
@@ -33,12 +33,14 @@ void xnn_f32_vrndz_ukernel__rvv_u8v(
   do {
     const size_t n = __riscv_vsetvl_e32m8(batch);
     vfloat32m8_t x_f32v = __riscv_vle32_v_f32m8(input, n); input += n;
-    // We need to remember which values are infinity, so we can preserve them
-    // after rounding.
-    // TODO: We should also preserve NaN.
-    vbool4_t inf_bv = __riscv_vmfeq_vf_f32m8_b4(x_f32v, INFINITY, n);
-    vbool4_t ninf_bv = __riscv_vmfeq_vf_f32m8_b4(x_f32v, -INFINITY, n);
-    vbool4_t mask_bv = __riscv_vmor_mm_b4(inf_bv, ninf_bv, n);
+
+    // preserve NaN
+    vbool4_t nan_bv = __riscv_vmfeq_vv_f32m8_b4(x_f32v, x_f32v, n);
+    // magnitude < (1 << FLT_MANT_DIG)
+    vfloat32m8_t mag = __riscv_vfabs_v_f32m8(x_f32v, n);
+    vbool4_t mag_bv = __riscv_vmflt_vf_f32m8_b4(mag, (1 << __FLT_MANT_DIG__), n);
+    vbool4_t mask_bv = __riscv_vmnand_mm_b4(nan_bv, mag_bv, n);
+
     vint32m8_t x_rnd_i32v = __riscv_vfcvt_x_f_v_i32m8_rm(x_f32v, __RISCV_FRM_RTZ, n);
     vfloat32m8_t out_f32v = __riscv_vfcvt_f_x_v_f32m8(x_rnd_i32v, n);
     out_f32v = __riscv_vmerge_vvm_f32m8(out_f32v, x_f32v, mask_bv, n);

--- a/src/f32-vrnd/rvv.c.in
+++ b/src/f32-vrnd/rvv.c.in
@@ -36,12 +36,14 @@ void xnn_f32_v${OP.lower()}_ukernel__rvv_u${LMUL}v(
   do {
     const size_t n = __riscv_vsetvl_e32m${LMUL}(batch);
     vfloat32m${LMUL}_t x_f32v = __riscv_vle32_v_f32m${LMUL}(input, n); input += n;
-    // We need to remember which values are infinity, so we can preserve them
-    // after rounding.
-    // TODO: We should also preserve NaN.
-    vbool${32//LMUL}_t inf_bv = __riscv_vmfeq_vf_f32m${LMUL}_b${32//LMUL}(x_f32v, INFINITY, n);
-    vbool${32//LMUL}_t ninf_bv = __riscv_vmfeq_vf_f32m${LMUL}_b${32//LMUL}(x_f32v, -INFINITY, n);
-    vbool${32//LMUL}_t mask_bv = __riscv_vmor_mm_b${32//LMUL}(inf_bv, ninf_bv, n);
+
+    // preserve NaN
+    vbool${32//LMUL}_t nan_bv = __riscv_vmfeq_vv_f32m${LMUL}_b${32//LMUL}(x_f32v, x_f32v, n);
+    // magnitude < (1 << FLT_MANT_DIG)
+    vfloat32m${LMUL}_t mag = __riscv_vfabs_v_f32m${LMUL}(x_f32v, n);
+    vbool${32//LMUL}_t mag_bv = __riscv_vmflt_vf_f32m${LMUL}_b${32//LMUL}(mag, (1 << __FLT_MANT_DIG__), n);
+    vbool${32//LMUL}_t mask_bv = __riscv_vmnand_mm_b${32//LMUL}(nan_bv, mag_bv, n);
+
     vint32m${LMUL}_t x_rnd_i32v = __riscv_vfcvt_x_f_v_i32m${LMUL}_rm(x_f32v, ${ROUND_MODE}, n);
     vfloat32m${LMUL}_t out_f32v = __riscv_vfcvt_f_x_v_f32m${LMUL}(x_rnd_i32v, n);
     out_f32v = __riscv_vmerge_vvm_f32m${LMUL}(out_f32v, x_f32v, mask_bv, n);

--- a/test/unary-ops.h
+++ b/test/unary-ops.h
@@ -332,12 +332,6 @@ struct RoundToNearestEven : public UnaryOpInfo {
     return std::nearbyint(x);
   }
 
-#if XNN_ARCH_RISCV
-  bool IsInSupportedRange(float y) const override {
-    // TODO(#8087): These ops are broken for large inputs on RISCV.
-    return std::abs(y) < 1e6f;
-  }
-#endif
 };
 
 struct RoundTowardsZero : public UnaryOpInfo {
@@ -345,12 +339,6 @@ struct RoundTowardsZero : public UnaryOpInfo {
     return std::trunc(x);
   }
 
-#if XNN_ARCH_RISCV
-  bool IsInSupportedRange(float y) const override {
-    // TODO(#8087): These ops are broken for large inputs on RISCV.
-    return std::abs(y) < 1e6f;
-  }
-#endif
 };
 
 struct RoundUp : public UnaryOpInfo {
@@ -358,12 +346,6 @@ struct RoundUp : public UnaryOpInfo {
     return std::ceil(x);
   }
 
-#if XNN_ARCH_RISCV
-  bool IsInSupportedRange(float y) const override {
-    // TODO(#8087): These ops are broken for large inputs on RISCV.
-    return std::abs(y) < 1e6f;
-  }
-#endif
 };
 
 struct RoundDown : public UnaryOpInfo {
@@ -371,12 +353,6 @@ struct RoundDown : public UnaryOpInfo {
     return std::floor(x);
   }
 
-#if XNN_ARCH_RISCV
-  bool IsInSupportedRange(float y) const override {
-    // TODO(#8087): These ops are broken for large inputs on RISCV.
-    return std::abs(y) < 1e6f;
-  }
-#endif
 };
 
 struct Sigmoid : public UnaryOpInfo {


### PR DESCRIPTION
Fix to address #8087
- Avoid NaN and int conversion for large numbers (no remainder) for f32-vrnd RVV kernels. 
- Remove test workaround for this issue.
- Tested with f32-vrnd tests and subgraph/unary-test which now all pass