### PR TITLE
Detect size_t overflow in get_tensor_size and reject the tensor

### DIFF
--- a/src/runtime.c
+++ b/src/runtime.c
@@ -76,6 +76,12 @@ enum xnn_status xnn_reshape_external_value(
     value->shape = new_shape;
   }
   value->size = xnn_runtime_tensor_get_size(value);
+  if (value->size == SIZE_MAX) {
+    xnn_log_error(
+      "failed to reshape runtime: size overflow for Value %" PRIu32 " with the given shape",
+      external_id);
+    return xnn_status_unsupported_parameter;
+  }
   return xnn_status_success;
 }
 

--- a/src/tensor.c
+++ b/src/tensor.c
@@ -816,24 +816,15 @@ size_t get_tensor_size(const struct xnn_gemm_config* gemm_config, enum xnn_value
   // Returns SIZE_MAX on overflow so the caller can detect and reject the tensor
   // before the wrapped value is treated as an allocation size.
   const size_t num_elements = xnn_shape_multiply_all_dims(shape);
-  if (num_elements == SIZE_MAX) {
-    return SIZE_MAX;
-  }
-  uint64_t size_bits = xnn_datatype_size_bits(datatype);
-  if (size_bits != 0 && num_elements > UINT64_MAX / size_bits) {
-    return SIZE_MAX;
-  }
-  size_bits *= (uint64_t) num_elements;
-
-  // Round size up to the nearest byte. (size_bits + 7) cannot wrap because we
-  // already bounded size_bits via the check above.
-  const uint64_t size_bytes = (size_bits + 7) >> 3;
-  if (size_bytes > (uint64_t) SIZE_MAX) {
+  size_t size_bits;
+  if (num_elements == SIZE_MAX ||
+      !xnn_safe_mul(num_elements, xnn_datatype_size_bits(datatype), &size_bits) ||
+      !xnn_safe_add(size_bits, 7, &size_bits)) {
     return SIZE_MAX;
   }
   // TODO: We should not be using this helper for non-byte-addressable types,
   // perhaps we should just assert here.
-  return (size_t) size_bytes;
+  return size_bits >> 3;
 }
 
 size_t xnn_runtime_tensor_get_size(const struct xnn_runtime_value* value)

--- a/src/tensor.c
+++ b/src/tensor.c
@@ -153,6 +153,10 @@ enum xnn_status xnn_define_tensor_value(
   value->datatype = datatype;
   set_shape(value, num_dims, dims);
   value->size = xnn_tensor_get_size(value);
+  if (value->size == SIZE_MAX) {
+    xnn_log_error("failed to create Dense Tensor value: size overflow for the given shape");
+    return xnn_status_unsupported_parameter;
+  }
   value->flags = flags;
   value->data = (void*) (uintptr_t) data;
   set_allocation_type(value);
@@ -209,6 +213,10 @@ enum xnn_status xnn_define_quantized_tensor_value(
   value->quantization.scale = scale;
   set_shape(value, num_dims, dims);
   value->size = xnn_tensor_get_size(value);
+  if (value->size == SIZE_MAX) {
+    xnn_log_error("failed to create Quantized Dense Tensor value: size overflow for the given shape");
+    return xnn_status_unsupported_parameter;
+  }
   value->flags = flags;
   value->data = (void*) (uintptr_t) data;
   set_allocation_type(value);
@@ -286,6 +294,10 @@ enum xnn_status xnn_define_dynamically_quantized_tensor_value(
   value->quantization.num_nonbatch_dims = num_nonbatch_dims;
   set_shape(value, num_dims, dims);
   value->size = xnn_tensor_get_size(value);
+  if (value->size == SIZE_MAX) {
+    xnn_log_error("failed to create Dynamically Quantized Dense Tensor value: size overflow for the given shape");
+    return xnn_status_unsupported_parameter;
+  }
   value->quantization.dynamic_params_size = xnn_tensor_get_dynamic_quant_param_size(value->datatype, &value->shape, value->quantization.num_nonbatch_dims);
   value->quantization.row_sum_size = xnn_tensor_get_row_sum_size(value->datatype, &value->shape, value->quantization.num_nonbatch_dims);
   value->flags = flags;
@@ -454,6 +466,10 @@ enum xnn_status xnn_define_channelwise_quantized_tensor_value_v3(
   value->quantization.channel_dimension = channel_dim;
   set_shape(value, num_dims, dims);
   value->size = xnn_tensor_get_size(value);
+  if (value->size == SIZE_MAX) {
+    xnn_log_error("failed to create Channelwise Quantized Dense Tensor value: size overflow for the given shape");
+    return xnn_status_unsupported_parameter;
+  }
   value->flags = flags;
   value->data = (void*) (uintptr_t) data;
   set_allocation_type(value);
@@ -612,6 +628,10 @@ enum xnn_status xnn_define_blockwise_quantized_tensor_value_v2(
   value->quantization.block_size = block_size;
   set_shape(value, num_dims, dims);
   value->size = xnn_tensor_get_size(value);
+  if (value->size == SIZE_MAX) {
+    xnn_log_error("failed to create Blockwise Quantized Dense Tensor value: size overflow for the given shape");
+    return xnn_status_unsupported_parameter;
+  }
   value->flags = flags;
   value->data = (void*) (uintptr_t) data;
   set_allocation_type(value);
@@ -637,12 +657,17 @@ enum xnn_status xnn_define_blockwise_quantized_tensor_value(
                                                         block_size, dims, data, external_id, flags, xnn_datatype_bf16, id_out);
 }
 
+// All shape-multiply helpers return SIZE_MAX on overflow. Callers that size
+// allocations must treat SIZE_MAX as "too large" and propagate
+// xnn_status_unsupported_parameter.
 size_t xnn_shape_multiply_all_dims(
   const struct xnn_shape* shape)
 {
   size_t batch_size = 1;
   for (size_t i = 0; i < shape->num_dims; i++) {
-    batch_size *= shape->dim[i];
+    if (!xnn_safe_mul(batch_size, shape->dim[i], &batch_size)) {
+      return SIZE_MAX;
+    }
   }
   return batch_size;
 }
@@ -653,7 +678,9 @@ size_t xnn_shape_multiply_batch_dims(
 {
   size_t batch_size = 1;
   for (size_t i = 0; i + num_nonbatch_dims < shape->num_dims; i++) {
-    batch_size *= shape->dim[i];
+    if (!xnn_safe_mul(batch_size, shape->dim[i], &batch_size)) {
+      return SIZE_MAX;
+    }
   }
   return batch_size;
 }
@@ -663,7 +690,9 @@ size_t xnn_shape_multiply_non_channel_dims(
 {
   size_t batch_size = 1;
   for (size_t i = 0; i + 1 < shape->num_dims; i++) {
-    batch_size *= shape->dim[i];
+    if (!xnn_safe_mul(batch_size, shape->dim[i], &batch_size)) {
+      return SIZE_MAX;
+    }
   }
   return batch_size;
 }
@@ -674,7 +703,9 @@ size_t xnn_shape_multiply_leading_dims(
 {
   size_t batch_size = 1;
   for (size_t i = 0; i < num_leading_dims; i++) {
-    batch_size *= shape->dim[i];
+    if (!xnn_safe_mul(batch_size, shape->dim[i], &batch_size)) {
+      return SIZE_MAX;
+    }
   }
   return batch_size;
 }
@@ -685,7 +716,9 @@ size_t xnn_shape_multiply_trailing_dims(
 {
   size_t product = 1;
   for (size_t i = start_dim; i < shape->num_dims; i++) {
-    product *= shape->dim[i];
+    if (!xnn_safe_mul(product, shape->dim[i], &product)) {
+      return SIZE_MAX;
+    }
   }
   return product;
 }
@@ -780,14 +813,27 @@ size_t get_tensor_size(const struct xnn_gemm_config* gemm_config, enum xnn_value
            xnn_x8_packq_f32qp8_gemm_packed_size(gemm_config, m, k);
   }
 
+  // Returns SIZE_MAX on overflow so the caller can detect and reject the tensor
+  // before the wrapped value is treated as an allocation size.
+  const size_t num_elements = xnn_shape_multiply_all_dims(shape);
+  if (num_elements == SIZE_MAX) {
+    return SIZE_MAX;
+  }
   uint64_t size_bits = xnn_datatype_size_bits(datatype);
+  if (size_bits != 0 && num_elements > UINT64_MAX / size_bits) {
+    return SIZE_MAX;
+  }
+  size_bits *= (uint64_t) num_elements;
 
-  size_bits *= xnn_shape_multiply_all_dims(shape);
-
-  // Round size up to the nearest byte.
+  // Round size up to the nearest byte. (size_bits + 7) cannot wrap because we
+  // already bounded size_bits via the check above.
+  const uint64_t size_bytes = (size_bits + 7) >> 3;
+  if (size_bytes > (uint64_t) SIZE_MAX) {
+    return SIZE_MAX;
+  }
   // TODO: We should not be using this helper for non-byte-addressable types,
   // perhaps we should just assert here.
-  return (size_bits + 7) >> 3;
+  return (size_t) size_bytes;
 }
 
 size_t xnn_runtime_tensor_get_size(const struct xnn_runtime_value* value)

--- a/src/tensor.c
+++ b/src/tensor.c
@@ -816,10 +816,14 @@ size_t get_tensor_size(const struct xnn_gemm_config* gemm_config, enum xnn_value
   // Returns SIZE_MAX on overflow so the caller can detect and reject the tensor
   // before the wrapped value is treated as an allocation size.
   const size_t num_elements = xnn_shape_multiply_all_dims(shape);
+  if (num_elements == SIZE_MAX) {
+    return SIZE_MAX;
+  }
   size_t size_bits;
-  if (num_elements == SIZE_MAX ||
-      !xnn_safe_mul(num_elements, xnn_datatype_size_bits(datatype), &size_bits) ||
-      !xnn_safe_add(size_bits, 7, &size_bits)) {
+  if (!xnn_safe_mul(num_elements, xnn_datatype_size_bits(datatype), &size_bits)) {
+    return SIZE_MAX;
+  }
+  if (!xnn_safe_add(size_bits, 7, &size_bits)) {
     return SIZE_MAX;
   }
   // TODO: We should not be using this helper for non-byte-addressable types,

--- a/src/xnnpack/math.h
+++ b/src/xnnpack/math.h
@@ -656,6 +656,35 @@ XNN_INLINE static bool xnn_bfloat16_is_zero(xnn_bfloat16 f) {
   return (uint16_t) (xnn_bfloat16_to_bits(f) * 2) == 0;
 }
 
+// Overflow-safe arithmetic for allocation size calculations.
+// Returns false (and leaves *result unspecified) if the operation would
+// overflow size_t.
+XNN_INLINE static bool xnn_safe_mul(size_t a, size_t b, size_t* result) {
+#if defined(__GNUC__) || defined(__clang__)
+  return !__builtin_mul_overflow(a, b, result);
+#else
+  if (a != 0 && b > SIZE_MAX / a) {
+    *result = 0;
+    return false;
+  }
+  *result = a * b;
+  return true;
+#endif
+}
+
+XNN_INLINE static bool xnn_safe_add(size_t a, size_t b, size_t* result) {
+#if defined(__GNUC__) || defined(__clang__)
+  return !__builtin_add_overflow(a, b, result);
+#else
+  if (b > SIZE_MAX - a) {
+    *result = 0;
+    return false;
+  }
+  *result = a + b;
+  return true;
+#endif
+}
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif


### PR DESCRIPTION
Fix https://github.com/google/XNNPACK/issues/10100:

- Add xnn_safe_mul / xnn_safe_add helpers in math.h. Same shape as the helpers proposed in #9860, so the two PRs can share them once one of them lands.
- Use xnn_safe_mul in all five xnn_shape_multiply_*_dims helpers and in the size_bits step of get_tensor_size; return SIZE_MAX on overflow.
- Reject the tensor with xnn_status_unsupported_parameter at the five xnn_define_* call sites and at xnn_reshape_external_value when the computed size is SIZE_MAX.

This stacks cleanly on top of #9860; happy to rebase or fold once that lands.