### PR TITLE
Fix Bazel Windows ARM64 MSVC config

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1515,6 +1515,8 @@ alias(
     actual = select({
         ":xnn_enable_arm_fp16_scalar_explicit_true": ":xnn_enable_arm_fp16_scalar_explicit_true",
         ":xnn_enable_arm_fp16_scalar_explicit_false": ":xnn_enable_arm_fp16_scalar_explicit_true",
+        # Disable for Windows ARM64 MSVC unless explicitly enabled
+        "//build_config:windows_arm64": ":xnn_enable_arm_fp16_scalar_explicit_true",
         "//conditions:default": ":arm_fp16_scalar_enabled_by_default",
     }),
 )
@@ -1580,6 +1582,8 @@ alias(
     actual = select({
         ":xnn_enable_arm_bf16_explicit_true": ":xnn_enable_arm_bf16_explicit_true",
         ":xnn_enable_arm_bf16_explicit_false": ":xnn_enable_arm_bf16_explicit_true",
+        # Disable for Windows ARM64 MSVC unless explicitly enabled
+        "//build_config:windows_arm64": ":xnn_enable_arm_bf16_explicit_true",
         "//conditions:default": ":arm_bf16_enabled_by_default",
     }),
 )
@@ -2077,7 +2081,7 @@ alias(
         ":xnn_enable_kleidiai_explicit_true": ":xnn_enable_kleidiai_explicit_true",
         ":xnn_enable_kleidiai_explicit_false": ":xnn_enable_kleidiai_explicit_true",
         # Disable for Windows ARM64 unless explicitly enabled
-        "//build_config:windows_aarch64": ":xnn_enable_kleidiai_explicit_true",
+        "//build_config:windows_arm64": ":xnn_enable_kleidiai_explicit_true",
         "//conditions:default": ":kleidiai_enabled_by_default",
     }),
 )
