### PR TITLE
Use safe tail loads for inputs in maxpool kernels

### DIFF
--- a/src/f16-maxpool/gen/f16-maxpool-9p-minmax-avx2-u16.c
+++ b/src/f16-maxpool/gen/f16-maxpool-9p-minmax-avx2-u16.c
@@ -16,7 +16,6 @@
 // On some architectures, we have max(u8, u8) but not max(s8, s8). We can emulate max(s8, s8) on these architectures by
 // xoring with the sign bit mask.
 #define xnn_load_impl(x) xnn_signcomplement_s16(xnn_loadu_s16(x))
-#define xnn_load_tail_impl(x, c) xnn_signcomplement_s16(xnn_load_tail_s16(x, c))
 #define xnn_load_tail_safe_impl(x, c) xnn_signcomplement_s16(xnn_load_tail_safe_s16(x, c))
 #define xnn_pre_store_impl(x) xnn_signcomplement_s16(x)
 
@@ -98,15 +97,15 @@ XNN_FORCE_REALIZATION(vmax);
       xnn_storeu_s16(o, vacc); o += 16;
     }
     if (c > 0) {
-      const xnn_simd_s16_t vi0 = xnn_load_tail_impl(i0, c);
-      const xnn_simd_s16_t vi1 = xnn_load_tail_impl(i1, c);
-      const xnn_simd_s16_t vi2 = xnn_load_tail_impl(i2, c);
-      const xnn_simd_s16_t vi3 = xnn_load_tail_impl(i3, c);
-      const xnn_simd_s16_t vi4 = xnn_load_tail_impl(i4, c);
-      const xnn_simd_s16_t vi5 = xnn_load_tail_impl(i5, c);
-      const xnn_simd_s16_t vi6 = xnn_load_tail_impl(i6, c);
-      const xnn_simd_s16_t vi7 = xnn_load_tail_impl(i7, c);
-      const xnn_simd_s16_t vi8 = xnn_load_tail_impl(i8, c);
+      const xnn_simd_s16_t vi0 = xnn_load_tail_safe_impl(i0, c);
+      const xnn_simd_s16_t vi1 = xnn_load_tail_safe_impl(i1, c);
+      const xnn_simd_s16_t vi2 = xnn_load_tail_safe_impl(i2, c);
+      const xnn_simd_s16_t vi3 = xnn_load_tail_safe_impl(i3, c);
+      const xnn_simd_s16_t vi4 = xnn_load_tail_safe_impl(i4, c);
+      const xnn_simd_s16_t vi5 = xnn_load_tail_safe_impl(i5, c);
+      const xnn_simd_s16_t vi6 = xnn_load_tail_safe_impl(i6, c);
+      const xnn_simd_s16_t vi7 = xnn_load_tail_safe_impl(i7, c);
+      const xnn_simd_s16_t vi8 = xnn_load_tail_safe_impl(i8, c);
 
       const xnn_simd_s16_t vmax018 = xnn_max_s16(xnn_max_s16(vi0, vi1), vi8);
       const xnn_simd_s16_t vmax23 = xnn_max_s16(vi2, vi3);
@@ -179,15 +178,15 @@ XNN_FORCE_REALIZATION(vmax);
         xnn_storeu_s16(o, vacc); o += 16;
       }
       if (c > 0) {
-        const xnn_simd_s16_t vi0 = xnn_load_tail_impl(i0, c);
-        const xnn_simd_s16_t vi1 = xnn_load_tail_impl(i1, c);
-        const xnn_simd_s16_t vi2 = xnn_load_tail_impl(i2, c);
-        const xnn_simd_s16_t vi3 = xnn_load_tail_impl(i3, c);
-        const xnn_simd_s16_t vi4 = xnn_load_tail_impl(i4, c);
-        const xnn_simd_s16_t vi5 = xnn_load_tail_impl(i5, c);
-        const xnn_simd_s16_t vi6 = xnn_load_tail_impl(i6, c);
-        const xnn_simd_s16_t vi7 = xnn_load_tail_impl(i7, c);
-        const xnn_simd_s16_t vi8 = xnn_load_tail_impl(i8, c);
+        const xnn_simd_s16_t vi0 = xnn_load_tail_safe_impl(i0, c);
+        const xnn_simd_s16_t vi1 = xnn_load_tail_safe_impl(i1, c);
+        const xnn_simd_s16_t vi2 = xnn_load_tail_safe_impl(i2, c);
+        const xnn_simd_s16_t vi3 = xnn_load_tail_safe_impl(i3, c);
+        const xnn_simd_s16_t vi4 = xnn_load_tail_safe_impl(i4, c);
+        const xnn_simd_s16_t vi5 = xnn_load_tail_safe_impl(i5, c);
+        const xnn_simd_s16_t vi6 = xnn_load_tail_safe_impl(i6, c);
+        const xnn_simd_s16_t vi7 = xnn_load_tail_safe_impl(i7, c);
+        const xnn_simd_s16_t vi8 = xnn_load_tail_safe_impl(i8, c);
         const xnn_simd_s16_t vprev = xnn_load_tail_safe_impl(o, c);
 
         const xnn_simd_s16_t vmax018 = xnn_max_s16(xnn_max_s16(vi0, vi1), vi8);

--- a/src/f16-maxpool/gen/f16-maxpool-9p-minmax-neonfp16arith-u8.c
+++ b/src/f16-maxpool/gen/f16-maxpool-9p-minmax-neonfp16arith-u8.c
@@ -16,7 +16,6 @@
 // On some architectures, we have max(u8, u8) but not max(s8, s8). We can emulate max(s8, s8) on these architectures by
 // xoring with the sign bit mask.
 #define xnn_load_impl(x) xnn_loadu_f16(x)
-#define xnn_load_tail_impl(x, c) xnn_load_tail_f16(x, c)
 #define xnn_load_tail_safe_impl(x, c) xnn_load_tail_safe_f16(x, c)
 #define xnn_pre_store_impl(x) x
 
@@ -98,15 +97,15 @@ void xnn_f16_maxpool_minmax_ukernel_9p__neonfp16arith_u8(
       xnn_storeu_f16(o, vacc); o += 8;
     }
     if (c > 0) {
-      const xnn_simd_f16_t vi0 = xnn_load_tail_impl(i0, c);
-      const xnn_simd_f16_t vi1 = xnn_load_tail_impl(i1, c);
-      const xnn_simd_f16_t vi2 = xnn_load_tail_impl(i2, c);
-      const xnn_simd_f16_t vi3 = xnn_load_tail_impl(i3, c);
-      const xnn_simd_f16_t vi4 = xnn_load_tail_impl(i4, c);
-      const xnn_simd_f16_t vi5 = xnn_load_tail_impl(i5, c);
-      const xnn_simd_f16_t vi6 = xnn_load_tail_impl(i6, c);
-      const xnn_simd_f16_t vi7 = xnn_load_tail_impl(i7, c);
-      const xnn_simd_f16_t vi8 = xnn_load_tail_impl(i8, c);
+      const xnn_simd_f16_t vi0 = xnn_load_tail_safe_impl(i0, c);
+      const xnn_simd_f16_t vi1 = xnn_load_tail_safe_impl(i1, c);
+      const xnn_simd_f16_t vi2 = xnn_load_tail_safe_impl(i2, c);
+      const xnn_simd_f16_t vi3 = xnn_load_tail_safe_impl(i3, c);
+      const xnn_simd_f16_t vi4 = xnn_load_tail_safe_impl(i4, c);
+      const xnn_simd_f16_t vi5 = xnn_load_tail_safe_impl(i5, c);
+      const xnn_simd_f16_t vi6 = xnn_load_tail_safe_impl(i6, c);
+      const xnn_simd_f16_t vi7 = xnn_load_tail_safe_impl(i7, c);
+      const xnn_simd_f16_t vi8 = xnn_load_tail_safe_impl(i8, c);
 
       const xnn_simd_f16_t vmax018 = xnn_max_f16(xnn_max_f16(vi0, vi1), vi8);
       const xnn_simd_f16_t vmax23 = xnn_max_f16(vi2, vi3);
@@ -179,15 +178,15 @@ void xnn_f16_maxpool_minmax_ukernel_9p__neonfp16arith_u8(
         xnn_storeu_f16(o, vacc); o += 8;
       }
       if (c > 0) {
-        const xnn_simd_f16_t vi0 = xnn_load_tail_impl(i0, c);
-        const xnn_simd_f16_t vi1 = xnn_load_tail_impl(i1, c);
-        const xnn_simd_f16_t vi2 = xnn_load_tail_impl(i2, c);
-        const xnn_simd_f16_t vi3 = xnn_load_tail_impl(i3, c);
-        const xnn_simd_f16_t vi4 = xnn_load_tail_impl(i4, c);
-        const xnn_simd_f16_t vi5 = xnn_load_tail_impl(i5, c);
-        const xnn_simd_f16_t vi6 = xnn_load_tail_impl(i6, c);
-        const xnn_simd_f16_t vi7 = xnn_load_tail_impl(i7, c);
-        const xnn_simd_f16_t vi8 = xnn_load_tail_impl(i8, c);
+        const xnn_simd_f16_t vi0 = xnn_load_tail_safe_impl(i0, c);
+        const xnn_simd_f16_t vi1 = xnn_load_tail_safe_impl(i1, c);
+        const xnn_simd_f16_t vi2 = xnn_load_tail_safe_impl(i2, c);
+        const xnn_simd_f16_t vi3 = xnn_load_tail_safe_impl(i3, c);
+        const xnn_simd_f16_t vi4 = xnn_load_tail_safe_impl(i4, c);
+        const xnn_simd_f16_t vi5 = xnn_load_tail_safe_impl(i5, c);
+        const xnn_simd_f16_t vi6 = xnn_load_tail_safe_impl(i6, c);
+        const xnn_simd_f16_t vi7 = xnn_load_tail_safe_impl(i7, c);
+        const xnn_simd_f16_t vi8 = xnn_load_tail_safe_impl(i8, c);
         const xnn_simd_f16_t vprev = xnn_load_tail_safe_impl(o, c);
 
         const xnn_simd_f16_t vmax018 = xnn_max_f16(xnn_max_f16(vi0, vi1), vi8);

--- a/src/f16-maxpool/gen/f16-maxpool-9p-minmax-sse41-u8.c
+++ b/src/f16-maxpool/gen/f16-maxpool-9p-minmax-sse41-u8.c
@@ -16,7 +16,6 @@
 // On some architectures, we have max(u8, u8) but not max(s8, s8). We can emulate max(s8, s8) on these architectures by
 // xoring with the sign bit mask.
 #define xnn_load_impl(x) xnn_signcomplement_s16(xnn_loadu_s16(x))
-#define xnn_load_tail_impl(x, c) xnn_signcomplement_s16(xnn_load_tail_s16(x, c))
 #define xnn_load_tail_safe_impl(x, c) xnn_signcomplement_s16(xnn_load_tail_safe_s16(x, c))
 #define xnn_pre_store_impl(x) xnn_signcomplement_s16(x)
 
@@ -98,15 +97,15 @@ XNN_FORCE_REALIZATION(vmax);
       xnn_storeu_s16(o, vacc); o += 8;
     }
     if (c > 0) {
-      const xnn_simd_s16_t vi0 = xnn_load_tail_impl(i0, c);
-      const xnn_simd_s16_t vi1 = xnn_load_tail_impl(i1, c);
-      const xnn_simd_s16_t vi2 = xnn_load_tail_impl(i2, c);
-      const xnn_simd_s16_t vi3 = xnn_load_tail_impl(i3, c);
-      const xnn_simd_s16_t vi4 = xnn_load_tail_impl(i4, c);
-      const xnn_simd_s16_t vi5 = xnn_load_tail_impl(i5, c);
-      const xnn_simd_s16_t vi6 = xnn_load_tail_impl(i6, c);
-      const xnn_simd_s16_t vi7 = xnn_load_tail_impl(i7, c);
-      const xnn_simd_s16_t vi8 = xnn_load_tail_impl(i8, c);
+      const xnn_simd_s16_t vi0 = xnn_load_tail_safe_impl(i0, c);
+      const xnn_simd_s16_t vi1 = xnn_load_tail_safe_impl(i1, c);
+      const xnn_simd_s16_t vi2 = xnn_load_tail_safe_impl(i2, c);
+      const xnn_simd_s16_t vi3 = xnn_load_tail_safe_impl(i3, c);
+      const xnn_simd_s16_t vi4 = xnn_load_tail_safe_impl(i4, c);
+      const xnn_simd_s16_t vi5 = xnn_load_tail_safe_impl(i5, c);
+      const xnn_simd_s16_t vi6 = xnn_load_tail_safe_impl(i6, c);
+      const xnn_simd_s16_t vi7 = xnn_load_tail_safe_impl(i7, c);
+      const xnn_simd_s16_t vi8 = xnn_load_tail_safe_impl(i8, c);
 
       const xnn_simd_s16_t vmax018 = xnn_max_s16(xnn_max_s16(vi0, vi1), vi8);
       const xnn_simd_s16_t vmax23 = xnn_max_s16(vi2, vi3);
@@ -179,15 +178,15 @@ XNN_FORCE_REALIZATION(vmax);
         xnn_storeu_s16(o, vacc); o += 8;
       }
       if (c > 0) {
-        const xnn_simd_s16_t vi0 = xnn_load_tail_impl(i0, c);
-        const xnn_simd_s16_t vi1 = xnn_load_tail_impl(i1, c);
-        const xnn_simd_s16_t vi2 = xnn_load_tail_impl(i2, c);
-        const xnn_simd_s16_t vi3 = xnn_load_tail_impl(i3, c);
-        const xnn_simd_s16_t vi4 = xnn_load_tail_impl(i4, c);
-        const xnn_simd_s16_t vi5 = xnn_load_tail_impl(i5, c);
-        const xnn_simd_s16_t vi6 = xnn_load_tail_impl(i6, c);
-        const xnn_simd_s16_t vi7 = xnn_load_tail_impl(i7, c);
-        const xnn_simd_s16_t vi8 = xnn_load_tail_impl(i8, c);
+        const xnn_simd_s16_t vi0 = xnn_load_tail_safe_impl(i0, c);
+        const xnn_simd_s16_t vi1 = xnn_load_tail_safe_impl(i1, c);
+        const xnn_simd_s16_t vi2 = xnn_load_tail_safe_impl(i2, c);
+        const xnn_simd_s16_t vi3 = xnn_load_tail_safe_impl(i3, c);
+        const xnn_simd_s16_t vi4 = xnn_load_tail_safe_impl(i4, c);
+        const xnn_simd_s16_t vi5 = xnn_load_tail_safe_impl(i5, c);
+        const xnn_simd_s16_t vi6 = xnn_load_tail_safe_impl(i6, c);
+        const xnn_simd_s16_t vi7 = xnn_load_tail_safe_impl(i7, c);
+        const xnn_simd_s16_t vi8 = xnn_load_tail_safe_impl(i8, c);
         const xnn_simd_s16_t vprev = xnn_load_tail_safe_impl(o, c);
 
         const xnn_simd_s16_t vmax018 = xnn_max_s16(xnn_max_s16(vi0, vi1), vi8);

--- a/src/f32-maxpool/gen/f32-maxpool-9p-minmax-hvx-u32.c
+++ b/src/f32-maxpool/gen/f32-maxpool-9p-minmax-hvx-u32.c
@@ -16,7 +16,6 @@
 // On some architectures, we have max(u8, u8) but not max(s8, s8). We can emulate max(s8, s8) on these architectures by
 // xoring with the sign bit mask.
 #define xnn_load_impl(x) xnn_loadu_f32(x)
-#define xnn_load_tail_impl(x, c) xnn_load_tail_f32(x, c)
 #define xnn_load_tail_safe_impl(x, c) xnn_load_tail_safe_f32(x, c)
 #define xnn_pre_store_impl(x) x
 
@@ -98,15 +97,15 @@ void xnn_f32_maxpool_minmax_ukernel_9p__hvx_u32(
       xnn_storeu_f32(o, vacc); o += 32;
     }
     if (c > 0) {
-      const xnn_simd_f32_t vi0 = xnn_load_tail_impl(i0, c);
-      const xnn_simd_f32_t vi1 = xnn_load_tail_impl(i1, c);
-      const xnn_simd_f32_t vi2 = xnn_load_tail_impl(i2, c);
-      const xnn_simd_f32_t vi3 = xnn_load_tail_impl(i3, c);
-      const xnn_simd_f32_t vi4 = xnn_load_tail_impl(i4, c);
-      const xnn_simd_f32_t vi5 = xnn_load_tail_impl(i5, c);
-      const xnn_simd_f32_t vi6 = xnn_load_tail_impl(i6, c);
-      const xnn_simd_f32_t vi7 = xnn_load_tail_impl(i7, c);
-      const xnn_simd_f32_t vi8 = xnn_load_tail_impl(i8, c);
+      const xnn_simd_f32_t vi0 = xnn_load_tail_safe_impl(i0, c);
+      const xnn_simd_f32_t vi1 = xnn_load_tail_safe_impl(i1, c);
+      const xnn_simd_f32_t vi2 = xnn_load_tail_safe_impl(i2, c);
+      const xnn_simd_f32_t vi3 = xnn_load_tail_safe_impl(i3, c);
+      const xnn_simd_f32_t vi4 = xnn_load_tail_safe_impl(i4, c);
+      const xnn_simd_f32_t vi5 = xnn_load_tail_safe_impl(i5, c);
+      const xnn_simd_f32_t vi6 = xnn_load_tail_safe_impl(i6, c);
+      const xnn_simd_f32_t vi7 = xnn_load_tail_safe_impl(i7, c);
+      const xnn_simd_f32_t vi8 = xnn_load_tail_safe_impl(i8, c);
 
       const xnn_simd_f32_t vmax018 = xnn_max_f32(xnn_max_f32(vi0, vi1), vi8);
       const xnn_simd_f32_t vmax23 = xnn_max_f32(vi2, vi3);
@@ -179,15 +178,15 @@ void xnn_f32_maxpool_minmax_ukernel_9p__hvx_u32(
         xnn_storeu_f32(o, vacc); o += 32;
       }
       if (c > 0) {
-        const xnn_simd_f32_t vi0 = xnn_load_tail_impl(i0, c);
-        const xnn_simd_f32_t vi1 = xnn_load_tail_impl(i1, c);
-        const xnn_simd_f32_t vi2 = xnn_load_tail_impl(i2, c);
-        const xnn_simd_f32_t vi3 = xnn_load_tail_impl(i3, c);
-        const xnn_simd_f32_t vi4 = xnn_load_tail_impl(i4, c);
-        const xnn_simd_f32_t vi5 = xnn_load_tail_impl(i5, c);
-        const xnn_simd_f32_t vi6 = xnn_load_tail_impl(i6, c);
-        const xnn_simd_f32_t vi7 = xnn_load_tail_impl(i7, c);
-        const xnn_simd_f32_t vi8 = xnn_load_tail_impl(i8, c);
+        const xnn_simd_f32_t vi0 = xnn_load_tail_safe_impl(i0, c);
+        const xnn_simd_f32_t vi1 = xnn_load_tail_safe_impl(i1, c);
+        const xnn_simd_f32_t vi2 = xnn_load_tail_safe_impl(i2, c);
+        const xnn_simd_f32_t vi3 = xnn_load_tail_safe_impl(i3, c);
+        const xnn_simd_f32_t vi4 = xnn_load_tail_safe_impl(i4, c);
+        const xnn_simd_f32_t vi5 = xnn_load_tail_safe_impl(i5, c);
+        const xnn_simd_f32_t vi6 = xnn_load_tail_safe_impl(i6, c);
+        const xnn_simd_f32_t vi7 = xnn_load_tail_safe_impl(i7, c);
+        const xnn_simd_f32_t vi8 = xnn_load_tail_safe_impl(i8, c);
         const xnn_simd_f32_t vprev = xnn_load_tail_safe_impl(o, c);
 
         const xnn_simd_f32_t vmax018 = xnn_max_f32(xnn_max_f32(vi0, vi1), vi8);

--- a/src/f32-maxpool/gen/f32-maxpool-9p-minmax-neon-u4.c
+++ b/src/f32-maxpool/gen/f32-maxpool-9p-minmax-neon-u4.c
@@ -16,7 +16,6 @@
 // On some architectures, we have max(u8, u8) but not max(s8, s8). We can emulate max(s8, s8) on these architectures by
 // xoring with the sign bit mask.
 #define xnn_load_impl(x) xnn_loadu_f32(x)
-#define xnn_load_tail_impl(x, c) xnn_load_tail_f32(x, c)
 #define xnn_load_tail_safe_impl(x, c) xnn_load_tail_safe_f32(x, c)
 #define xnn_pre_store_impl(x) x
 
@@ -98,15 +97,15 @@ void xnn_f32_maxpool_minmax_ukernel_9p__neon_u4(
       xnn_storeu_f32(o, vacc); o += 4;
     }
     if (c > 0) {
-      const xnn_simd_f32_t vi0 = xnn_load_tail_impl(i0, c);
-      const xnn_simd_f32_t vi1 = xnn_load_tail_impl(i1, c);
-      const xnn_simd_f32_t vi2 = xnn_load_tail_impl(i2, c);
-      const xnn_simd_f32_t vi3 = xnn_load_tail_impl(i3, c);
-      const xnn_simd_f32_t vi4 = xnn_load_tail_impl(i4, c);
-      const xnn_simd_f32_t vi5 = xnn_load_tail_impl(i5, c);
-      const xnn_simd_f32_t vi6 = xnn_load_tail_impl(i6, c);
-      const xnn_simd_f32_t vi7 = xnn_load_tail_impl(i7, c);
-      const xnn_simd_f32_t vi8 = xnn_load_tail_impl(i8, c);
+      const xnn_simd_f32_t vi0 = xnn_load_tail_safe_impl(i0, c);
+      const xnn_simd_f32_t vi1 = xnn_load_tail_safe_impl(i1, c);
+      const xnn_simd_f32_t vi2 = xnn_load_tail_safe_impl(i2, c);
+      const xnn_simd_f32_t vi3 = xnn_load_tail_safe_impl(i3, c);
+      const xnn_simd_f32_t vi4 = xnn_load_tail_safe_impl(i4, c);
+      const xnn_simd_f32_t vi5 = xnn_load_tail_safe_impl(i5, c);
+      const xnn_simd_f32_t vi6 = xnn_load_tail_safe_impl(i6, c);
+      const xnn_simd_f32_t vi7 = xnn_load_tail_safe_impl(i7, c);
+      const xnn_simd_f32_t vi8 = xnn_load_tail_safe_impl(i8, c);
 
       const xnn_simd_f32_t vmax018 = xnn_max_f32(xnn_max_f32(vi0, vi1), vi8);
       const xnn_simd_f32_t vmax23 = xnn_max_f32(vi2, vi3);
@@ -179,15 +178,15 @@ void xnn_f32_maxpool_minmax_ukernel_9p__neon_u4(
         xnn_storeu_f32(o, vacc); o += 4;
       }
       if (c > 0) {
-        const xnn_simd_f32_t vi0 = xnn_load_tail_impl(i0, c);
-        const xnn_simd_f32_t vi1 = xnn_load_tail_impl(i1, c);
-        const xnn_simd_f32_t vi2 = xnn_load_tail_impl(i2, c);
-        const xnn_simd_f32_t vi3 = xnn_load_tail_impl(i3, c);
-        const xnn_simd_f32_t vi4 = xnn_load_tail_impl(i4, c);
-        const xnn_simd_f32_t vi5 = xnn_load_tail_impl(i5, c);
-        const xnn_simd_f32_t vi6 = xnn_load_tail_impl(i6, c);
-        const xnn_simd_f32_t vi7 = xnn_load_tail_impl(i7, c);
-        const xnn_simd_f32_t vi8 = xnn_load_tail_impl(i8, c);
+        const xnn_simd_f32_t vi0 = xnn_load_tail_safe_impl(i0, c);
+        const xnn_simd_f32_t vi1 = xnn_load_tail_safe_impl(i1, c);
+        const xnn_simd_f32_t vi2 = xnn_load_tail_safe_impl(i2, c);
+        const xnn_simd_f32_t vi3 = xnn_load_tail_safe_impl(i3, c);
+        const xnn_simd_f32_t vi4 = xnn_load_tail_safe_impl(i4, c);
+        const xnn_simd_f32_t vi5 = xnn_load_tail_safe_impl(i5, c);
+        const xnn_simd_f32_t vi6 = xnn_load_tail_safe_impl(i6, c);
+        const xnn_simd_f32_t vi7 = xnn_load_tail_safe_impl(i7, c);
+        const xnn_simd_f32_t vi8 = xnn_load_tail_safe_impl(i8, c);
         const xnn_simd_f32_t vprev = xnn_load_tail_safe_impl(o, c);
 
         const xnn_simd_f32_t vmax018 = xnn_max_f32(xnn_max_f32(vi0, vi1), vi8);

--- a/src/f32-maxpool/gen/f32-maxpool-9p-minmax-scalar-u1.c
+++ b/src/f32-maxpool/gen/f32-maxpool-9p-minmax-scalar-u1.c
@@ -16,7 +16,6 @@
 // On some architectures, we have max(u8, u8) but not max(s8, s8). We can emulate max(s8, s8) on these architectures by
 // xoring with the sign bit mask.
 #define xnn_load_impl(x) xnn_loadu_f32(x)
-#define xnn_load_tail_impl(x, c) xnn_load_tail_f32(x, c)
 #define xnn_load_tail_safe_impl(x, c) xnn_load_tail_safe_f32(x, c)
 #define xnn_pre_store_impl(x) x
 

--- a/src/f32-maxpool/gen/f32-maxpool-9p-minmax-sse2-u4.c
+++ b/src/f32-maxpool/gen/f32-maxpool-9p-minmax-sse2-u4.c
@@ -16,7 +16,6 @@
 // On some architectures, we have max(u8, u8) but not max(s8, s8). We can emulate max(s8, s8) on these architectures by
 // xoring with the sign bit mask.
 #define xnn_load_impl(x) xnn_loadu_f32(x)
-#define xnn_load_tail_impl(x, c) xnn_load_tail_f32(x, c)
 #define xnn_load_tail_safe_impl(x, c) xnn_load_tail_safe_f32(x, c)
 #define xnn_pre_store_impl(x) x
 
@@ -98,15 +97,15 @@ void xnn_f32_maxpool_minmax_ukernel_9p__sse2_u4(
       xnn_storeu_f32(o, vacc); o += 4;
     }
     if (c > 0) {
-      const xnn_simd_f32_t vi0 = xnn_load_tail_impl(i0, c);
-      const xnn_simd_f32_t vi1 = xnn_load_tail_impl(i1, c);
-      const xnn_simd_f32_t vi2 = xnn_load_tail_impl(i2, c);
-      const xnn_simd_f32_t vi3 = xnn_load_tail_impl(i3, c);
-      const xnn_simd_f32_t vi4 = xnn_load_tail_impl(i4, c);
-      const xnn_simd_f32_t vi5 = xnn_load_tail_impl(i5, c);
-      const xnn_simd_f32_t vi6 = xnn_load_tail_impl(i6, c);
-      const xnn_simd_f32_t vi7 = xnn_load_tail_impl(i7, c);
-      const xnn_simd_f32_t vi8 = xnn_load_tail_impl(i8, c);
+      const xnn_simd_f32_t vi0 = xnn_load_tail_safe_impl(i0, c);
+      const xnn_simd_f32_t vi1 = xnn_load_tail_safe_impl(i1, c);
+      const xnn_simd_f32_t vi2 = xnn_load_tail_safe_impl(i2, c);
+      const xnn_simd_f32_t vi3 = xnn_load_tail_safe_impl(i3, c);
+      const xnn_simd_f32_t vi4 = xnn_load_tail_safe_impl(i4, c);
+      const xnn_simd_f32_t vi5 = xnn_load_tail_safe_impl(i5, c);
+      const xnn_simd_f32_t vi6 = xnn_load_tail_safe_impl(i6, c);
+      const xnn_simd_f32_t vi7 = xnn_load_tail_safe_impl(i7, c);
+      const xnn_simd_f32_t vi8 = xnn_load_tail_safe_impl(i8, c);
 
       const xnn_simd_f32_t vmax018 = xnn_max_f32(xnn_max_f32(vi0, vi1), vi8);
       const xnn_simd_f32_t vmax23 = xnn_max_f32(vi2, vi3);
@@ -179,15 +178,15 @@ void xnn_f32_maxpool_minmax_ukernel_9p__sse2_u4(
         xnn_storeu_f32(o, vacc); o += 4;
       }
       if (c > 0) {
-        const xnn_simd_f32_t vi0 = xnn_load_tail_impl(i0, c);
-        const xnn_simd_f32_t vi1 = xnn_load_tail_impl(i1, c);
-        const xnn_simd_f32_t vi2 = xnn_load_tail_impl(i2, c);
-        const xnn_simd_f32_t vi3 = xnn_load_tail_impl(i3, c);
-        const xnn_simd_f32_t vi4 = xnn_load_tail_impl(i4, c);
-        const xnn_simd_f32_t vi5 = xnn_load_tail_impl(i5, c);
-        const xnn_simd_f32_t vi6 = xnn_load_tail_impl(i6, c);
-        const xnn_simd_f32_t vi7 = xnn_load_tail_impl(i7, c);
-        const xnn_simd_f32_t vi8 = xnn_load_tail_impl(i8, c);
+        const xnn_simd_f32_t vi0 = xnn_load_tail_safe_impl(i0, c);
+        const xnn_simd_f32_t vi1 = xnn_load_tail_safe_impl(i1, c);
+        const xnn_simd_f32_t vi2 = xnn_load_tail_safe_impl(i2, c);
+        const xnn_simd_f32_t vi3 = xnn_load_tail_safe_impl(i3, c);
+        const xnn_simd_f32_t vi4 = xnn_load_tail_safe_impl(i4, c);
+        const xnn_simd_f32_t vi5 = xnn_load_tail_safe_impl(i5, c);
+        const xnn_simd_f32_t vi6 = xnn_load_tail_safe_impl(i6, c);
+        const xnn_simd_f32_t vi7 = xnn_load_tail_safe_impl(i7, c);
+        const xnn_simd_f32_t vi8 = xnn_load_tail_safe_impl(i8, c);
         const xnn_simd_f32_t vprev = xnn_load_tail_safe_impl(o, c);
 
         const xnn_simd_f32_t vmax018 = xnn_max_f32(xnn_max_f32(vi0, vi1), vi8);

--- a/src/f32-maxpool/gen/f32-maxpool-9p-minmax-wasmsimd-u4.c
+++ b/src/f32-maxpool/gen/f32-maxpool-9p-minmax-wasmsimd-u4.c
@@ -16,7 +16,6 @@
 // On some architectures, we have max(u8, u8) but not max(s8, s8). We can emulate max(s8, s8) on these architectures by
 // xoring with the sign bit mask.
 #define xnn_load_impl(x) xnn_loadu_f32(x)
-#define xnn_load_tail_impl(x, c) xnn_load_tail_f32(x, c)
 #define xnn_load_tail_safe_impl(x, c) xnn_load_tail_safe_f32(x, c)
 #define xnn_pre_store_impl(x) x
 
@@ -98,15 +97,15 @@ void xnn_f32_maxpool_minmax_ukernel_9p__wasmsimd_u4(
       xnn_storeu_f32(o, vacc); o += 4;
     }
     if (c > 0) {
-      const xnn_simd_f32_t vi0 = xnn_load_tail_impl(i0, c);
-      const xnn_simd_f32_t vi1 = xnn_load_tail_impl(i1, c);
-      const xnn_simd_f32_t vi2 = xnn_load_tail_impl(i2, c);
-      const xnn_simd_f32_t vi3 = xnn_load_tail_impl(i3, c);
-      const xnn_simd_f32_t vi4 = xnn_load_tail_impl(i4, c);
-      const xnn_simd_f32_t vi5 = xnn_load_tail_impl(i5, c);
-      const xnn_simd_f32_t vi6 = xnn_load_tail_impl(i6, c);
-      const xnn_simd_f32_t vi7 = xnn_load_tail_impl(i7, c);
-      const xnn_simd_f32_t vi8 = xnn_load_tail_impl(i8, c);
+      const xnn_simd_f32_t vi0 = xnn_load_tail_safe_impl(i0, c);
+      const xnn_simd_f32_t vi1 = xnn_load_tail_safe_impl(i1, c);
+      const xnn_simd_f32_t vi2 = xnn_load_tail_safe_impl(i2, c);
+      const xnn_simd_f32_t vi3 = xnn_load_tail_safe_impl(i3, c);
+      const xnn_simd_f32_t vi4 = xnn_load_tail_safe_impl(i4, c);
+      const xnn_simd_f32_t vi5 = xnn_load_tail_safe_impl(i5, c);
+      const xnn_simd_f32_t vi6 = xnn_load_tail_safe_impl(i6, c);
+      const xnn_simd_f32_t vi7 = xnn_load_tail_safe_impl(i7, c);
+      const xnn_simd_f32_t vi8 = xnn_load_tail_safe_impl(i8, c);
 
       const xnn_simd_f32_t vmax018 = xnn_max_f32(xnn_max_f32(vi0, vi1), vi8);
       const xnn_simd_f32_t vmax23 = xnn_max_f32(vi2, vi3);
@@ -179,15 +178,15 @@ void xnn_f32_maxpool_minmax_ukernel_9p__wasmsimd_u4(
         xnn_storeu_f32(o, vacc); o += 4;
       }
       if (c > 0) {
-        const xnn_simd_f32_t vi0 = xnn_load_tail_impl(i0, c);
-        const xnn_simd_f32_t vi1 = xnn_load_tail_impl(i1, c);
-        const xnn_simd_f32_t vi2 = xnn_load_tail_impl(i2, c);
-        const xnn_simd_f32_t vi3 = xnn_load_tail_impl(i3, c);
-        const xnn_simd_f32_t vi4 = xnn_load_tail_impl(i4, c);
-        const xnn_simd_f32_t vi5 = xnn_load_tail_impl(i5, c);
-        const xnn_simd_f32_t vi6 = xnn_load_tail_impl(i6, c);
-        const xnn_simd_f32_t vi7 = xnn_load_tail_impl(i7, c);
-        const xnn_simd_f32_t vi8 = xnn_load_tail_impl(i8, c);
+        const xnn_simd_f32_t vi0 = xnn_load_tail_safe_impl(i0, c);
+        const xnn_simd_f32_t vi1 = xnn_load_tail_safe_impl(i1, c);
+        const xnn_simd_f32_t vi2 = xnn_load_tail_safe_impl(i2, c);
+        const xnn_simd_f32_t vi3 = xnn_load_tail_safe_impl(i3, c);
+        const xnn_simd_f32_t vi4 = xnn_load_tail_safe_impl(i4, c);
+        const xnn_simd_f32_t vi5 = xnn_load_tail_safe_impl(i5, c);
+        const xnn_simd_f32_t vi6 = xnn_load_tail_safe_impl(i6, c);
+        const xnn_simd_f32_t vi7 = xnn_load_tail_safe_impl(i7, c);
+        const xnn_simd_f32_t vi8 = xnn_load_tail_safe_impl(i8, c);
         const xnn_simd_f32_t vprev = xnn_load_tail_safe_impl(o, c);
 
         const xnn_simd_f32_t vmax018 = xnn_max_f32(xnn_max_f32(vi0, vi1), vi8);

--- a/src/f32-maxpool/maxpool.c.in
+++ b/src/f32-maxpool/maxpool.c.in
@@ -15,17 +15,14 @@ $DATATYPE_IMPL = {"f32": "f32", "f16": "f16" if ARCH == "neonfp16arith" else "s1
 // xoring with the sign bit mask.
 $if ARCH == "sse2" and DATATYPE == "s8":
   #define xnn_load_impl(x) xnn_xor_u8(xnn_loadu_u8(x), vsign_bit_mask)
-  #define xnn_load_tail_impl(x, c) xnn_xor_u8(xnn_load_tail_u8(x, c), vsign_bit_mask)
   #define xnn_load_tail_safe_impl(x, c) xnn_xor_u8(xnn_load_tail_safe_u8(x, c), vsign_bit_mask)
   #define xnn_pre_store_impl(x) xnn_xor_u8(x, vsign_bit_mask)
 $elif DATATYPE == "f16" and ARCH != "neonfp16arith":
   #define xnn_load_impl(x) xnn_signcomplement_s16(xnn_loadu_s16(x))
-  #define xnn_load_tail_impl(x, c) xnn_signcomplement_s16(xnn_load_tail_s16(x, c))
   #define xnn_load_tail_safe_impl(x, c) xnn_signcomplement_s16(xnn_load_tail_safe_s16(x, c))
   #define xnn_pre_store_impl(x) xnn_signcomplement_s16(x)
 $else:
   #define xnn_load_impl(x) xnn_loadu_${DATATYPE}(x)
-  #define xnn_load_tail_impl(x, c) xnn_load_tail_${DATATYPE}(x, c)
   #define xnn_load_tail_safe_impl(x, c) xnn_load_tail_safe_${DATATYPE}(x, c)
   #define xnn_pre_store_impl(x) x
 
@@ -104,7 +101,7 @@ $elif DATATYPE == "f16" and ARCH != "neonfp16arith":
     $if SIMD_SIZE > 1:
       if (c > 0) {
         $for K in range(9):
-          const xnn_simd_${DATATYPE_IMPL}_t vi${K} = xnn_load_tail_impl(i${K}, c);
+          const xnn_simd_${DATATYPE_IMPL}_t vi${K} = xnn_load_tail_safe_impl(i${K}, c);
 
         const xnn_simd_${DATATYPE_IMPL}_t vmax018 = xnn_max_${DATATYPE_IMPL}(xnn_max_${DATATYPE_IMPL}(vi0, vi1), vi8);
         const xnn_simd_${DATATYPE_IMPL}_t vmax23 = xnn_max_${DATATYPE_IMPL}(vi2, vi3);
@@ -159,7 +156,7 @@ $elif DATATYPE == "f16" and ARCH != "neonfp16arith":
       $if SIMD_SIZE > 1:
         if (c > 0) {
           $for K in range(9):
-            const xnn_simd_${DATATYPE_IMPL}_t vi${K} = xnn_load_tail_impl(i${K}, c);
+            const xnn_simd_${DATATYPE_IMPL}_t vi${K} = xnn_load_tail_safe_impl(i${K}, c);
           const xnn_simd_${DATATYPE_IMPL}_t vprev = xnn_load_tail_safe_impl(o, c);
 
           const xnn_simd_${DATATYPE_IMPL}_t vmax018 = xnn_max_${DATATYPE_IMPL}(xnn_max_${DATATYPE_IMPL}(vi0, vi1), vi8);

--- a/src/s8-maxpool/gen/s8-maxpool-9p-minmax-neon-u16.c
+++ b/src/s8-maxpool/gen/s8-maxpool-9p-minmax-neon-u16.c
@@ -16,7 +16,6 @@
 // On some architectures, we have max(u8, u8) but not max(s8, s8). We can emulate max(s8, s8) on these architectures by
 // xoring with the sign bit mask.
 #define xnn_load_impl(x) xnn_loadu_s8(x)
-#define xnn_load_tail_impl(x, c) xnn_load_tail_s8(x, c)
 #define xnn_load_tail_safe_impl(x, c) xnn_load_tail_safe_s8(x, c)
 #define xnn_pre_store_impl(x) x
 
@@ -98,15 +97,15 @@ void xnn_s8_maxpool_minmax_ukernel_9p__neon_u16(
       xnn_storeu_s8(o, vacc); o += 16;
     }
     if (c > 0) {
-      const xnn_simd_s8_t vi0 = xnn_load_tail_impl(i0, c);
-      const xnn_simd_s8_t vi1 = xnn_load_tail_impl(i1, c);
-      const xnn_simd_s8_t vi2 = xnn_load_tail_impl(i2, c);
-      const xnn_simd_s8_t vi3 = xnn_load_tail_impl(i3, c);
-      const xnn_simd_s8_t vi4 = xnn_load_tail_impl(i4, c);
-      const xnn_simd_s8_t vi5 = xnn_load_tail_impl(i5, c);
-      const xnn_simd_s8_t vi6 = xnn_load_tail_impl(i6, c);
-      const xnn_simd_s8_t vi7 = xnn_load_tail_impl(i7, c);
-      const xnn_simd_s8_t vi8 = xnn_load_tail_impl(i8, c);
+      const xnn_simd_s8_t vi0 = xnn_load_tail_safe_impl(i0, c);
+      const xnn_simd_s8_t vi1 = xnn_load_tail_safe_impl(i1, c);
+      const xnn_simd_s8_t vi2 = xnn_load_tail_safe_impl(i2, c);
+      const xnn_simd_s8_t vi3 = xnn_load_tail_safe_impl(i3, c);
+      const xnn_simd_s8_t vi4 = xnn_load_tail_safe_impl(i4, c);
+      const xnn_simd_s8_t vi5 = xnn_load_tail_safe_impl(i5, c);
+      const xnn_simd_s8_t vi6 = xnn_load_tail_safe_impl(i6, c);
+      const xnn_simd_s8_t vi7 = xnn_load_tail_safe_impl(i7, c);
+      const xnn_simd_s8_t vi8 = xnn_load_tail_safe_impl(i8, c);
 
       const xnn_simd_s8_t vmax018 = xnn_max_s8(xnn_max_s8(vi0, vi1), vi8);
       const xnn_simd_s8_t vmax23 = xnn_max_s8(vi2, vi3);
@@ -179,15 +178,15 @@ void xnn_s8_maxpool_minmax_ukernel_9p__neon_u16(
         xnn_storeu_s8(o, vacc); o += 16;
       }
       if (c > 0) {
-        const xnn_simd_s8_t vi0 = xnn_load_tail_impl(i0, c);
-        const xnn_simd_s8_t vi1 = xnn_load_tail_impl(i1, c);
-        const xnn_simd_s8_t vi2 = xnn_load_tail_impl(i2, c);
-        const xnn_simd_s8_t vi3 = xnn_load_tail_impl(i3, c);
-        const xnn_simd_s8_t vi4 = xnn_load_tail_impl(i4, c);
-        const xnn_simd_s8_t vi5 = xnn_load_tail_impl(i5, c);
-        const xnn_simd_s8_t vi6 = xnn_load_tail_impl(i6, c);
-        const xnn_simd_s8_t vi7 = xnn_load_tail_impl(i7, c);
-        const xnn_simd_s8_t vi8 = xnn_load_tail_impl(i8, c);
+        const xnn_simd_s8_t vi0 = xnn_load_tail_safe_impl(i0, c);
+        const xnn_simd_s8_t vi1 = xnn_load_tail_safe_impl(i1, c);
+        const xnn_simd_s8_t vi2 = xnn_load_tail_safe_impl(i2, c);
+        const xnn_simd_s8_t vi3 = xnn_load_tail_safe_impl(i3, c);
+        const xnn_simd_s8_t vi4 = xnn_load_tail_safe_impl(i4, c);
+        const xnn_simd_s8_t vi5 = xnn_load_tail_safe_impl(i5, c);
+        const xnn_simd_s8_t vi6 = xnn_load_tail_safe_impl(i6, c);
+        const xnn_simd_s8_t vi7 = xnn_load_tail_safe_impl(i7, c);
+        const xnn_simd_s8_t vi8 = xnn_load_tail_safe_impl(i8, c);
         const xnn_simd_s8_t vprev = xnn_load_tail_safe_impl(o, c);
 
         const xnn_simd_s8_t vmax018 = xnn_max_s8(xnn_max_s8(vi0, vi1), vi8);

--- a/src/s8-maxpool/gen/s8-maxpool-9p-minmax-scalar-u1.c
+++ b/src/s8-maxpool/gen/s8-maxpool-9p-minmax-scalar-u1.c
@@ -16,7 +16,6 @@
 // On some architectures, we have max(u8, u8) but not max(s8, s8). We can emulate max(s8, s8) on these architectures by
 // xoring with the sign bit mask.
 #define xnn_load_impl(x) xnn_loadu_s8(x)
-#define xnn_load_tail_impl(x, c) xnn_load_tail_s8(x, c)
 #define xnn_load_tail_safe_impl(x, c) xnn_load_tail_safe_s8(x, c)
 #define xnn_pre_store_impl(x) x
 

--- a/src/s8-maxpool/gen/s8-maxpool-9p-minmax-sse41-u16.c
+++ b/src/s8-maxpool/gen/s8-maxpool-9p-minmax-sse41-u16.c
@@ -16,7 +16,6 @@
 // On some architectures, we have max(u8, u8) but not max(s8, s8). We can emulate max(s8, s8) on these architectures by
 // xoring with the sign bit mask.
 #define xnn_load_impl(x) xnn_loadu_s8(x)
-#define xnn_load_tail_impl(x, c) xnn_load_tail_s8(x, c)
 #define xnn_load_tail_safe_impl(x, c) xnn_load_tail_safe_s8(x, c)
 #define xnn_pre_store_impl(x) x
 
@@ -98,15 +97,15 @@ void xnn_s8_maxpool_minmax_ukernel_9p__sse41_u16(
       xnn_storeu_s8(o, vacc); o += 16;
     }
     if (c > 0) {
-      const xnn_simd_s8_t vi0 = xnn_load_tail_impl(i0, c);
-      const xnn_simd_s8_t vi1 = xnn_load_tail_impl(i1, c);
-      const xnn_simd_s8_t vi2 = xnn_load_tail_impl(i2, c);
-      const xnn_simd_s8_t vi3 = xnn_load_tail_impl(i3, c);
-      const xnn_simd_s8_t vi4 = xnn_load_tail_impl(i4, c);
-      const xnn_simd_s8_t vi5 = xnn_load_tail_impl(i5, c);
-      const xnn_simd_s8_t vi6 = xnn_load_tail_impl(i6, c);
-      const xnn_simd_s8_t vi7 = xnn_load_tail_impl(i7, c);
-      const xnn_simd_s8_t vi8 = xnn_load_tail_impl(i8, c);
+      const xnn_simd_s8_t vi0 = xnn_load_tail_safe_impl(i0, c);
+      const xnn_simd_s8_t vi1 = xnn_load_tail_safe_impl(i1, c);
+      const xnn_simd_s8_t vi2 = xnn_load_tail_safe_impl(i2, c);
+      const xnn_simd_s8_t vi3 = xnn_load_tail_safe_impl(i3, c);
+      const xnn_simd_s8_t vi4 = xnn_load_tail_safe_impl(i4, c);
+      const xnn_simd_s8_t vi5 = xnn_load_tail_safe_impl(i5, c);
+      const xnn_simd_s8_t vi6 = xnn_load_tail_safe_impl(i6, c);
+      const xnn_simd_s8_t vi7 = xnn_load_tail_safe_impl(i7, c);
+      const xnn_simd_s8_t vi8 = xnn_load_tail_safe_impl(i8, c);
 
       const xnn_simd_s8_t vmax018 = xnn_max_s8(xnn_max_s8(vi0, vi1), vi8);
       const xnn_simd_s8_t vmax23 = xnn_max_s8(vi2, vi3);
@@ -179,15 +178,15 @@ void xnn_s8_maxpool_minmax_ukernel_9p__sse41_u16(
         xnn_storeu_s8(o, vacc); o += 16;
       }
       if (c > 0) {
-        const xnn_simd_s8_t vi0 = xnn_load_tail_impl(i0, c);
-        const xnn_simd_s8_t vi1 = xnn_load_tail_impl(i1, c);
-        const xnn_simd_s8_t vi2 = xnn_load_tail_impl(i2, c);
-        const xnn_simd_s8_t vi3 = xnn_load_tail_impl(i3, c);
-        const xnn_simd_s8_t vi4 = xnn_load_tail_impl(i4, c);
-        const xnn_simd_s8_t vi5 = xnn_load_tail_impl(i5, c);
-        const xnn_simd_s8_t vi6 = xnn_load_tail_impl(i6, c);
-        const xnn_simd_s8_t vi7 = xnn_load_tail_impl(i7, c);
-        const xnn_simd_s8_t vi8 = xnn_load_tail_impl(i8, c);
+        const xnn_simd_s8_t vi0 = xnn_load_tail_safe_impl(i0, c);
+        const xnn_simd_s8_t vi1 = xnn_load_tail_safe_impl(i1, c);
+        const xnn_simd_s8_t vi2 = xnn_load_tail_safe_impl(i2, c);
+        const xnn_simd_s8_t vi3 = xnn_load_tail_safe_impl(i3, c);
+        const xnn_simd_s8_t vi4 = xnn_load_tail_safe_impl(i4, c);
+        const xnn_simd_s8_t vi5 = xnn_load_tail_safe_impl(i5, c);
+        const xnn_simd_s8_t vi6 = xnn_load_tail_safe_impl(i6, c);
+        const xnn_simd_s8_t vi7 = xnn_load_tail_safe_impl(i7, c);
+        const xnn_simd_s8_t vi8 = xnn_load_tail_safe_impl(i8, c);
         const xnn_simd_s8_t vprev = xnn_load_tail_safe_impl(o, c);
 
         const xnn_simd_s8_t vmax018 = xnn_max_s8(xnn_max_s8(vi0, vi1), vi8);

--- a/src/s8-maxpool/gen/s8-maxpool-9p-minmax-wasmsimd-u16.c
+++ b/src/s8-maxpool/gen/s8-maxpool-9p-minmax-wasmsimd-u16.c
@@ -16,7 +16,6 @@
 // On some architectures, we have max(u8, u8) but not max(s8, s8). We can emulate max(s8, s8) on these architectures by
 // xoring with the sign bit mask.
 #define xnn_load_impl(x) xnn_loadu_s8(x)
-#define xnn_load_tail_impl(x, c) xnn_load_tail_s8(x, c)
 #define xnn_load_tail_safe_impl(x, c) xnn_load_tail_safe_s8(x, c)
 #define xnn_pre_store_impl(x) x
 
@@ -98,15 +97,15 @@ void xnn_s8_maxpool_minmax_ukernel_9p__wasmsimd_u16(
       xnn_storeu_s8(o, vacc); o += 16;
     }
     if (c > 0) {
-      const xnn_simd_s8_t vi0 = xnn_load_tail_impl(i0, c);
-      const xnn_simd_s8_t vi1 = xnn_load_tail_impl(i1, c);
-      const xnn_simd_s8_t vi2 = xnn_load_tail_impl(i2, c);
-      const xnn_simd_s8_t vi3 = xnn_load_tail_impl(i3, c);
-      const xnn_simd_s8_t vi4 = xnn_load_tail_impl(i4, c);
-      const xnn_simd_s8_t vi5 = xnn_load_tail_impl(i5, c);
-      const xnn_simd_s8_t vi6 = xnn_load_tail_impl(i6, c);
-      const xnn_simd_s8_t vi7 = xnn_load_tail_impl(i7, c);
-      const xnn_simd_s8_t vi8 = xnn_load_tail_impl(i8, c);
+      const xnn_simd_s8_t vi0 = xnn_load_tail_safe_impl(i0, c);
+      const xnn_simd_s8_t vi1 = xnn_load_tail_safe_impl(i1, c);
+      const xnn_simd_s8_t vi2 = xnn_load_tail_safe_impl(i2, c);
+      const xnn_simd_s8_t vi3 = xnn_load_tail_safe_impl(i3, c);
+      const xnn_simd_s8_t vi4 = xnn_load_tail_safe_impl(i4, c);
+      const xnn_simd_s8_t vi5 = xnn_load_tail_safe_impl(i5, c);
+      const xnn_simd_s8_t vi6 = xnn_load_tail_safe_impl(i6, c);
+      const xnn_simd_s8_t vi7 = xnn_load_tail_safe_impl(i7, c);
+      const xnn_simd_s8_t vi8 = xnn_load_tail_safe_impl(i8, c);
 
       const xnn_simd_s8_t vmax018 = xnn_max_s8(xnn_max_s8(vi0, vi1), vi8);
       const xnn_simd_s8_t vmax23 = xnn_max_s8(vi2, vi3);
@@ -179,15 +178,15 @@ void xnn_s8_maxpool_minmax_ukernel_9p__wasmsimd_u16(
         xnn_storeu_s8(o, vacc); o += 16;
       }
       if (c > 0) {
-        const xnn_simd_s8_t vi0 = xnn_load_tail_impl(i0, c);
-        const xnn_simd_s8_t vi1 = xnn_load_tail_impl(i1, c);
-        const xnn_simd_s8_t vi2 = xnn_load_tail_impl(i2, c);
-        const xnn_simd_s8_t vi3 = xnn_load_tail_impl(i3, c);
-        const xnn_simd_s8_t vi4 = xnn_load_tail_impl(i4, c);
-        const xnn_simd_s8_t vi5 = xnn_load_tail_impl(i5, c);
-        const xnn_simd_s8_t vi6 = xnn_load_tail_impl(i6, c);
-        const xnn_simd_s8_t vi7 = xnn_load_tail_impl(i7, c);
-        const xnn_simd_s8_t vi8 = xnn_load_tail_impl(i8, c);
+        const xnn_simd_s8_t vi0 = xnn_load_tail_safe_impl(i0, c);
+        const xnn_simd_s8_t vi1 = xnn_load_tail_safe_impl(i1, c);
+        const xnn_simd_s8_t vi2 = xnn_load_tail_safe_impl(i2, c);
+        const xnn_simd_s8_t vi3 = xnn_load_tail_safe_impl(i3, c);
+        const xnn_simd_s8_t vi4 = xnn_load_tail_safe_impl(i4, c);
+        const xnn_simd_s8_t vi5 = xnn_load_tail_safe_impl(i5, c);
+        const xnn_simd_s8_t vi6 = xnn_load_tail_safe_impl(i6, c);
+        const xnn_simd_s8_t vi7 = xnn_load_tail_safe_impl(i7, c);
+        const xnn_simd_s8_t vi8 = xnn_load_tail_safe_impl(i8, c);
         const xnn_simd_s8_t vprev = xnn_load_tail_safe_impl(o, c);
 
         const xnn_simd_s8_t vmax018 = xnn_max_s8(xnn_max_s8(vi0, vi1), vi8);

--- a/src/u8-maxpool/gen/u8-maxpool-9p-minmax-neon-u16.c
+++ b/src/u8-maxpool/gen/u8-maxpool-9p-minmax-neon-u16.c
@@ -16,7 +16,6 @@
 // On some architectures, we have max(u8, u8) but not max(s8, s8). We can emulate max(s8, s8) on these architectures by
 // xoring with the sign bit mask.
 #define xnn_load_impl(x) xnn_loadu_u8(x)
-#define xnn_load_tail_impl(x, c) xnn_load_tail_u8(x, c)
 #define xnn_load_tail_safe_impl(x, c) xnn_load_tail_safe_u8(x, c)
 #define xnn_pre_store_impl(x) x
 
@@ -98,15 +97,15 @@ void xnn_u8_maxpool_minmax_ukernel_9p__neon_u16(
       xnn_storeu_u8(o, vacc); o += 16;
     }
     if (c > 0) {
-      const xnn_simd_u8_t vi0 = xnn_load_tail_impl(i0, c);
-      const xnn_simd_u8_t vi1 = xnn_load_tail_impl(i1, c);
-      const xnn_simd_u8_t vi2 = xnn_load_tail_impl(i2, c);
-      const xnn_simd_u8_t vi3 = xnn_load_tail_impl(i3, c);
-      const xnn_simd_u8_t vi4 = xnn_load_tail_impl(i4, c);
-      const xnn_simd_u8_t vi5 = xnn_load_tail_impl(i5, c);
-      const xnn_simd_u8_t vi6 = xnn_load_tail_impl(i6, c);
-      const xnn_simd_u8_t vi7 = xnn_load_tail_impl(i7, c);
-      const xnn_simd_u8_t vi8 = xnn_load_tail_impl(i8, c);
+      const xnn_simd_u8_t vi0 = xnn_load_tail_safe_impl(i0, c);
+      const xnn_simd_u8_t vi1 = xnn_load_tail_safe_impl(i1, c);
+      const xnn_simd_u8_t vi2 = xnn_load_tail_safe_impl(i2, c);
+      const xnn_simd_u8_t vi3 = xnn_load_tail_safe_impl(i3, c);
+      const xnn_simd_u8_t vi4 = xnn_load_tail_safe_impl(i4, c);
+      const xnn_simd_u8_t vi5 = xnn_load_tail_safe_impl(i5, c);
+      const xnn_simd_u8_t vi6 = xnn_load_tail_safe_impl(i6, c);
+      const xnn_simd_u8_t vi7 = xnn_load_tail_safe_impl(i7, c);
+      const xnn_simd_u8_t vi8 = xnn_load_tail_safe_impl(i8, c);
 
       const xnn_simd_u8_t vmax018 = xnn_max_u8(xnn_max_u8(vi0, vi1), vi8);
       const xnn_simd_u8_t vmax23 = xnn_max_u8(vi2, vi3);
@@ -179,15 +178,15 @@ void xnn_u8_maxpool_minmax_ukernel_9p__neon_u16(
         xnn_storeu_u8(o, vacc); o += 16;
       }
       if (c > 0) {
-        const xnn_simd_u8_t vi0 = xnn_load_tail_impl(i0, c);
-        const xnn_simd_u8_t vi1 = xnn_load_tail_impl(i1, c);
-        const xnn_simd_u8_t vi2 = xnn_load_tail_impl(i2, c);
-        const xnn_simd_u8_t vi3 = xnn_load_tail_impl(i3, c);
-        const xnn_simd_u8_t vi4 = xnn_load_tail_impl(i4, c);
-        const xnn_simd_u8_t vi5 = xnn_load_tail_impl(i5, c);
-        const xnn_simd_u8_t vi6 = xnn_load_tail_impl(i6, c);
-        const xnn_simd_u8_t vi7 = xnn_load_tail_impl(i7, c);
-        const xnn_simd_u8_t vi8 = xnn_load_tail_impl(i8, c);
+        const xnn_simd_u8_t vi0 = xnn_load_tail_safe_impl(i0, c);
+        const xnn_simd_u8_t vi1 = xnn_load_tail_safe_impl(i1, c);
+        const xnn_simd_u8_t vi2 = xnn_load_tail_safe_impl(i2, c);
+        const xnn_simd_u8_t vi3 = xnn_load_tail_safe_impl(i3, c);
+        const xnn_simd_u8_t vi4 = xnn_load_tail_safe_impl(i4, c);
+        const xnn_simd_u8_t vi5 = xnn_load_tail_safe_impl(i5, c);
+        const xnn_simd_u8_t vi6 = xnn_load_tail_safe_impl(i6, c);
+        const xnn_simd_u8_t vi7 = xnn_load_tail_safe_impl(i7, c);
+        const xnn_simd_u8_t vi8 = xnn_load_tail_safe_impl(i8, c);
         const xnn_simd_u8_t vprev = xnn_load_tail_safe_impl(o, c);
 
         const xnn_simd_u8_t vmax018 = xnn_max_u8(xnn_max_u8(vi0, vi1), vi8);

--- a/src/u8-maxpool/gen/u8-maxpool-9p-minmax-scalar-u1.c
+++ b/src/u8-maxpool/gen/u8-maxpool-9p-minmax-scalar-u1.c
@@ -16,7 +16,6 @@
 // On some architectures, we have max(u8, u8) but not max(s8, s8). We can emulate max(s8, s8) on these architectures by
 // xoring with the sign bit mask.
 #define xnn_load_impl(x) xnn_loadu_u8(x)
-#define xnn_load_tail_impl(x, c) xnn_load_tail_u8(x, c)
 #define xnn_load_tail_safe_impl(x, c) xnn_load_tail_safe_u8(x, c)
 #define xnn_pre_store_impl(x) x
 

--- a/src/u8-maxpool/gen/u8-maxpool-9p-minmax-sse2-u16.c
+++ b/src/u8-maxpool/gen/u8-maxpool-9p-minmax-sse2-u16.c
@@ -16,7 +16,6 @@
 // On some architectures, we have max(u8, u8) but not max(s8, s8). We can emulate max(s8, s8) on these architectures by
 // xoring with the sign bit mask.
 #define xnn_load_impl(x) xnn_loadu_u8(x)
-#define xnn_load_tail_impl(x, c) xnn_load_tail_u8(x, c)
 #define xnn_load_tail_safe_impl(x, c) xnn_load_tail_safe_u8(x, c)
 #define xnn_pre_store_impl(x) x
 
@@ -98,15 +97,15 @@ void xnn_u8_maxpool_minmax_ukernel_9p__sse2_u16(
       xnn_storeu_u8(o, vacc); o += 16;
     }
     if (c > 0) {
-      const xnn_simd_u8_t vi0 = xnn_load_tail_impl(i0, c);
-      const xnn_simd_u8_t vi1 = xnn_load_tail_impl(i1, c);
-      const xnn_simd_u8_t vi2 = xnn_load_tail_impl(i2, c);
-      const xnn_simd_u8_t vi3 = xnn_load_tail_impl(i3, c);
-      const xnn_simd_u8_t vi4 = xnn_load_tail_impl(i4, c);
-      const xnn_simd_u8_t vi5 = xnn_load_tail_impl(i5, c);
-      const xnn_simd_u8_t vi6 = xnn_load_tail_impl(i6, c);
-      const xnn_simd_u8_t vi7 = xnn_load_tail_impl(i7, c);
-      const xnn_simd_u8_t vi8 = xnn_load_tail_impl(i8, c);
+      const xnn_simd_u8_t vi0 = xnn_load_tail_safe_impl(i0, c);
+      const xnn_simd_u8_t vi1 = xnn_load_tail_safe_impl(i1, c);
+      const xnn_simd_u8_t vi2 = xnn_load_tail_safe_impl(i2, c);
+      const xnn_simd_u8_t vi3 = xnn_load_tail_safe_impl(i3, c);
+      const xnn_simd_u8_t vi4 = xnn_load_tail_safe_impl(i4, c);
+      const xnn_simd_u8_t vi5 = xnn_load_tail_safe_impl(i5, c);
+      const xnn_simd_u8_t vi6 = xnn_load_tail_safe_impl(i6, c);
+      const xnn_simd_u8_t vi7 = xnn_load_tail_safe_impl(i7, c);
+      const xnn_simd_u8_t vi8 = xnn_load_tail_safe_impl(i8, c);
 
       const xnn_simd_u8_t vmax018 = xnn_max_u8(xnn_max_u8(vi0, vi1), vi8);
       const xnn_simd_u8_t vmax23 = xnn_max_u8(vi2, vi3);
@@ -179,15 +178,15 @@ void xnn_u8_maxpool_minmax_ukernel_9p__sse2_u16(
         xnn_storeu_u8(o, vacc); o += 16;
       }
       if (c > 0) {
-        const xnn_simd_u8_t vi0 = xnn_load_tail_impl(i0, c);
-        const xnn_simd_u8_t vi1 = xnn_load_tail_impl(i1, c);
-        const xnn_simd_u8_t vi2 = xnn_load_tail_impl(i2, c);
-        const xnn_simd_u8_t vi3 = xnn_load_tail_impl(i3, c);
-        const xnn_simd_u8_t vi4 = xnn_load_tail_impl(i4, c);
-        const xnn_simd_u8_t vi5 = xnn_load_tail_impl(i5, c);
-        const xnn_simd_u8_t vi6 = xnn_load_tail_impl(i6, c);
-        const xnn_simd_u8_t vi7 = xnn_load_tail_impl(i7, c);
-        const xnn_simd_u8_t vi8 = xnn_load_tail_impl(i8, c);
+        const xnn_simd_u8_t vi0 = xnn_load_tail_safe_impl(i0, c);
+        const xnn_simd_u8_t vi1 = xnn_load_tail_safe_impl(i1, c);
+        const xnn_simd_u8_t vi2 = xnn_load_tail_safe_impl(i2, c);
+        const xnn_simd_u8_t vi3 = xnn_load_tail_safe_impl(i3, c);
+        const xnn_simd_u8_t vi4 = xnn_load_tail_safe_impl(i4, c);
+        const xnn_simd_u8_t vi5 = xnn_load_tail_safe_impl(i5, c);
+        const xnn_simd_u8_t vi6 = xnn_load_tail_safe_impl(i6, c);
+        const xnn_simd_u8_t vi7 = xnn_load_tail_safe_impl(i7, c);
+        const xnn_simd_u8_t vi8 = xnn_load_tail_safe_impl(i8, c);
         const xnn_simd_u8_t vprev = xnn_load_tail_safe_impl(o, c);
 
         const xnn_simd_u8_t vmax018 = xnn_max_u8(xnn_max_u8(vi0, vi1), vi8);

--- a/src/u8-maxpool/gen/u8-maxpool-9p-minmax-wasmsimd-u16.c
+++ b/src/u8-maxpool/gen/u8-maxpool-9p-minmax-wasmsimd-u16.c
@@ -16,7 +16,6 @@
 // On some architectures, we have max(u8, u8) but not max(s8, s8). We can emulate max(s8, s8) on these architectures by
 // xoring with the sign bit mask.
 #define xnn_load_impl(x) xnn_loadu_u8(x)
-#define xnn_load_tail_impl(x, c) xnn_load_tail_u8(x, c)
 #define xnn_load_tail_safe_impl(x, c) xnn_load_tail_safe_u8(x, c)
 #define xnn_pre_store_impl(x) x
 
@@ -98,15 +97,15 @@ void xnn_u8_maxpool_minmax_ukernel_9p__wasmsimd_u16(
       xnn_storeu_u8(o, vacc); o += 16;
     }
     if (c > 0) {
-      const xnn_simd_u8_t vi0 = xnn_load_tail_impl(i0, c);
-      const xnn_simd_u8_t vi1 = xnn_load_tail_impl(i1, c);
-      const xnn_simd_u8_t vi2 = xnn_load_tail_impl(i2, c);
-      const xnn_simd_u8_t vi3 = xnn_load_tail_impl(i3, c);
-      const xnn_simd_u8_t vi4 = xnn_load_tail_impl(i4, c);
-      const xnn_simd_u8_t vi5 = xnn_load_tail_impl(i5, c);
-      const xnn_simd_u8_t vi6 = xnn_load_tail_impl(i6, c);
-      const xnn_simd_u8_t vi7 = xnn_load_tail_impl(i7, c);
-      const xnn_simd_u8_t vi8 = xnn_load_tail_impl(i8, c);
+      const xnn_simd_u8_t vi0 = xnn_load_tail_safe_impl(i0, c);
+      const xnn_simd_u8_t vi1 = xnn_load_tail_safe_impl(i1, c);
+      const xnn_simd_u8_t vi2 = xnn_load_tail_safe_impl(i2, c);
+      const xnn_simd_u8_t vi3 = xnn_load_tail_safe_impl(i3, c);
+      const xnn_simd_u8_t vi4 = xnn_load_tail_safe_impl(i4, c);
+      const xnn_simd_u8_t vi5 = xnn_load_tail_safe_impl(i5, c);
+      const xnn_simd_u8_t vi6 = xnn_load_tail_safe_impl(i6, c);
+      const xnn_simd_u8_t vi7 = xnn_load_tail_safe_impl(i7, c);
+      const xnn_simd_u8_t vi8 = xnn_load_tail_safe_impl(i8, c);
 
       const xnn_simd_u8_t vmax018 = xnn_max_u8(xnn_max_u8(vi0, vi1), vi8);
       const xnn_simd_u8_t vmax23 = xnn_max_u8(vi2, vi3);
@@ -179,15 +178,15 @@ void xnn_u8_maxpool_minmax_ukernel_9p__wasmsimd_u16(
         xnn_storeu_u8(o, vacc); o += 16;
       }
       if (c > 0) {
-        const xnn_simd_u8_t vi0 = xnn_load_tail_impl(i0, c);
-        const xnn_simd_u8_t vi1 = xnn_load_tail_impl(i1, c);
-        const xnn_simd_u8_t vi2 = xnn_load_tail_impl(i2, c);
-        const xnn_simd_u8_t vi3 = xnn_load_tail_impl(i3, c);
-        const xnn_simd_u8_t vi4 = xnn_load_tail_impl(i4, c);
-        const xnn_simd_u8_t vi5 = xnn_load_tail_impl(i5, c);
-        const xnn_simd_u8_t vi6 = xnn_load_tail_impl(i6, c);
-        const xnn_simd_u8_t vi7 = xnn_load_tail_impl(i7, c);
-        const xnn_simd_u8_t vi8 = xnn_load_tail_impl(i8, c);
+        const xnn_simd_u8_t vi0 = xnn_load_tail_safe_impl(i0, c);
+        const xnn_simd_u8_t vi1 = xnn_load_tail_safe_impl(i1, c);
+        const xnn_simd_u8_t vi2 = xnn_load_tail_safe_impl(i2, c);
+        const xnn_simd_u8_t vi3 = xnn_load_tail_safe_impl(i3, c);
+        const xnn_simd_u8_t vi4 = xnn_load_tail_safe_impl(i4, c);
+        const xnn_simd_u8_t vi5 = xnn_load_tail_safe_impl(i5, c);
+        const xnn_simd_u8_t vi6 = xnn_load_tail_safe_impl(i6, c);
+        const xnn_simd_u8_t vi7 = xnn_load_tail_safe_impl(i7, c);
+        const xnn_simd_u8_t vi8 = xnn_load_tail_safe_impl(i8, c);
         const xnn_simd_u8_t vprev = xnn_load_tail_safe_impl(o, c);
 
         const xnn_simd_u8_t vmax018 = xnn_max_u8(xnn_max_u8(vi0, vi1), vi8);


### PR DESCRIPTION
The maxpool kernel uses `xnn_load_tail_impl` for input reads in the tail section. On SSE2 for example, `xnn_load_tail_u8` performs a full 16-byte `_mm_loadu_si128` even when fewer bytes are valid. This out-of-bounds read is annotated with `XNN_OOB_READS` to suppress sanitizer warnings, but it can cause a real SEGV when the input tensor's last valid bytes are near a page boundary and the overread crosses into unmapped memory.

This PR fixes the issue by switching the tail section input loads from `xnn_load_tail_impl` to `xnn_load_tail_safe_impl`. This change affects both the template (maxpool.c.in) and all generated maxpool kernels (f16, f32, s8, u8) across SSE2, SSE4.1, AVX2, NEON, WASM SIMD, and HVX backends.

Chromium issue: https://issues.chromium.org/issues/506960160