### PR TITLE
Remove unnecessary xnn_subgraph_reserve_nodes() call in replace_node_with_lut()

### DIFF
--- a/src/subgraph.c
+++ b/src/subgraph.c
@@ -1905,7 +1905,6 @@ static bool replace_node_with_lut(xnn_subgraph_t subgraph,
                                   struct xnn_node* node, uint32_t input_id,
                                   uint32_t unary_input_id,
                                   xnn_subgraph_t unary_subgraph) {
-  XNN_RETURN_IF_ERROR(xnn_subgraph_reserve_nodes(subgraph, 1));
   XNN_RETURN_IF_ERROR(xnn_subgraph_reserve_values(subgraph, 1));
 
   const uint32_t unary_output_id =


### PR DESCRIPTION
`replace_node_with_lut()` rewrites the existing node in place via `xnn_define_unary_elementwise_lut_in_place()` and never adds a new node to the subgraph. The `xnn_subgraph_reserve_nodes(subgraph, 1)` call at the top of the function is therefore unnecessary.

When the nodes array capacity is insufficient, `xnn_subgraph_reserve_nodes()` calls `xnn_reallocate_memory()` which frees the old subgraph->nodes buffer and allocates a new one. This invalidates the node pointer passed in by the caller `xnn_subgraph_fuse_unary_quantized_into_lut`, as well as the nodes_to_fuse[] pointers it holds. Subsequent accesses
to [node->num_inputs] (and other fields) then read freed heap memory, causing a heap-use-after-free.

Chromium issue: https://issues.chromium.org/issues/513592061