### PR TITLE
Fix xnn_get_rounded_size to always guarantee XNN_EXTRA_BYTES padding

### DIFF
--- a/src/xnnpack/subgraph.h
+++ b/src/xnnpack/subgraph.h
@@ -554,11 +554,11 @@ size_t xnn_tensor_get_size(const struct xnn_value* value);
 size_t xnn_runtime_tensor_get_size(const struct xnn_runtime_value* value);
 
 XNN_INLINE static size_t xnn_get_rounded_size(size_t size) {
-  // We round it to XNN_EXTRA_BYTES to ensure that we can read more than the
-  // actual size of the tensor, and round it to allocation alignment to ensure
-  // that all tensors and operator workspaces are aligned correctly.
-  return round_up_po2(round_up_po2(size, XNN_EXTRA_BYTES),
-                      XNN_ALLOCATION_ALIGNMENT);
+  // Add XNN_EXTRA_BYTES of padding after the data so that XNNPACK kernels can
+  // over-read by up to XNN_EXTRA_BYTES without triggering memory-safety faults
+  // (e.g. MTE on ARM64). Merely rounding up to a multiple of XNN_EXTRA_BYTES
+  // provides no padding for sizes that are already aligned.
+  return round_up_po2(size + XNN_EXTRA_BYTES, XNN_ALLOCATION_ALIGNMENT);
 }
 
 // Returns the size of tensor rounded to appropriate extra bytes and allocation


### PR DESCRIPTION
The old formula `round_up_po2(round_up_po2(size, XNN_EXTRA_BYTES), alignment)` silently provided zero over-read headroom whenever a tensor's byte size was already a multiple of `XNN_EXTRA_BYTES`, which causes `SEGV_MTESERR` on MTE-enabled ARM64 devices when a kernel reads past the end of one tensor into a differently-tagged adjacent allocation. Changing the formula to `round_up_po2(size + XNN_EXTRA_BYTES, alignment)` guarantees at least `XNN_EXTRA_BYTES` of padding after every XNNPACK-managed tensor on all architectures. Verified against ARM64, x86-64, Hexagon, and WASM alignment configs — no case regresses in allocated size. Fixes #9982