### PR TITLE
fix: dot/schedule_bench A_stride_m for transpose_a kernels

### DIFF
--- a/ynnpack/kernels/dot/schedule_bench.cc
+++ b/ynnpack/kernels/dot/schedule_bench.cc
@@ -152,7 +152,12 @@ double run_benchmark(TA, TB, TC, const kernel_info& kernel, size_t m, size_t n,
           size_t a_stride_m, span<const size_t> a_k_strides, const void* b_ptr,
           span<const size_t> b_k_strides, size_t init_c_stride_m,
           const void* init_c, void* c_ptr) {
-        kernel.kernel(m, n, k[2], k[1], k[0], a_stride_m,
+        // For dot_flag::transpose_a kernels, the 6th kernel arg is the
+        // stride of the k1/tile_k dimension of the packed A (see dot.h),
+        // not the m stride. subgraph/dot.cc does the same swap — mirror
+        // it here.
+        kernel.kernel(m, n, k[2], k[1], k[0],
+                      pack_a ? a_k_strides[0] : a_stride_m,
                       a_k_strides[2], a_k_strides[1], a_ptr, b_k_strides[2],
                       b_k_strides[1], b_k_strides[0], b_ptr, init_c_stride_m,
                       init_c, c.stride(0) * sizeof(TC), c_ptr);


### PR DESCRIPTION
## Summary

- `schedule_bench` was passing `a_stride_m` (the `{i, tile_k}` intra-row stride) as the 6th positional arg to kernels that set `dot_flag::transpose_a`, but for those kernels the 6th arg is consumed as the stride along the k1 dimension of the packed tensor (the advance per inner-k step)
- `subgraph/dot.cc::call_kernel` already does the correct swap (`transposed_a ? a_k_strides[0] : a_stride_m`). This change mirrors it in `schedule_bench` so the bench exercises the same work the production path executes
- The built-in correctness check (A = B = 1, assert `c == k` everywhere) can't catch this class of bug because the wrong-stride loads still return 1s. Benchmark GFLOPS numbers reported against this bench were inflated by artificial cache hits on overlapping reads

## Test plan

- [x] `bazel test //ynnpack/kernels/dot/...` passes (including `schedule_bench_test`, `schedule_test`, `consistent_arithmetic_test`, `test`)
