### PR TITLE
Clarify explicit-false build option alias behavior

### DIFF
--- a/ynnpack/build_defs.bzl
+++ b/ynnpack/build_defs.bzl
@@ -39,6 +39,9 @@ def define_build_option(name, default_all = [], default_any = []):
         name = name,
         actual = select({
             explicit_true: ":" + explicit_true,
+            # This alias is used as a positive condition in downstream select()
+            # calls. When the option is explicitly false, route the alias to the
+            # explicit-true config_setting so the public condition does not match.
             explicit_false: ":" + explicit_true,
             "//conditions:default": ":" + default,
         }),


### PR DESCRIPTION
This clarifies the intentionally counterintuitive `define_build_option` alias behavior in `ynnpack/build_defs.bzl`.

The public alias is used as a positive condition in downstream `select()` calls. I tested the suggested one-line change against `//ynnpack/base:base` and it would make `--define ynn_enable_cpuinfo=false` still select the CPUINFO path. The existing mapping keeps that condition false.

Verified with Docker + Bazel 9.1.0:
- original mapping, `--define ynn_enable_cpuinfo=true`: `YNN_ENABLE_CPUINFO` present
- original mapping, `--define ynn_enable_cpuinfo=false`: `YNN_ENABLE_CPUINFO` absent
- changed mapping, `--define ynn_enable_cpuinfo=false`: `YNN_ENABLE_CPUINFO` present

So this PR is now documentation only: it preserves the current behavior and explains why the explicit-false branch intentionally routes to the explicit-true config setting.