### PR TITLE
[subgraph] Fully connected: reject non-zero zero-point for QS8 filter and add regression test

### DIFF
--- a/src/subgraph/fully-connected.c
+++ b/src/subgraph/fully-connected.c
@@ -1835,6 +1835,7 @@ enum xnn_status xnn_define_fully_connected(xnn_subgraph_t subgraph,
                       xnn_node_type_to_string(xnn_node_type_fully_connected),
                       filter_id, kernel_value->quantization.zero_point,
                       xnn_datatype_to_string(kernel_value->datatype));
+        return xnn_status_invalid_parameter;
       }
       break;
     case xnn_datatype_quint8:

--- a/test/subgraph/fully-connected.cc
+++ b/test/subgraph/fully-connected.cc
@@ -763,6 +763,47 @@ TEST(FullyConnectedF32, dynamic_b) {
   TestDynamicB<float, float, float, float>();
 }
 
+TEST(FullyConnectedQS8, filter_zero_point_must_be_zero) {
+  ASSERT_EQ(xnn_status_success, xnn_initialize(nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(3, 0, &subgraph));
+
+  const size_t input_dims[] = {1, 4};
+  uint32_t input_id = XNN_INVALID_VALUE_ID;
+  ASSERT_EQ(xnn_status_success,
+            xnn_define_quantized_tensor_value(
+                subgraph, xnn_datatype_qint8, /*zero_point=*/0,
+                /*scale=*/0.75f, /*num_dims=*/2, input_dims,
+                /*data=*/nullptr, /*external_id=*/0,
+                XNN_VALUE_FLAG_EXTERNAL_INPUT, &input_id));
+
+  const size_t filter_dims[] = {3, 4};
+  int8_t filter_data[12] = {};
+  uint32_t filter_id = XNN_INVALID_VALUE_ID;
+  ASSERT_EQ(xnn_status_success,
+            xnn_define_quantized_tensor_value(
+                subgraph, xnn_datatype_qint8, /*zero_point=*/1,
+                /*scale=*/0.5f, /*num_dims=*/2, filter_dims, filter_data,
+                XNN_INVALID_VALUE_ID, /*flags=*/0, &filter_id));
+
+  const size_t output_dims[] = {1, 3};
+  uint32_t output_id = XNN_INVALID_VALUE_ID;
+  ASSERT_EQ(xnn_status_success,
+            xnn_define_quantized_tensor_value(
+                subgraph, xnn_datatype_qint8, /*zero_point=*/0,
+                /*scale=*/0.25f, /*num_dims=*/2, output_dims,
+                /*data=*/nullptr, /*external_id=*/1,
+                XNN_VALUE_FLAG_EXTERNAL_OUTPUT, &output_id));
+
+  ASSERT_EQ(xnn_status_invalid_parameter,
+            xnn_define_fully_connected(
+                subgraph, -128.0f, 127.0f, input_id, filter_id,
+                XNN_INVALID_VALUE_ID, output_id, /*flags=*/0));
+
+  xnn_delete_subgraph(subgraph);
+}
+
 // Regression test: fully-connected with a zero-dimensional input must not
 // cause a heap-buffer-overflow via unsigned underflow on num_dims - 1.
 TEST(FullyConnectedF32, zero_dim_input_rejected) {


### PR DESCRIPTION
  ## Summary
  Fix a validation bug in fully-connected subgraph definition for QS8 filters.

  ## Changes
  - Added missing `return xnn_status_invalid_parameter;` in
    `src/subgraph/fully-connected.c` when:
    - filter datatype is `xnn_datatype_qint8`, and
    - filter zero-point is non-zero.
  - Added regression test:
    - `test/subgraph/fully-connected.cc`
    - `TEST(FullyConnectedQS8, filter_zero_point_must_be_zero)`