### PR TITLE
Reject qpint8 in xnn_define_dynamically_quantized_tensor_value

### DIFF
--- a/src/tensor.c
+++ b/src/tensor.c
@@ -261,11 +261,10 @@ enum xnn_status xnn_define_dynamically_quantized_tensor_value(
     case xnn_datatype_qdint8:
       break;
     case xnn_datatype_qpint8:
-      // qpint8 reaches get_tensor_size() at tensor.c:770, which dereferences
-      // value->gemm_config (left NULL by this define path). Reject until the
-      // gemm-config wiring is added.
+      // qpint8 is an internal datatype produced downstream of public types
+      // like qdint8; it is not valid as an input to the public define API.
       xnn_log_error("failed to create Dynamically Quantized Dense Tensor value: "
-        "datatype %s (%d) is not supported on this code path",
+        "datatype %s (%d) is an internal type and cannot be used through the public API",
         xnn_datatype_to_string(datatype), datatype);
       return xnn_status_unsupported_parameter;
     default:

--- a/src/tensor.c
+++ b/src/tensor.c
@@ -259,8 +259,15 @@ enum xnn_status xnn_define_dynamically_quantized_tensor_value(
 
   switch (datatype) {
     case xnn_datatype_qdint8:
-    case xnn_datatype_qpint8:
       break;
+    case xnn_datatype_qpint8:
+      // qpint8 reaches get_tensor_size() at tensor.c:770, which dereferences
+      // value->gemm_config (left NULL by this define path). Reject until the
+      // gemm-config wiring is added.
+      xnn_log_error("failed to create Dynamically Quantized Dense Tensor value: "
+        "datatype %s (%d) is not supported on this code path",
+        xnn_datatype_to_string(datatype), datatype);
+      return xnn_status_unsupported_parameter;
     default:
       xnn_log_error("failed to create Dynamically Quantized Dense Tensor value: unsupported datatype %s (%d)",
         xnn_datatype_to_string(datatype), datatype);


### PR DESCRIPTION
Fix https://github.com/google/XNNPACK/issues/10099:
Calling xnn_define_dynamically_quantized_tensor_value with datatype=xnn_datatype_qpint8 lands in get_tensor_size at tensor.c:770, which asserts gemm_config != NULL. Nothing on the dynamically-quantized define path sets value->gemm_config, so the assert fires in Debug; in Release the NULL is dereferenced inside
xnn_x8_packq_f32qp8_gemm_packed_size (packq.h:62), which reads gemm_config->mr_packed and friends.

qpint8 only works through other code paths that wire up gemm_config first. The dynamically-quantized define path is not one of them, so reject it here with xnn_status_unsupported_parameter rather than letting it crash later.