### PR TITLE
ci: declare permissions on the four reusable-workflow entry points

### DIFF
--- a/.github/workflows/on-pr-approved.yml
+++ b/.github/workflows/on-pr-approved.yml
@@ -3,6 +3,10 @@ run-name: ${{ github.event.pull_request.title }}
 on:
   pull_request_review:
     types: [submitted]
+permissions:
+  contents: read   # checkout in the called workflow
+  actions: write   # cache restore + save in the called workflow (actions/cache@v5)
+
 jobs:
   build-and-test:
     if: github.event.review.state == 'APPROVED'

--- a/.github/workflows/on-pr-merge-to-master.yml
+++ b/.github/workflows/on-pr-merge-to-master.yml
@@ -6,6 +6,10 @@ on:
       - 'docker/**'
   workflow_dispatch:
 
+permissions:
+  contents: read   # checkout in the called workflow
+  actions: write   # cache restore + save in the called workflow (actions/cache@v5)
+
 jobs:
   build-and-test:
     uses: ./.github/workflows/build.yml

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -6,6 +6,10 @@ on:
       - master
   workflow_dispatch:
 
+permissions:
+  contents: read   # checkout in the called workflow
+  actions: write   # cache restore + save in the called workflow (actions/cache@v5)
+
 jobs:
   build-and-test:
     uses: ./.github/workflows/build.yml

--- a/.github/workflows/sde-tests-linux-windows.yml
+++ b/.github/workflows/sde-tests-linux-windows.yml
@@ -7,6 +7,10 @@ env:
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read   # checkout in the called workflow
+  actions: write   # cache restore + save in the called workflow (actions/cache@v5)
+
 jobs:
 
   build:


### PR DESCRIPTION
Four caller workflows (`on-pr-approved`, `on-pr-merge-to-master`, `on-push`, `sde-tests-linux-windows`) delegate to `build.yml` / `build-linux-windows.yml`. The reusables themselves currently inherit the caller`s `GITHUB_TOKEN` since they declare no `permissions:` block.

Adding explicit scopes at the caller level keeps the reusables untouched (they have many callers; changing their declarations is riskier):

- **`contents: read`** — for `actions/checkout@v6` in the reusable
- **`actions: write`** — for `actions/cache@v5` save path. The action restores AND saves; on a cache miss the matrix needs to save at the end of the run, and that requires `actions: write` once the workflow stops inheriting the repo default scope.

YAML validates locally.