### PR TITLE
[RVV] add missing rvv f16 generators

### DIFF
--- a/scripts/generate-f16-vapproxgelu.sh
+++ b/scripts/generate-f16-vapproxgelu.sh
@@ -8,4 +8,9 @@
 tools/xngen src/f16-vapproxgelu/rational-6-4.c.in -D ARCH=scalar -D BATCH_TILES=1,2,4,8 -o src/f16-vapproxgelu/gen/f16-vapproxgelu-scalar-rational-6-4-div.c &
 tools/xngen src/f16-vapproxgelu/rational-6-4.c.in -D ARCH=neonfp16arith -D BATCH_TILES=8,16,32 -o src/f16-vapproxgelu/gen/f16-vapproxgelu-neonfp16arith-rational-6-4-div.c &
 
+################################## RISC-V Vector ###############################
+tools/xngen src/f16-vapproxgelu/rvvfp16arith-rational-6-4.c.in -D LMUL=1 -o src/f16-vapproxgelu/gen/f16-vapproxgelu-rvvfp16arith-rational-6-4-div-u1v.c &
+tools/xngen src/f16-vapproxgelu/rvvfp16arith-rational-6-4.c.in -D LMUL=2 -o src/f16-vapproxgelu/gen/f16-vapproxgelu-rvvfp16arith-rational-6-4-div-u2v.c &
+tools/xngen src/f16-vapproxgelu/rvvfp16arith-rational-6-4.c.in -D LMUL=4 -o src/f16-vapproxgelu/gen/f16-vapproxgelu-rvvfp16arith-rational-6-4-div-u4v.c &
+
 wait

--- a/scripts/generate-f16-vsigmoid.sh
+++ b/scripts/generate-f16-vsigmoid.sh
@@ -31,4 +31,9 @@ tools/xngen src/f16-vsigmoid/avx2.c.in -D BATCH_TILE=16 -D DIV_ALGO=rcp -o src/f
 tools/xngen src/f16-vsigmoid/avx2.c.in -D BATCH_TILE=24 -D DIV_ALGO=rcp -o src/f16-vsigmoid/gen/f16-vsigmoid-avx2-rr1-p2-rcp-u24.c &
 tools/xngen src/f16-vsigmoid/avx2.c.in -D BATCH_TILE=32 -D DIV_ALGO=rcp -o src/f16-vsigmoid/gen/f16-vsigmoid-avx2-rr1-p2-rcp-u32.c &
 
+################################## RISC-V Vector ##############################
+tools/xngen src/f16-vsigmoid/rvvfp16arith-rr2-p2.c.in -D LMUL=1 -o src/f16-vsigmoid/gen/f16-vsigmoid-rvvfp16arith-rr2-p2-u1v.c &
+tools/xngen src/f16-vsigmoid/rvvfp16arith-rr2-p2.c.in -D LMUL=2 -o src/f16-vsigmoid/gen/f16-vsigmoid-rvvfp16arith-rr2-p2-u2v.c &
+tools/xngen src/f16-vsigmoid/rvvfp16arith-rr2-p2.c.in -D LMUL=4 -o src/f16-vsigmoid/gen/f16-vsigmoid-rvvfp16arith-rr2-p2-u4v.c &
+
 wait

--- a/scripts/generate-f16-vtanh.sh
+++ b/scripts/generate-f16-vtanh.sh
@@ -62,6 +62,11 @@ tools/xngen src/f16-vtanh/neonfp16arith-expm1minus.c.in -D P=3 -D H=2 -D PS=0 -D
 tools/xngen src/f16-vtanh/neonfp16arith-expm1minus.c.in -D P=3 -D H=2 -D PS=0 -D BATCH_TILE=24 -D SAT=MINMAX -D DIV=RECPEADJ -o src/f16-vtanh/gen/f16-vtanh-neonfp16arith-expm1minus-rr1-p3h2ts-recpeadj-u24.c &
 tools/xngen src/f16-vtanh/neonfp16arith-expm1minus.c.in -D P=3 -D H=2 -D PS=0 -D BATCH_TILE=32 -D SAT=MINMAX -D DIV=RECPEADJ -o src/f16-vtanh/gen/f16-vtanh-neonfp16arith-expm1minus-rr1-p3h2ts-recpeadj-u32.c &
 
+################################## RISC-V Vector ##############################
+tools/xngen src/f16-vtanh/rvvfp16arith-expm1minus-rr1-p3h2ts.c.in -D LMUL=1 -o src/f16-vtanh/gen/f16-vtanh-rvvfp16arith-expm1minus-rr1-p3h2ts-div-u1v.c &
+tools/xngen src/f16-vtanh/rvvfp16arith-expm1minus-rr1-p3h2ts.c.in -D LMUL=2 -o src/f16-vtanh/gen/f16-vtanh-rvvfp16arith-expm1minus-rr1-p3h2ts-div-u2v.c &
+tools/xngen src/f16-vtanh/rvvfp16arith-expm1minus-rr1-p3h2ts.c.in -D LMUL=4 -o src/f16-vtanh/gen/f16-vtanh-rvvfp16arith-expm1minus-rr1-p3h2ts-div-u4v.c &
+
 ################################ Portable SIMD ################################
 tools/xngen src/f16-vtanh/simd-expm1minus.c.in -D ARCH=scalar -D P=3 -D H=2 -D PS=0 -D BATCH_TILES=1,2,4 -D DIV=DIV -o src/f16-vtanh/gen/f16-vtanh-scalar-expm1minus-rr1-p3h2ts-div.c &
 tools/xngen src/f16-vtanh/simd-expm1minus.c.in -D ARCH=avx512fp16 -D P=3 -D H=2 -D PS=0 -D BATCH_TILES=32,64 -D DIV=DIV -o src/f16-vtanh/gen/f16-vtanh-avx512fp16-expm1minus-rr1-p3h2ts-div.c &


### PR DESCRIPTION
I noticed f16 rvv generators were missing from a recent commit.  Generated kernels are unchanged. 