@@ -2094,6 +2098,8 @@ alias(
     actual = select({
         ":xnn_enable_assembly_explicit_true": ":xnn_enable_assembly_explicit_true",
         ":xnn_enable_assembly_explicit_false": ":xnn_enable_assembly_explicit_true",
+        # Disable for Windows ARM64 unless explicitly enabled
+        "//build_config:windows_arm64": ":xnn_enable_assembly_explicit_true",
         "//conditions:default": ":assembly_enabled_by_default",
     }),
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -87,6 +87,8 @@ http_archive(
 # cpuinfo library, used for detecting processor characteristics
 http_archive(
     name = "cpuinfo",
+    patch_args = ["-p1"],
+    patches = ["//:cpuinfo_windows_arm64_msvc.patch"],
     sha256 = "995316f224247d1611ab1b624a66bc5cbd5b5d2e5ce991ed68d983aac950ad8b",
     strip_prefix = "cpuinfo-bc3c01e230c6974283e4b89421cfb0e232435589",
     urls = [

--- a/build_config/BUILD.bazel
+++ b/build_config/BUILD.bazel
@@ -142,9 +142,9 @@ config_setting(
 )
 
 config_setting(
-    name = "windows_aarch64",
+    name = "windows_arm64",
     values = {
-         "cpu": "aarch64_windows",
+        "cpu": "arm64_windows",
     },
 )
 
@@ -340,6 +340,7 @@ selects.config_setting_group(
         ":macos_arm64",
         ":tvos_arm64",
         ":watchos_arm64_32",
+        ":windows_arm64",
     ],
 )
 
@@ -348,6 +349,7 @@ selects.config_setting_group(
     match_any = [
         ":aarch32",
         ":aarch64",
+        ":windows_arm64",
     ],
 )
 

--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -389,6 +389,7 @@ def xnnpack_cc_library(
             "//build_config:windows_x86_64_mingw": gcc_copts,
             "//build_config:windows_x86_64_msys": gcc_copts,
             "//build_config:windows_x86_64": msvc_copts,
+            "//build_config:windows_arm64": msvc_copts,
             "//conditions:default": gcc_copts,
         }) + select({
             "//:optimized_build": optimized_copts,
@@ -459,6 +460,7 @@ def xnnpack_unit_test(name, srcs, copts = [], mingw_copts = [], msys_copts = [],
             "//build_config:windows_x86_64_mingw": ["-Wno-unused-function"],
             "//build_config:windows_x86_64_msys": ["-Wno-unused-function"],
             "//build_config:windows_x86_64": [],
+            "//build_config:windows_arm64": [],
             "//conditions:default": ["-Wno-unused-function"],
         }) + copts,
         linkopts = select({
@@ -527,6 +529,7 @@ def xnnpack_benchmark(name, srcs, copts = [], deps = [], tags = [], defines = []
             "//build_config:windows_x86_64_mingw": ["-Wno-unused-function"],
             "//build_config:windows_x86_64_msys": ["-Wno-unused-function"],
             "//build_config:windows_x86_64": [],
+            "//build_config:windows_arm64": [],
             "//conditions:default": ["-Wno-unused-function"],
         }) + copts,
         linkopts = select({

--- a/build_params.bzl
+++ b/build_params.bzl
@@ -353,8 +353,11 @@ XNNPACK_PARAMS_FOR_ARCH = {
         copts = ["-march=armv8.2-a+fp16"],
     ),
     "neonbf16": _create_params(
-        cond = "//build_config:aarch64",
-        copts = ["-march=armv8.2-a+bf16"],
+        cond = "//:arm_bf16_enabled",
+        copts = select({
+            "//build_config:windows_arm64": [],
+            "//conditions:default": ["-march=armv8.2-a+bf16"],
+        }),
     ),
     "neondotfp16arith": _create_params(
         cond = "//:arm_neondotfp16_enabled",

--- a/cpuinfo_windows_arm64_msvc.patch
+++ b/cpuinfo_windows_arm64_msvc.patch
@@ -1,0 +1,39 @@
+diff --git a/BUILD.bazel b/BUILD.bazel
+index d78fb2de..6d3afe99 100644
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -199,6 +199,10 @@ cc_library(
+         ":macos_x86_64_legacy": False,
+         "//conditions:default": True,
+     }),
++    linkopts = select({
++        ":windows_arm64": ["Advapi32.lib"],
++        "//conditions:default": [],
++    }),
+     # Headers must be in textual_hdrs to allow us to set the standard to C99
+     textual_hdrs = [
+         "include/cpuinfo.h",
+@@ -217,6 +217,7 @@ cc_library(
+         "src/arm/android/api.h",
+         "src/arm/linux/api.h",
+         "src/arm/linux/cp.h",
++        "src/arm/windows/windows-arm-init.h",
+         "src/arm/api.h",
+         "src/arm/midr.h",
+         "src/riscv/api.h",
+diff --git a/src/arm/cache.c b/src/arm/cache.c
+index 9878223d..16fb6b14 100644
+--- a/src/arm/cache.c
++++ b/src/arm/cache.c
+@@ -13 +13 @@ void cpuinfo_arm_decode_cache(
+-	const struct cpuinfo_arm_chipset chipset[restrict static 1],
++	const struct cpuinfo_arm_chipset chipset[RESTRICT_STATIC 1],
+@@ -16,4 +16,4 @@ void cpuinfo_arm_decode_cache(
+-	struct cpuinfo_cache l1i[restrict static 1],
+-	struct cpuinfo_cache l1d[restrict static 1],
+-	struct cpuinfo_cache l2[restrict static 1],
+-	struct cpuinfo_cache l3[restrict static 1]) {
++	struct cpuinfo_cache l1i[RESTRICT_STATIC 1],
++	struct cpuinfo_cache l1d[RESTRICT_STATIC 1],
++	struct cpuinfo_cache l2[RESTRICT_STATIC 1],
++	struct cpuinfo_cache l3[RESTRICT_STATIC 1]) {


### PR DESCRIPTION
## Summary
The problem is:

Bazel’s Windows C++ toolchain path here uses arm64_windows. TensorFlow/XLA’s Windows toolchain definitions also key Windows ARM64 on arm64_windows. But XNNPACK currently keys its Windows ARM64 config on aarch64_windows.

## Reproduction
On Windows ARM64 with MSVC, upstream XNNPACK currently falls through to GCC std C flags for `--cpu=arm64_windows` and fails with:

```text
cl : Command line error D8021 : invalid numeric argument '/Wimplicit-fallthrough'
```
