### PR TITLE
Map Cortex-A320 to A510 kernel selection path

### DIFF
--- a/src/configs/hardware-config.c
+++ b/src/configs/hardware-config.c
@@ -95,6 +95,7 @@ static enum xnn_uarch cpuinfo_to_xnn_uarch(enum cpuinfo_uarch uarch) {
     case cpuinfo_uarch_cortex_a76: return xnn_uarch_cortex_a76;
     case cpuinfo_uarch_cortex_a77: return xnn_uarch_cortex_a77;
     case cpuinfo_uarch_cortex_a78: return xnn_uarch_cortex_a78;
+    case cpuinfo_uarch_cortex_a320: return xnn_uarch_cortex_a510;
     case cpuinfo_uarch_cortex_a510: return xnn_uarch_cortex_a510;
     case cpuinfo_uarch_cortex_a710: return xnn_uarch_cortex_a710;
     case cpuinfo_uarch_cortex_a715: return xnn_uarch_cortex_a715;


### PR DESCRIPTION
Follow-up to #10060 (Zephyr platform support).

Bumps the cpuinfo dependency to include the Cortex-A320 MIDR decode
(pytorch/cpuinfo#384, merged) and adds a one-line mapping in
`cpuinfo_to_xnn_uarch()` so XNNPACK selects the optimised kernel
path on Cortex-A320 cores.

The A320 is an ARMv9.2-A efficiency core in the same family as
the A510/A520.  We map it to `xnn_uarch_cortex_a510` since A520 is
not exposed in `xnn_uarch` either, and A510 is the closest existing
entry; the mapping can be revisited once silicon is available for
benchmarking.