### PR TITLE
Security: fix output loop bound and double-free in subgraph copy

### DIFF
--- a/src/subgraph.c
+++ b/src/subgraph.c
@@ -1823,6 +1823,9 @@ static uint32_t copy_value_to_static_subgraph(xnn_subgraph_t src_subgraph,
     dst_value->id = dst_id;
     dst_value->producer = XNN_INVALID_NODE_ID;
     dst_value->first_consumer = XNN_INVALID_NODE_ID;
+    // Clear the cleanup flag to avoid double-free: the source subgraph retains
+    // ownership of the data pointer.
+    dst_value->flags &= ~XNN_VALUE_FLAG_NEEDS_CLEANUP;
   }
   return dst_id;
 }
@@ -1842,7 +1845,7 @@ static struct xnn_node* copy_node_to_static_subgraph(
         src_subgraph, value, value_map, dst_subgraph);
     dst_node->inputs[i] = dst_id;
   }
-  for (size_t i = 0; i < src_node->num_inputs; i++) {
+  for (size_t i = 0; i < src_node->num_outputs; i++) {
     const struct xnn_value* value = &src_subgraph->values[src_node->outputs[i]];
     const uint32_t dst_id = copy_value_to_static_subgraph(
         src_subgraph, value, value_map, dst_subgraph);


### PR DESCRIPTION
This PR fixs two bugs in static subgraph copy:
1. Fix output copy loop using wrong bound: The loop that copies node outputs was iterating with src_node->num_inputs instead of src_node->num_outputs. This could cause out-of-bounds access when num_outputs > num_inputs, or silently skip copying outputs when num_outputs < num_inputs.
2. Fix potential double-free of value data: When copying a value to the destination subgraph, the XNN_VALUE_FLAG_NEEDS_CLEANUP flag was carried over from the source. Since both source and destination values pointed to the same data, destroying both subgraphs would free the same pointer twice. Clear the flag on the copy so only the source subgraph retains ownership.