### PR TITLE
Per-microkernel symbol-name and wall-time profiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -604,6 +604,7 @@ SET(XNNPACK_SRCS
   src/configs/xx-pad-config.c
   src/configs/x8-lut-config.c
   src/init.c
+  src/microkernel-name-registry.c
   src/params.c
   "${PROJECT_BINARY_DIR}/build_identifier.c")
 

--- a/include/xnnpack.h
+++ b/include/xnnpack.h
@@ -2414,6 +2414,13 @@ enum xnn_profile_info {
   xnn_profile_info_operator_name,
   /// Returns a uint64_t[] with the runtimes of all operators in the same order as xnn_profile_info_operator_name.
   xnn_profile_info_operator_timing,
+  /// Returns a char[] of null-separated C symbol names for the microkernel dispatched by each operator, in
+  /// the same order as xnn_profile_info_operator_name. Operators that don't go through the XNN_INIT_*_UKERNEL
+  /// macros contribute an empty string.
+  xnn_profile_info_microkernel_name,
+  /// Returns a uint64_t[] of accumulated microkernel wall time in microseconds, in the same order as
+  /// xnn_profile_info_microkernel_name. Zeroes when XNNPACK was built without -DXNN_ENABLE_UKERNEL_TIMING=1.
+  xnn_profile_info_microkernel_timing,
 };
 
 /// Return profile information for all operators.

--- a/src/configs/argmaxpool-config.c
+++ b/src/configs/argmaxpool-config.c
@@ -14,15 +14,17 @@
 #include "src/xnnpack/init-once.h"
 #include "src/xnnpack/log.h"
 #include "src/xnnpack/microfnptr.h"
+#include "src/xnnpack/microkernel-name-registry.h"
 
 static struct xnn_argmaxpool_config f32_argmaxpool_config = {0};
 
 XNN_INIT_ONCE_GUARD(f32_argmaxpool);
 
 // Macros to log the microkernel names if and when they are registered.
-#define XNN_INIT_ARGMAXPOOL_UKERNEL(ukernel)   \
-  (xnn_argmaxpool_unipass_ukernel_fn) ukernel; \
-  xnn_log_info("Using argmaxpool microkernel '%s'.", #ukernel);
+#define XNN_INIT_ARGMAXPOOL_UKERNEL(ukernel)                    \
+  (xnn_argmaxpool_unipass_ukernel_fn) ukernel;                  \
+  xnn_log_info("Using argmaxpool microkernel '%s'.", #ukernel); \
+  XNN_REGISTER_UKERNEL_NAME(ukernel);
 
 static void init_f32_argmaxpool_config(void) {
   f32_argmaxpool_config.primary_tile = 9;

--- a/src/configs/avgpool-config.c
+++ b/src/configs/avgpool-config.c
@@ -14,6 +14,7 @@
 #include "src/xnnpack/init-once.h"
 #include "src/xnnpack/log.h"
 #include "src/xnnpack/microfnptr.h"
+#include "src/xnnpack/microkernel-name-registry.h"
 #include "src/xnnpack/microparams-init.h"
 
 static struct xnn_avgpool_config f16_avgpool_config = {0};
@@ -23,9 +24,10 @@ XNN_INIT_ONCE_GUARD(f16_avgpool);
 XNN_INIT_ONCE_GUARD(f32_avgpool);
 
 // Macros to log the microkernel names if and when they are registered.
-#define XNN_INIT_AVGPOOL_UKERNEL(ukernel) \
-  (xnn_avgpool_ukernel_fn) ukernel;      \
-  xnn_log_info("Using avgpool microkernel '%s'.", #ukernel);
+#define XNN_INIT_AVGPOOL_UKERNEL(ukernel)                    \
+  (xnn_avgpool_ukernel_fn) ukernel;                          \
+  xnn_log_info("Using avgpool microkernel '%s'.", #ukernel); \
+  XNN_REGISTER_UKERNEL_NAME(ukernel);
 
 static void init_f16_avgpool_config(void) {
   #if XNN_ENABLE_ARM_FP16_VECTOR && (XNN_ARCH_ARM || XNN_ARCH_ARM64)

--- a/src/configs/binary-elementwise-config.c
+++ b/src/configs/binary-elementwise-config.c
@@ -13,6 +13,7 @@
 #include "src/xnnpack/init-once.h"
 #include "src/xnnpack/log.h"
 #include "src/xnnpack/microfnptr.h"
+#include "src/xnnpack/microkernel-name-registry.h"
 #include "src/xnnpack/microparams-init.h"
 #include "src/xnnpack/vbinary.h"
 
@@ -68,9 +69,10 @@ XNN_INIT_ONCE_GUARD(qu8_vmul);
 XNN_INIT_ONCE_GUARD(qu8_vprelu);
 
 // Macros to log the microkernel names if and when they are registered.
-#define XNN_INIT_BINARY_UKERNEL(ukernel) \
-  (xnn_vbinary_ukernel_fn) ukernel;      \
-  xnn_log_info("Using binary microkernel '%s'.", #ukernel);
+#define XNN_INIT_BINARY_UKERNEL(ukernel)                    \
+  (xnn_vbinary_ukernel_fn) ukernel;                         \
+  xnn_log_info("Using binary microkernel '%s'.", #ukernel); \
+  XNN_REGISTER_UKERNEL_NAME(ukernel);
 
 static void init_f16_vadd_config(void) {
   #if XNN_ENABLE_ARM_FP16_SCALAR && XNN_ENABLE_ARM_FP16_VECTOR && XNN_ARCH_ARM

--- a/src/configs/cmul-config.c
+++ b/src/configs/cmul-config.c
@@ -13,6 +13,7 @@
 #include "src/xnnpack/init-once.h"
 #include "src/xnnpack/log.h"
 #include "src/xnnpack/microfnptr.h"
+#include "src/xnnpack/microkernel-name-registry.h"
 #include "src/xnnpack/vbinary.h"
 
 #if XNN_ENABLE_ARM_FP16_VECTOR && (XNN_ARCH_ARM || XNN_ARCH_ARM64)
@@ -26,9 +27,10 @@ static struct xnn_cmul_config f32_cmul_config = {0};
 XNN_INIT_ONCE_GUARD(f32_cmul);
 
 // Macros to log the microkernel names if and when they are registered.
-#define XNN_INIT_CMUL_UKERNEL(ukernel) \
-  (xnn_vbinary_ukernel_fn) ukernel;    \
-  xnn_log_info("Using cmul microkernel '%s'.", #ukernel);
+#define XNN_INIT_CMUL_UKERNEL(ukernel)                    \
+  (xnn_vbinary_ukernel_fn) ukernel;                       \
+  xnn_log_info("Using cmul microkernel '%s'.", #ukernel); \
+  XNN_REGISTER_UKERNEL_NAME(ukernel);
 
 #if XNN_ENABLE_ARM_FP16_VECTOR && (XNN_ARCH_ARM || XNN_ARCH_ARM64)
   static void init_f16_cmul_config(void) {

--- a/src/configs/conv-hwc2chw-config.c
+++ b/src/configs/conv-hwc2chw-config.c
@@ -14,6 +14,7 @@
 #include "src/xnnpack/init-once.h"
 #include "src/xnnpack/log.h"
 #include "src/xnnpack/microfnptr.h"
+#include "src/xnnpack/microkernel-name-registry.h"
 #include "src/xnnpack/microparams-init.h"
 
 static struct xnn_conv_hwc2chw_config f16_conv_hwc2chw_3x3c3s2_config = {0};
@@ -23,9 +24,10 @@ XNN_INIT_ONCE_GUARD(f16_conv_hwc2chw_3x3c3s2);
 XNN_INIT_ONCE_GUARD(f32_conv_hwc2chw_3x3c3s2);
 
 // Macros to log the microkernel names if and when they are registered.
-#define XNN_INIT_CONV_UKERNEL(ukernel) \
-  (xnn_conv_hwc2chw_ukernel_fn) ukernel;    \
-  xnn_log_info("Using conv_hwc2chw microkernel '%s'.", #ukernel);
+#define XNN_INIT_CONV_UKERNEL(ukernel)                            \
+  (xnn_conv_hwc2chw_ukernel_fn) ukernel;                          \
+  xnn_log_info("Using conv_hwc2chw microkernel '%s'.", #ukernel); \
+  XNN_REGISTER_UKERNEL_NAME(ukernel);
 
 static void init_f16_conv_hwc2chw_3x3c3s2_config(void) {
   #if XNN_ENABLE_ARM_FP16_SCALAR && XNN_ENABLE_ARM_FP16_VECTOR && XNN_ARCH_ARM

--- a/src/configs/dwconv-config.c
+++ b/src/configs/dwconv-config.c
@@ -14,6 +14,7 @@
 #include "src/xnnpack/init-once.h"
 #include "src/xnnpack/log.h"
 #include "src/xnnpack/microfnptr.h"
+#include "src/xnnpack/microkernel-name-registry.h"
 #include "src/xnnpack/microparams-init.h"
 
 static struct xnn_dwconv_config f16_dwconv_config[XNN_MAX_F16_DWCONV_UKERNELS] = {0};
@@ -29,9 +30,10 @@ XNN_INIT_ONCE_GUARD(qs8_dwconv);
 XNN_INIT_ONCE_GUARD(qu8_dwconv);
 
 // Macros to log the microkernel names if and when they are registered.
-#define XNN_INIT_DWCONV_UKERNEL(ukernel) \
-  (xnn_dwconv_ukernel_fn) ukernel;       \
-  xnn_log_info("Using dwconv microkernel '%s'.", #ukernel);
+#define XNN_INIT_DWCONV_UKERNEL(ukernel)                    \
+  (xnn_dwconv_ukernel_fn) ukernel;                          \
+  xnn_log_info("Using dwconv microkernel '%s'.", #ukernel); \
+  XNN_REGISTER_UKERNEL_NAME(ukernel);
 
 static void init_f16_dwconv_config(void) {
   #if XNN_ENABLE_ARM_FP16_SCALAR && XNN_ENABLE_ARM_FP16_VECTOR && XNN_ARCH_ARM

--- a/src/configs/dwconv2d-chw-config.c
+++ b/src/configs/dwconv2d-chw-config.c
@@ -14,6 +14,7 @@
 #include "src/xnnpack/init-once.h"
 #include "src/xnnpack/log.h"
 #include "src/xnnpack/microfnptr.h"
+#include "src/xnnpack/microkernel-name-registry.h"
 #include "src/xnnpack/microparams-init.h"
 
 static struct xnn_dwconv2d_chw_config f16_dwconv2d_chw_config = {0};
@@ -23,9 +24,10 @@ XNN_INIT_ONCE_GUARD(f16_dwconv2d_chw);
 XNN_INIT_ONCE_GUARD(f32_dwconv2d_chw);
 
 // Macros to log the microkernel names if and when they are registered.
-#define XNN_INIT_DWCONV2D_UKERNEL(ukernel) \
-  (xnn_dwconv2d_chw_ukernel_fn) ukernel;       \
-  xnn_log_info("Using dwconv2d_chw microkernel '%s'.", #ukernel);
+#define XNN_INIT_DWCONV2D_UKERNEL(ukernel)                        \
+  (xnn_dwconv2d_chw_ukernel_fn) ukernel;                          \
+  xnn_log_info("Using dwconv2d_chw microkernel '%s'.", #ukernel); \
+  XNN_REGISTER_UKERNEL_NAME(ukernel);
 
 static void init_f16_dwconv2d_chw_config(void) {
   #if XNN_ENABLE_ARM_FP16_SCALAR && XNN_ENABLE_ARM_FP16_VECTOR && XNN_ARCH_ARM

--- a/src/configs/gemm-config.c
+++ b/src/configs/gemm-config.c
@@ -17,6 +17,7 @@
 #include "src/xnnpack/log.h"
 #include "src/xnnpack/math.h"
 #include "src/xnnpack/microfnptr.h"
+#include "src/xnnpack/microkernel-name-registry.h"
 #include "src/xnnpack/microparams-init.h"
 #include "src/xnnpack/pack.h"
 #include "src/xnnpack/packw.h"
@@ -105,52 +106,62 @@ XNN_INIT_ONCE_GUARD(qs8_qc8w_gemm);
 XNN_INIT_ONCE_GUARD(qu8_gemm);
 
 // Macros to log the microkernel names if and when they are registered.
-#define XNN_INIT_GEMM_UKERNEL(ukernel) \
-  (xnn_gemm_ukernel_fn) ukernel;       \
-  xnn_log_info("Using gemm microkernel '%s'.", #ukernel);
+#define XNN_INIT_GEMM_UKERNEL(ukernel)                    \
+  (xnn_gemm_ukernel_fn) ukernel;                          \
+  xnn_log_info("Using gemm microkernel '%s'.", #ukernel); \
+  XNN_REGISTER_UKERNEL_NAME(ukernel);
 
 #define XNN_INIT_HMP_GEMM_UKERNEL(ukernel)                 \
   xnn_init_hmp_gemm_ukernel((xnn_gemm_ukernel_fn)ukernel); \
-  xnn_log_info("Using gemm microkernel '%s'.", #ukernel);
+  xnn_log_info("Using gemm microkernel '%s'.", #ukernel);  \
+  XNN_REGISTER_UKERNEL_NAME(ukernel);
 
-#define XNN_INIT_IGEMM_UKERNEL(ukernel) \
-  (xnn_igemm_ukernel_fn) ukernel;       \
-  xnn_log_info("Using igemm microkernel '%s'.", #ukernel);
+#define XNN_INIT_IGEMM_UKERNEL(ukernel)                    \
+  (xnn_igemm_ukernel_fn) ukernel;                          \
+  xnn_log_info("Using igemm microkernel '%s'.", #ukernel); \
+  XNN_REGISTER_UKERNEL_NAME(ukernel);
 
 #define XNN_INIT_HMP_IGEMM_UKERNEL(ukernel)                  \
   xnn_init_hmp_igemm_ukernel((xnn_igemm_ukernel_fn)ukernel); \
-  xnn_log_info("Using igemm microkernel '%s'.", #ukernel);
+  xnn_log_info("Using igemm microkernel '%s'.", #ukernel);   \
+  XNN_REGISTER_UKERNEL_NAME(ukernel);
 
-#define XNN_INIT_DQGEMM_UKERNEL(ukernel) \
-  (xnn_dqgemm_ukernel_fn) ukernel;       \
-  xnn_log_info("Using dqgemm microkernel '%s'.", #ukernel);
+#define XNN_INIT_DQGEMM_UKERNEL(ukernel)                    \
+  (xnn_dqgemm_ukernel_fn) ukernel;                          \
+  xnn_log_info("Using dqgemm microkernel '%s'.", #ukernel); \
+  XNN_REGISTER_UKERNEL_NAME(ukernel);
 
 #define XNN_INIT_HMP_DQGEMM_UKERNEL(ukernel)                   \
   xnn_init_hmp_dqgemm_ukernel((xnn_dqgemm_ukernel_fn)ukernel); \
-  xnn_log_info("Using dqgemm microkernel '%s'.", #ukernel);
+  xnn_log_info("Using dqgemm microkernel '%s'.", #ukernel);    \
+  XNN_REGISTER_UKERNEL_NAME(ukernel);
 
-#define XNN_INIT_DQIGEMM_UKERNEL(ukernel) \
-  (xnn_dqigemm_ukernel_fn) ukernel;       \
-  xnn_log_info("Using dqigemm microkernel '%s'.", #ukernel);
+#define XNN_INIT_DQIGEMM_UKERNEL(ukernel)                    \
+  (xnn_dqigemm_ukernel_fn) ukernel;                          \
+  xnn_log_info("Using dqigemm microkernel '%s'.", #ukernel); \
+  XNN_REGISTER_UKERNEL_NAME(ukernel);
 
 #define XNN_INIT_HMP_DQIGEMM_UKERNEL(ukernel)                    \
   xnn_init_hmp_dqigemm_ukernel((xnn_dqigemm_ukernel_fn)ukernel); \
-  xnn_log_info("Using dqigemm microkernel '%s'.", #ukernel);
+  xnn_log_info("Using dqigemm microkernel '%s'.", #ukernel);     \
+  XNN_REGISTER_UKERNEL_NAME(ukernel);
 
-#define XNN_INIT_HMP_QP8GEMM_UKERNEL(ukernel)            \
-  xnn_init_hmp_qp8gemm_ukernel(                          \
-      (xnn_qp8_f32_qc4w_gemm_minmax_ukernel_fn)ukernel); \
-  xnn_log_info("Using qp8gemm microkernel '%s'.", #ukernel);
+#define XNN_INIT_HMP_QP8GEMM_UKERNEL(ukernel)                \
+  xnn_init_hmp_qp8gemm_ukernel(                              \
+      (xnn_qp8_f32_qc4w_gemm_minmax_ukernel_fn)ukernel);     \
+  xnn_log_info("Using qp8gemm microkernel '%s'.", #ukernel); \
+  XNN_REGISTER_UKERNEL_NAME(ukernel);
 
-#define XNN_INIT_HMP_QP8GEMM_BL_UKERNEL(ukernel)         \
-  xnn_init_hmp_qp8gemm_bl_ukernel(                       \
-      (xnn_qp8_f32_qb4w_gemm_minmax_ukernel_fn)ukernel); \
-  xnn_log_info("Using qp8gemm_bl microkernel '%s'.", #ukernel);
+#define XNN_INIT_HMP_QP8GEMM_BL_UKERNEL(ukernel)                \
+  xnn_init_hmp_qp8gemm_bl_ukernel(                              \
+      (xnn_qp8_f32_qb4w_gemm_minmax_ukernel_fn)ukernel);        \
+  xnn_log_info("Using qp8gemm_bl microkernel '%s'.", #ukernel); \
+  XNN_REGISTER_UKERNEL_NAME(ukernel);
 
-#define XNN_INIT_HMP_PACKED_IGEMM_UKERNEL(ukernel)                    \
-  xnn_init_hmp_packed_igemm_ukernel(                                  \
-      (xnn_packed_lhs_igemm_ukernel_fn)ukernel);                      \
-  xnn_log_info("Using igemm microkernel '%s'.", #ukernel);
+#define XNN_INIT_HMP_PACKED_IGEMM_UKERNEL(ukernel)                             \
+  xnn_init_hmp_packed_igemm_ukernel((xnn_packed_lhs_igemm_ukernel_fn)ukernel); \
+  xnn_log_info("Using igemm microkernel '%s'.", #ukernel);                     \
+  XNN_REGISTER_UKERNEL_NAME(ukernel);
 
 static void init_f16_gemm_config(void) {
   // Common parameters.

--- a/src/configs/ibilinear-chw-config.c
+++ b/src/configs/ibilinear-chw-config.c
@@ -15,6 +15,7 @@
 #include "src/xnnpack/log.h"
 #include "src/xnnpack/indirection.h"
 #include "src/xnnpack/microfnptr.h"
+#include "src/xnnpack/microkernel-name-registry.h"
 
 static struct xnn_ibilinear_chw_config f16_ibilinear_chw_config = {0};
 static struct xnn_ibilinear_chw_config f32_ibilinear_chw_config = {0};
@@ -23,9 +24,10 @@ XNN_INIT_ONCE_GUARD(f16_ibilinear_chw);
 XNN_INIT_ONCE_GUARD(f32_ibilinear_chw);
 
 // Macros to log the microkernel names if and when they are registered.
-#define XNN_INIT_IBILINEAR_UKERNEL(ukernel) \
-  (xnn_ibilinear_chw_ukernel_fn) ukernel;       \
-  xnn_log_info("Using ibilinear_chw microkernel '%s'.", #ukernel);
+#define XNN_INIT_IBILINEAR_UKERNEL(ukernel)                        \
+  (xnn_ibilinear_chw_ukernel_fn) ukernel;                          \
+  xnn_log_info("Using ibilinear_chw microkernel '%s'.", #ukernel); \
+  XNN_REGISTER_UKERNEL_NAME(ukernel);
 
 static void init_f16_ibilinear_chw_config(void) {
   #if XNN_ENABLE_ARM_FP16_SCALAR && XNN_ENABLE_ARM_FP16_VECTOR && XNN_ARCH_ARM

--- a/src/configs/ibilinear-config.c
+++ b/src/configs/ibilinear-config.c
@@ -15,6 +15,7 @@
 #include "src/xnnpack/init-once.h"
 #include "src/xnnpack/log.h"
 #include "src/xnnpack/microfnptr.h"
+#include "src/xnnpack/microkernel-name-registry.h"
 
 static struct xnn_ibilinear_config f16_ibilinear_config = {0};
 static struct xnn_ibilinear_config f32_ibilinear_config = {0};
@@ -27,9 +28,10 @@ XNN_INIT_ONCE_GUARD(s8_ibilinear);
 XNN_INIT_ONCE_GUARD(u8_ibilinear);
 
 // Macros to log the microkernel names if and when they are registered.
-#define XNN_INIT_IBILINEAR_UKERNEL(ukernel) \
-  (xnn_ibilinear_ukernel_fn) ukernel;       \
-  xnn_log_info("Using ibilinear microkernel '%s'.", #ukernel);
+#define XNN_INIT_IBILINEAR_UKERNEL(ukernel)                    \
+  (xnn_ibilinear_ukernel_fn) ukernel;                          \
+  xnn_log_info("Using ibilinear microkernel '%s'.", #ukernel); \
+  XNN_REGISTER_UKERNEL_NAME(ukernel);
 
 static void init_f16_ibilinear_config(void) {
   #if XNN_ENABLE_ARM_FP16_SCALAR && XNN_ENABLE_ARM_FP16_VECTOR && XNN_ARCH_ARM

--- a/src/configs/maxpool-config.c
+++ b/src/configs/maxpool-config.c
@@ -14,6 +14,7 @@
 #include "src/xnnpack/log.h"
 #include "src/xnnpack/maxpool.h"
 #include "src/xnnpack/microfnptr.h"
+#include "src/xnnpack/microkernel-name-registry.h"
 #include "src/xnnpack/microparams-init.h"
 
 static struct xnn_maxpool_config f16_maxpool_config = {0};
@@ -27,9 +28,10 @@ XNN_INIT_ONCE_GUARD(s8_maxpool);
 XNN_INIT_ONCE_GUARD(u8_maxpool);
 
 // Macros to log the microkernel names if and when they are registered.
-#define XNN_INIT_MAXPOOL_UKERNEL(ukernel) \
-  (xnn_maxpool_ukernel_fn) ukernel;       \
-  xnn_log_info("Using maxpool microkernel '%s'.", #ukernel);
+#define XNN_INIT_MAXPOOL_UKERNEL(ukernel)                    \
+  (xnn_maxpool_ukernel_fn) ukernel;                          \
+  xnn_log_info("Using maxpool microkernel '%s'.", #ukernel); \
+  XNN_REGISTER_UKERNEL_NAME(ukernel);
 
 static void init_f16_maxpool_config(void) {
   #if XNN_ENABLE_ARM_FP16_SCALAR && XNN_ENABLE_ARM_FP16_VECTOR && XNN_ARCH_ARM

--- a/src/configs/raddstoreexpminusmax-config.c
+++ b/src/configs/raddstoreexpminusmax-config.c
@@ -15,6 +15,7 @@
 #include "src/xnnpack/init-once.h"
 #include "src/xnnpack/microfnptr.h"
 #include "src/xnnpack/log.h"
+#include "src/xnnpack/microkernel-name-registry.h"
 #include "src/xnnpack/raddstoreexpminusmax.h"
 
 static const int default_config = 0;
@@ -27,9 +28,10 @@ XNN_INIT_ONCE_GUARD(f16_raddstoreexpminusmax);
 XNN_INIT_ONCE_GUARD(f32_raddstoreexpminusmax);
 
 // Macros to log the microkernel names if and when they are registered.
-#define XNN_INIT_RADDSTOREEXPMINUSMAX_UKERNEL(ukernel) \
-  (xnn_raddstoreexpminusmax_ukernel_fn) ukernel;       \
-  xnn_log_info("Using raddstoreexpminusmax microkernel '%s'.", #ukernel);
+#define XNN_INIT_RADDSTOREEXPMINUSMAX_UKERNEL(ukernel)                    \
+  (xnn_raddstoreexpminusmax_ukernel_fn) ukernel;                          \
+  xnn_log_info("Using raddstoreexpminusmax microkernel '%s'.", #ukernel); \
+  XNN_REGISTER_UKERNEL_NAME(ukernel);
 
 static void init_f16_raddstoreexpminusmax_config(void) {
   #if XNN_ENABLE_ARM_FP16_SCALAR && XNN_ENABLE_ARM_FP16_VECTOR && XNN_ARCH_ARM

--- a/src/configs/reduce-config.c
+++ b/src/configs/reduce-config.c
@@ -16,6 +16,7 @@
 #include "src/xnnpack/init-once.h"
 #include "src/xnnpack/log.h"
 #include "src/xnnpack/microfnptr.h"
+#include "src/xnnpack/microkernel-name-registry.h"
 #include "src/xnnpack/microparams-init.h"
 #include "src/xnnpack/reduce.h"
 
@@ -58,19 +59,22 @@ XNN_INIT_ONCE_GUARD(u8_rmin);
 XNN_INIT_ONCE_GUARD(qu8_rsum);
 
 // Macros to log the microkernel names if and when they are registered.
-#define XNN_INIT_REDUCE_UKERNEL(ukernel) \
-  (xnn_reduce_ukernel_fn) ukernel;       \
-  xnn_log_info("Using reduce microkernel '%s'.", #ukernel);
+#define XNN_INIT_REDUCE_UKERNEL(ukernel)                    \
+  (xnn_reduce_ukernel_fn) ukernel;                          \
+  xnn_log_info("Using reduce microkernel '%s'.", #ukernel); \
+  XNN_REGISTER_UKERNEL_NAME(ukernel);
 
-#define XNN_INIT_REDUCE_DISCONTIGUOUS_UKERNEL(ukernel) \
-  (xnn_reduce_discontiguous_ukernel_fn) ukernel;       \
-  xnn_log_info("Using reduce_discontiguous microkernel '%s'.", #ukernel);
+#define XNN_INIT_REDUCE_DISCONTIGUOUS_UKERNEL(ukernel)                    \
+  (xnn_reduce_discontiguous_ukernel_fn) ukernel;                          \
+  xnn_log_info("Using reduce_discontiguous microkernel '%s'.", #ukernel); \
+  XNN_REGISTER_UKERNEL_NAME(ukernel);
 
 // TODO(b/405244706): remove once all the datatypes and reductions are
 // supported.
-#define XNN_INIT_REDUCE_DISCONTIGUOUS_UKERNEL2(ukernel) \
-  (xnn_reduce_discontiguous_ukernel_fn2) ukernel;       \
-  xnn_log_info("Using reduce_discontiguous microkernel '%s'.", #ukernel);
+#define XNN_INIT_REDUCE_DISCONTIGUOUS_UKERNEL2(ukernel)                   \
+  (xnn_reduce_discontiguous_ukernel_fn2) ukernel;                         \
+  xnn_log_info("Using reduce_discontiguous microkernel '%s'.", #ukernel); \
+  XNN_REGISTER_UKERNEL_NAME(ukernel);
 
 static uint32_t pack_xint8_x4(uint8_t value) {
   uint32_t v32 = (uint32_t)value;

--- a/src/configs/spmm-config.c
+++ b/src/configs/spmm-config.c
@@ -13,6 +13,7 @@
 #include "src/xnnpack/init-once.h"
 #include "src/xnnpack/log.h"
 #include "src/xnnpack/microfnptr.h"
+#include "src/xnnpack/microkernel-name-registry.h"
 #include "src/xnnpack/microparams-init.h"
 #include "src/xnnpack/spmm.h"
 
@@ -27,9 +28,10 @@ XNN_INIT_ONCE_GUARD(f32_spmm2);
 XNN_INIT_ONCE_GUARD(f32_spmm4);
 
 // Macros to log the microkernel names if and when they are registered.
-#define XNN_INIT_SPMM_UKERNEL(ukernel) \
-  (xnn_spmm_ukernel_fn) ukernel;       \
-  xnn_log_info("Using spmm microkernel '%s'.", #ukernel);
+#define XNN_INIT_SPMM_UKERNEL(ukernel)                    \
+  (xnn_spmm_ukernel_fn) ukernel;                          \
+  xnn_log_info("Using spmm microkernel '%s'.", #ukernel); \
+  XNN_REGISTER_UKERNEL_NAME(ukernel);
 
 static void init_f16_spmm_config(void) {
   #if XNN_ENABLE_ARM_FP16_SCALAR && XNN_ENABLE_ARM_FP16_VECTOR && XNN_ARCH_ARM

--- a/src/configs/transpose-config.c
+++ b/src/configs/transpose-config.c
@@ -13,6 +13,7 @@
 #include "src/xnnpack/init-once.h"
 #include "src/xnnpack/log.h"
 #include "src/xnnpack/microfnptr.h"
+#include "src/xnnpack/microkernel-name-registry.h"
 #include "src/xnnpack/transpose.h"
 #include "src/xnnpack/vunary.h"
 
@@ -21,17 +22,20 @@ static struct xnn_transpose_config transpose_config = {0};
 XNN_INIT_ONCE_GUARD(transpose);
 
 // Macros to log the microkernel names if and when they are registered.
-#define XNN_INIT_COPY_UKERNEL(ukernel) \
-  (xnn_vunary_ukernel_fn) ukernel;     \
-  xnn_log_info("Using copy microkernel '%s'.", #ukernel);
+#define XNN_INIT_COPY_UKERNEL(ukernel)                    \
+  (xnn_vunary_ukernel_fn) ukernel;                        \
+  xnn_log_info("Using copy microkernel '%s'.", #ukernel); \
+  XNN_REGISTER_UKERNEL_NAME(ukernel);
 
-#define XNN_INIT_TRANSPOSEC_UKERNEL(ukernel) \
-  (xnn_transposec_ukernel_fn) ukernel;       \
-  xnn_log_info("Using transposec microkernel '%s'.", #ukernel);
+#define XNN_INIT_TRANSPOSEC_UKERNEL(ukernel)                    \
+  (xnn_transposec_ukernel_fn) ukernel;                          \
+  xnn_log_info("Using transposec microkernel '%s'.", #ukernel); \
+  XNN_REGISTER_UKERNEL_NAME(ukernel);
 
-#define XNN_INIT_TRANSPOSEV_UKERNEL(ukernel) \
-  (xnn_transposev_ukernel_fn) ukernel;       \
-  xnn_log_info("Using transposev microkernel '%s'.", #ukernel);
+#define XNN_INIT_TRANSPOSEV_UKERNEL(ukernel)                    \
+  (xnn_transposev_ukernel_fn) ukernel;                          \
+  xnn_log_info("Using transposev microkernel '%s'.", #ukernel); \
+  XNN_REGISTER_UKERNEL_NAME(ukernel);
 
 static void init_transpose_config(void) {
   #if XNN_ARCH_ARM

--- a/src/configs/unary-elementwise-config.c
+++ b/src/configs/unary-elementwise-config.c
@@ -15,6 +15,7 @@
 #include "src/xnnpack/init-once.h"
 #include "src/xnnpack/log.h"
 #include "src/xnnpack/microfnptr.h"
+#include "src/xnnpack/microkernel-name-registry.h"
 #include "src/xnnpack/microparams-init.h"
 #include "src/xnnpack/packq.h"
 #include "src/xnnpack/vcvt.h"
@@ -143,9 +144,10 @@ XNN_INIT_ONCE_GUARD(u8_clamp);
 XNN_INIT_ONCE_GUARD(xx_copy);
 
 // Macros to log the microkernel names if and when they are registered.
-#define XNN_INIT_UNARY_UKERNEL(ukernel) \
-  (xnn_vunary_ukernel_fn) ukernel;      \
-  xnn_log_info("Using unary microkernel '%s'.", #ukernel);
+#define XNN_INIT_UNARY_UKERNEL(ukernel)                    \
+  (xnn_vunary_ukernel_fn) ukernel;                         \
+  xnn_log_info("Using unary microkernel '%s'.", #ukernel); \
+  XNN_REGISTER_UKERNEL_NAME(ukernel);
 
 static void init_f16_abs_config(void) {
   #if XNN_ENABLE_ARM_FP16_SCALAR && XNN_ENABLE_ARM_FP16_VECTOR && XNN_ARCH_ARM

--- a/src/configs/unpool-config.c
+++ b/src/configs/unpool-config.c
@@ -13,6 +13,7 @@
 #include "src/xnnpack/init-once.h"
 #include "src/xnnpack/log.h"
 #include "src/xnnpack/microfnptr.h"
+#include "src/xnnpack/microkernel-name-registry.h"
 #include "src/xnnpack/unpool.h"
 
 static struct xnn_unpool_config x32_unpool_config = {0};
@@ -20,9 +21,10 @@ static struct xnn_unpool_config x32_unpool_config = {0};
 XNN_INIT_ONCE_GUARD(x32_unpool);
 
 // Macros to log the microkernel names if and when they are registered.
-#define XNN_INIT_UNPOOL_UKERNEL(ukernel) \
-  (xnn_unpool_ukernel_fn) ukernel;       \
-  xnn_log_info("Using unpool microkernel '%s'.", #ukernel);
+#define XNN_INIT_UNPOOL_UKERNEL(ukernel)                    \
+  (xnn_unpool_ukernel_fn) ukernel;                          \
+  xnn_log_info("Using unpool microkernel '%s'.", #ukernel); \
+  XNN_REGISTER_UKERNEL_NAME(ukernel);
 
 static void init_x32_unpool_config(void) {
   #if XNN_ARCH_ARM

--- a/src/configs/vmulcaddc-config.c
+++ b/src/configs/vmulcaddc-config.c
@@ -13,6 +13,7 @@
 #include "src/xnnpack/init-once.h"
 #include "src/xnnpack/log.h"
 #include "src/xnnpack/microfnptr.h"
+#include "src/xnnpack/microkernel-name-registry.h"
 #include "src/xnnpack/microparams-init.h"
 #include "src/xnnpack/vmulcaddc.h"
 
@@ -23,9 +24,10 @@ XNN_INIT_ONCE_GUARD(f16_vmulcaddc);
 XNN_INIT_ONCE_GUARD(f32_vmulcaddc);
 
 // Macros to log the microkernel names if and when they are registered.
-#define XNN_INIT_VMULCADDC_UKERNEL(ukernel) \
-  (xnn_vmulcaddc_ukernel_fn) ukernel;       \
-  xnn_log_info("Using vmulcaddc microkernel '%s'.", #ukernel);
+#define XNN_INIT_VMULCADDC_UKERNEL(ukernel)                    \
+  (xnn_vmulcaddc_ukernel_fn) ukernel;                          \
+  xnn_log_info("Using vmulcaddc microkernel '%s'.", #ukernel); \
+  XNN_REGISTER_UKERNEL_NAME(ukernel);
 
 static void init_f16_vmulcaddc_config(void) {
   #if XNN_ENABLE_ARM_FP16_SCALAR && XNN_ENABLE_ARM_FP16_VECTOR && XNN_ARCH_ARM

--- a/src/microkernel-name-registry.c
+++ b/src/microkernel-name-registry.c
@@ -1,0 +1,78 @@
+// Copyright 2026 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root of this source tree.
+
+#include "src/xnnpack/microkernel-name-registry.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "src/xnnpack/cache.h"
+#include "src/xnnpack/init-once.h"
+#include "src/xnnpack/mutex.h"
+
+// Open-addressing table sized for the ~hundreds of distinct ukernels any
+// single build of XNNPACK registers (bounded by the union of XNN_INIT_*
+// _UKERNEL call sites across enabled ISAs). 4096 slots keeps load < 50%
+// with margin and avoids ever growing.
+#define XNN_NAME_TABLE_SIZE 4096
+#define XNN_NAME_TABLE_MASK (XNN_NAME_TABLE_SIZE - 1)
+
+struct entry {
+  const void* fn_ptr;
+  const char* name;
+};
+
+static struct entry name_table[XNN_NAME_TABLE_SIZE];
+
+static struct xnn_mutex mutex;
+XNN_INIT_ONCE_GUARD(mutex);
+static void init_mutex_config() { xnn_mutex_init(&mutex); }
+
+static inline uint32_t hash_fn_ptr(const void* fn_ptr) {
+  return murmur_hash3(&fn_ptr, sizeof(fn_ptr), /*seed=*/7);
+}
+
+void xnn_register_microkernel_name(const void* fn_ptr, const char* name) {
+  if (fn_ptr == NULL || name == NULL) {
+    return;
+  }
+  XNN_INIT_ONCE(mutex);
+  xnn_mutex_lock(&mutex);
+  uint32_t slot = hash_fn_ptr(fn_ptr) & XNN_NAME_TABLE_MASK;
+  for (size_t probes = 0; probes < XNN_NAME_TABLE_SIZE; probes++) {
+    if (name_table[slot].fn_ptr == NULL) {
+      name_table[slot].name = name;
+      name_table[slot].fn_ptr = fn_ptr;
+      break;
+    }
+    if (name_table[slot].fn_ptr == fn_ptr) {
+      break;
+    }
+    slot = (slot + 1) & XNN_NAME_TABLE_MASK;
+  }
+  xnn_mutex_unlock(&mutex);
+}
+
+const char* xnn_lookup_microkernel_name(const void* fn_ptr) {
+  if (fn_ptr == NULL) {
+    return NULL;
+  }
+  XNN_INIT_ONCE(mutex);
+  xnn_mutex_lock(&mutex);
+  const char* name = NULL;
+  uint32_t slot = hash_fn_ptr(fn_ptr) & XNN_NAME_TABLE_MASK;
+  for (size_t probes = 0; probes < XNN_NAME_TABLE_SIZE; probes++) {
+    if (name_table[slot].fn_ptr == NULL) {
+      break;
+    }
+    if (name_table[slot].fn_ptr == fn_ptr) {
+      name = name_table[slot].name;
+      break;
+    }
+    slot = (slot + 1) & XNN_NAME_TABLE_MASK;
+  }
+  xnn_mutex_unlock(&mutex);
+  return name;
+}

--- a/src/operator-run.c
+++ b/src/operator-run.c
@@ -9,6 +9,7 @@
 #include <assert.h>
 #include <limits.h>
 #include <math.h>
+#include <pthreadpool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
@@ -20,13 +21,13 @@
 #include "src/xnnpack/log.h"
 #include "src/xnnpack/math.h"
 #include "src/xnnpack/microfnptr.h"
+#include "src/xnnpack/microkernel-timing.h"
 #include "src/xnnpack/microkernel-type.h"
 #include "src/xnnpack/microparams.h"
 #include "src/xnnpack/operator-utils.h"
 #include "src/xnnpack/operator.h"
 #include "src/xnnpack/packq.h"
 #include "src/xnnpack/quantization.h"
-#include <pthreadpool.h>
 
 #if XNN_MAX_UARCH_TYPES > 1
 #include "src/xnnpack/config-types.h"
@@ -38,7 +39,8 @@ void xnn_compute_transposec_2d(struct transpose_context* restrict context,
                                size_t tile_j) {
   const size_t ld_input = context->input_stride[1];
   const size_t ld_output = context->output_stride[0];
-  context->const_size_ukernel(
+  XNN_UKERNEL_TIMING_RUN_AND_COMMIT(
+      context->ukernel_elapsed_us, context->const_size_ukernel,
       (const void*)((uintptr_t)context->x + i * context->input_stride[0] +
                     j * context->input_stride[1]),
       (void*)((uintptr_t)context->y + j * context->output_stride[1] +
@@ -59,7 +61,9 @@ void xnn_compute_transposec_3d(struct transpose_context* restrict context,
       (void*)((uintptr_t)context->y + i * context->output_stride[0] +
               j * context->output_stride[1] + k * context->output_stride[2]);
 
-  context->const_size_ukernel(x, y, ld_input, ld_output, tile_j, tile_k);
+  XNN_UKERNEL_TIMING_RUN_AND_COMMIT(context->ukernel_elapsed_us,
+                                    context->const_size_ukernel, x, y, ld_input,
+                                    ld_output, tile_j, tile_k);
 }
 
 void xnn_compute_transposec_4d(struct transpose_context* restrict context,
@@ -77,7 +81,9 @@ void xnn_compute_transposec_4d(struct transpose_context* restrict context,
               j * context->output_stride[1] + k * context->output_stride[2] +
               l * context->output_stride[3]);
 
-  context->const_size_ukernel(x, y, ld_input, ld_output, tile_k, tile_l);
+  XNN_UKERNEL_TIMING_RUN_AND_COMMIT(context->ukernel_elapsed_us,
+                                    context->const_size_ukernel, x, y, ld_input,
+                                    ld_output, tile_k, tile_l);
 }
 
 void xnn_compute_transposec_5d(struct transpose_context* restrict context,
@@ -96,7 +102,9 @@ void xnn_compute_transposec_5d(struct transpose_context* restrict context,
               j * context->output_stride[1] + k * context->output_stride[2] +
               l * context->output_stride[3] + m * context->output_stride[4]);
 
-  context->const_size_ukernel(x, y, ld_input, ld_output, tile_l, tile_m);
+  XNN_UKERNEL_TIMING_RUN_AND_COMMIT(context->ukernel_elapsed_us,
+                                    context->const_size_ukernel, x, y, ld_input,
+                                    ld_output, tile_l, tile_m);
 }
 
 void xnn_compute_transposec_6d(struct transpose_context* restrict context,
@@ -117,7 +125,9 @@ void xnn_compute_transposec_6d(struct transpose_context* restrict context,
               l * context->output_stride[3] + m * context->output_stride[4] +
               n * context->output_stride[5]);
 
-  context->const_size_ukernel(x, y, ld_input, ld_output, tile_m, tile_n);
+  XNN_UKERNEL_TIMING_RUN_AND_COMMIT(context->ukernel_elapsed_us,
+                                    context->const_size_ukernel, x, y, ld_input,
+                                    ld_output, tile_m, tile_n);
 }
 
 void xnn_compute_transposev_2d(struct transpose_context* restrict context,
@@ -132,9 +142,10 @@ void xnn_compute_transposev_2d(struct transpose_context* restrict context,
   void* y = (void*)((uintptr_t)context->y + context->output_stride[1] * j +
                     i * context->output_stride[0]);
 
-  context->variable_size_ukernel(
-      x, y, ld_input, ld_output, context->input_stride[0],
-      context->output_stride[1], element_size, tile_i, tile_j);
+  XNN_UKERNEL_TIMING_RUN_AND_COMMIT(
+      context->ukernel_elapsed_us, context->variable_size_ukernel, x, y,
+      ld_input, ld_output, context->input_stride[0], context->output_stride[1],
+      element_size, tile_i, tile_j);
 }
 
 void xnn_compute_transposev_3d(struct transpose_context* restrict context,
@@ -151,9 +162,10 @@ void xnn_compute_transposev_3d(struct transpose_context* restrict context,
       (void*)((uintptr_t)context->y + i * context->output_stride[0] +
               j * context->output_stride[1] + k * context->output_stride[2]);
 
-  context->variable_size_ukernel(
-      x, y, ld_input, ld_output, context->input_stride[1],
-      context->output_stride[2], element_size, tile_j, tile_k);
+  XNN_UKERNEL_TIMING_RUN_AND_COMMIT(
+      context->ukernel_elapsed_us, context->variable_size_ukernel, x, y,
+      ld_input, ld_output, context->input_stride[1], context->output_stride[2],
+      element_size, tile_j, tile_k);
 }
 
 void xnn_compute_transposev_4d(struct transpose_context* restrict context,
@@ -172,9 +184,10 @@ void xnn_compute_transposev_4d(struct transpose_context* restrict context,
               i * context->output_stride[0] + j * context->output_stride[1] +
               k * context->output_stride[2]);
 
-  context->variable_size_ukernel(
-      x, y, ld_input, ld_output, context->input_stride[2],
-      context->output_stride[3], element_size, tile_k, tile_l);
+  XNN_UKERNEL_TIMING_RUN_AND_COMMIT(
+      context->ukernel_elapsed_us, context->variable_size_ukernel, x, y,
+      ld_input, ld_output, context->input_stride[2], context->output_stride[3],
+      element_size, tile_k, tile_l);
 }
 
 void xnn_compute_transposev_5d(struct transpose_context* restrict context,
@@ -194,9 +207,10 @@ void xnn_compute_transposev_5d(struct transpose_context* restrict context,
               i * context->output_stride[0] + j * context->output_stride[1] +
               k * context->output_stride[2] + l * context->output_stride[3]);
 
-  context->variable_size_ukernel(
-      x, y, ld_input, ld_output, context->input_stride[3],
-      context->output_stride[4], element_size, tile_l, tile_m);
+  XNN_UKERNEL_TIMING_RUN_AND_COMMIT(
+      context->ukernel_elapsed_us, context->variable_size_ukernel, x, y,
+      ld_input, ld_output, context->input_stride[3], context->output_stride[4],
+      element_size, tile_l, tile_m);
 }
 
 void xnn_compute_transposev_6d(struct transpose_context* restrict context,
@@ -218,9 +232,10 @@ void xnn_compute_transposev_6d(struct transpose_context* restrict context,
               k * context->output_stride[2] + l * context->output_stride[3] +
               m * context->output_stride[4]);
 
-  context->variable_size_ukernel(
-      x, y, ld_input, ld_output, context->input_stride[4],
-      context->output_stride[5], element_size, tile_m, tile_n);
+  XNN_UKERNEL_TIMING_RUN_AND_COMMIT(
+      context->ukernel_elapsed_us, context->variable_size_ukernel, x, y,
+      ld_input, ld_output, context->input_stride[4], context->output_stride[5],
+      element_size, tile_m, tile_n);
 }
 
 void xnn_compute_batched_packw_gemm_gio(
@@ -359,6 +374,7 @@ void xnn_compute_hmp_grouped_gemm(struct gemm_context* restrict context,
   size_t group_index_b = 0;
   compute_group_indices(context, group_index, &group_index_a, &group_index_b);
 
+  XNN_UKERNEL_TIMING_LOCAL;
   while (mr_block_size > 0) {
     const size_t mr_step = min(mr_block_size, context->mr);
     if (context->quantization_params != NULL) {
@@ -379,8 +395,9 @@ void xnn_compute_hmp_grouped_gemm(struct gemm_context* restrict context,
         quantization_params = padded_quantization_params;
       };
 
-      context->dq_ukernel.function[uarch_index](
-          mr_step, nr_block_size, k_scaled,
+      XNN_UKERNEL_TIMING_RUN(
+          context->dq_ukernel.function[uarch_index], mr_step, nr_block_size,
+          k_scaled,
           (const void*)((uintptr_t)context->a + mr_block_start * a_stride +
                         group_index_a * context->ga_stride),
           a_stride,
@@ -392,8 +409,9 @@ void xnn_compute_hmp_grouped_gemm(struct gemm_context* restrict context,
                   group_index_c * context->gc_stride),
           cm_stride, context->cn_stride, &context->params, quantization_params);
     } else {
-      context->ukernel.function[uarch_index](
-          mr_step, nr_block_size, k_scaled,
+      XNN_UKERNEL_TIMING_RUN(
+          context->ukernel.function[uarch_index], mr_step, nr_block_size,
+          k_scaled,
           (const void*)((uintptr_t)context->a + mr_block_start * a_stride +
                         group_index_a * context->ga_stride),
           a_stride,
@@ -408,6 +426,7 @@ void xnn_compute_hmp_grouped_gemm(struct gemm_context* restrict context,
     mr_block_size -= mr_step;
     mr_block_start += mr_step;
   }
+  XNN_UKERNEL_TIMING_COMMIT(context->ukernel_elapsed_us[uarch_index]);
 }
 
 void xnn_compute_grouped_gemm(struct gemm_context* restrict context,
@@ -963,10 +982,11 @@ void xnn_compute_dwconv_unipass(struct dwconv_context* restrict context,
       context->output_pixel_stride -
       output_c_tile * context->output_channel_stride;
 
-  context->ukernel(output_c_tile, context->output_width, indirect_input,
-                   weights, output, context->indirect_input_width_stride,
-                   output_increment, input_offset, /*input_pixel_stride=*/0,
-                   context->zero, &context->params);
+  XNN_UKERNEL_TIMING_RUN_AND_COMMIT(
+      context->ukernel_elapsed_us, context->ukernel, output_c_tile,
+      context->output_width, indirect_input, weights, output,
+      context->indirect_input_width_stride, output_increment, input_offset,
+      /*input_pixel_stride=*/0, context->zero, &context->params);
 }
 
 void xnn_compute_dwconv2d_chw(struct dwconv2d_context* restrict context,
@@ -1230,7 +1250,9 @@ void xnn_compute_elementwise_binary_1d_tile(
   const void* a = (const void*)((uintptr_t)context->a + a_offset);
   const void* b = (const void*)((uintptr_t)context->b + b_offset);
   void* y = (void*)((uintptr_t)context->y + offset);
-  context->ukernel(count, a, b, y, &context->params);
+  XNN_UKERNEL_TIMING_RUN_AND_COMMIT(context->ukernel_elapsed_us,
+                                    context->ukernel, count, a, b, y,
+                                    &context->params);
 }
 
 void xnn_compute_elementwise_binary_1d(
@@ -1241,7 +1263,9 @@ void xnn_compute_elementwise_binary_1d(
     const void* b =
         (const void*)((uintptr_t)context->b + i * context->b_stride[4]);
     void* y = (void*)((uintptr_t)context->y + i * context->y_stride[4]);
-    context->ukernel(context->elements, a, b, y, &context->params);
+    XNN_UKERNEL_TIMING_RUN_AND_COMMIT(context->ukernel_elapsed_us,
+                                      context->ukernel, context->elements, a, b,
+                                      y, &context->params);
   }
 }
 
@@ -1252,10 +1276,11 @@ void xnn_compute_elementwise_binary_2d(
   uintptr_t b = (uintptr_t)context->b + i * context->b_stride[3];
   uintptr_t y = (uintptr_t)context->y + i * context->y_stride[3];
   for (size_t j = offset; j < offset + count; j++) {
-    context->ukernel(context->elements,
-                     (const void*)(a + j * context->a_stride[4]),
-                     (const void*)(b + j * context->b_stride[4]),
-                     (void*)(y + j * context->y_stride[4]), &context->params);
+    XNN_UKERNEL_TIMING_RUN_AND_COMMIT(
+        context->ukernel_elapsed_us, context->ukernel, context->elements,
+        (const void*)(a + j * context->a_stride[4]),
+        (const void*)(b + j * context->b_stride[4]),
+        (void*)(y + j * context->y_stride[4]), &context->params);
   }
 }
 
@@ -1267,8 +1292,8 @@ void xnn_compute_elementwise_binary_3d(
   uintptr_t y = (uintptr_t)context->y + i * context->y_stride[2];
   for (size_t j = offset_j; j < offset_j + count_j; j++) {
     for (size_t k = offset_k; k < offset_k + count_k; k++) {
-      context->ukernel(
-          context->elements,
+      XNN_UKERNEL_TIMING_RUN_AND_COMMIT(
+          context->ukernel_elapsed_us, context->ukernel, context->elements,
           (const void*)(a + j * context->a_stride[3] +
                         k * context->a_stride[4]),
           (const void*)(b + j * context->b_stride[3] +
@@ -1290,8 +1315,8 @@ void xnn_compute_elementwise_binary_4d(
                 j * context->y_stride[2];
   for (size_t k = offset_k; k < offset_k + count_k; k++) {
     for (size_t l = offset_l; l < offset_l + count_l; l++) {
-      context->ukernel(
-          context->elements,
+      XNN_UKERNEL_TIMING_RUN_AND_COMMIT(
+          context->ukernel_elapsed_us, context->ukernel, context->elements,
           (const void*)(a + k * context->a_stride[3] +
                         l * context->a_stride[4]),
           (const void*)(b + k * context->b_stride[3] +
@@ -1316,7 +1341,9 @@ void xnn_compute_elementwise_binary_5d(
   void* y = (void*)((uintptr_t)context->y + i * context->y_stride[0] +
                     j * context->y_stride[1] + k * context->y_stride[2] +
                     l * context->y_stride[3] + m * context->y_stride[4]);
-  context->ukernel(context->elements, a, b, y, &context->params);
+  XNN_UKERNEL_TIMING_RUN_AND_COMMIT(context->ukernel_elapsed_us,
+                                    context->ukernel, context->elements, a, b,
+                                    y, &context->params);
 }
 
 void xnn_compute_lut_strided(struct lut_strided_context* restrict context,
@@ -1348,7 +1375,9 @@ void xnn_compute_univector_strided(
   const void* x = (const void*)((uintptr_t)context->x + x_stride * batch_index);
   void* y = (void*)((uintptr_t)context->y + y_stride * batch_index);
   do {
-    context->ukernel(context->n, x, y, &context->params);
+    XNN_UKERNEL_TIMING_RUN_AND_COMMIT(context->ukernel_elapsed_us,
+                                      context->ukernel, context->n, x, y,
+                                      &context->params);
     x = (const void*)((uintptr_t)x + x_stride);
     y = (void*)((uintptr_t)y + y_stride);
   } while (--batch_range != 0);
@@ -1362,7 +1391,9 @@ void xnn_compute_univector_contiguous(
   const void* x = (const void*)((uintptr_t)context->x + offset);
   void* y =
       (void*)((uintptr_t)context->y + ((offset >> log2_xsize) << log2_ysize));
-  context->ukernel(size, x, y, &context->params);
+  XNN_UKERNEL_TIMING_RUN_AND_COMMIT(context->ukernel_elapsed_us,
+                                    context->ukernel, size, x, y,
+                                    &context->params);
 }
 
 void xnn_compute_contiguous_reduce(struct reduce_context* restrict context,
@@ -1414,8 +1445,9 @@ void xnn_compute_contiguous_reduce(struct reduce_context* restrict context,
         // output2_block_size output elements are written.
         for (size_t k = 0; k < output2_block_size; ++k) {
           // The microkernel reduces input dimension 5.
-          context->ukernel.contiguous_reduce(context->channels, input_row, output,
-                                             &context->params);
+          XNN_UKERNEL_TIMING_RUN_AND_COMMIT(
+              context->ukernel_elapsed_us, context->ukernel.contiguous_reduce,
+              context->channels, input_row, output, &context->params);
           // input_stride[4] is the number of bytes of input which have been
           // processed by the microkernel call.
           input_row = (const void*)((uintptr_t)input_row + input_stride[4]);
@@ -1484,6 +1516,7 @@ void xnn_compute_discontiguous_reduce(struct reduce_context* restrict context,
         context->accumulation_element_size, context->identity_value);
   }
 
+  XNN_UKERNEL_TIMING_LOCAL;
   if (context->channels != 0) {
     if (context->is_old_reduce) {
       // Input dimension 0 is reduced.
@@ -1492,8 +1525,9 @@ void xnn_compute_discontiguous_reduce(struct reduce_context* restrict context,
         for (size_t j = 0; j < input_shape2; ++j) {
           // The microkernel reduces input dimension 4 and iterates over
           // output_block_size elements of dimension 5.
-          context->ukernel.discontiguous_reduce(
-              context->channels, output2_block_size,
+          XNN_UKERNEL_TIMING_RUN(
+              context->ukernel.discontiguous_reduce, context->channels,
+              output2_block_size,
               (const void*)((uintptr_t)context->input + input_offset +
                             i * input_stride[0] + j * input_stride[2]),
               input_stride[4], context->zero,
@@ -1504,13 +1538,15 @@ void xnn_compute_discontiguous_reduce(struct reduce_context* restrict context,
     } else {
       // The microkernel reduces input dimension 0, 2 & 4 and iterates over
       // output_block_size elements of dimension 5.
-      context->ukernel.discontiguous_reduce2(
-          output2_block_size, context->channels, input_shape2, input_shape0,
+      XNN_UKERNEL_TIMING_RUN(
+          context->ukernel.discontiguous_reduce2, output2_block_size,
+          context->channels, input_shape2, input_shape0,
           (const void*)((uintptr_t)context->input + input_offset),
           input_stride[4], input_stride[2], input_stride[0], context->zero,
           output, &context->params);
     }
   }
+  XNN_UKERNEL_TIMING_COMMIT(context->ukernel_elapsed_us);
   // Convert to output datatype if accumulation type != output type.
   if (context->workspace) {
     void* workspace_ptr =
@@ -1768,8 +1804,10 @@ void xnn_compute_hmp_gemm(struct gemm_context* restrict context,
 
   while (mr_block_size > 0) {
     const size_t mr_step = min(mr_block_size, context->mr);
-    context->ukernel.function[uarch_index](
-        mr_step, nr_block_size, context->k_scaled,
+    XNN_UKERNEL_TIMING_RUN_AND_COMMIT(
+        context->ukernel_elapsed_us[uarch_index],
+        context->ukernel.function[uarch_index], mr_step, nr_block_size,
+        context->k_scaled,
         (const void*)((uintptr_t)context->a + mr_block_start * a_stride),
         a_stride,
         (const void*)((uintptr_t)context->packed_w +
@@ -1789,12 +1827,14 @@ void xnn_compute_hmp_dqgemm(struct gemm_context* restrict context,
   const size_t a_stride = context->a_stride;
   const size_t cm_stride = context->cm_stride;
 
+  XNN_UKERNEL_TIMING_LOCAL;
   while (mr_block_size > 0) {
     const size_t mr_step = min(mr_block_size, context->mr);
 
     if (context->with_row_sum) {
-      context->dq_qc2w_ukernel.function[uarch_index](
-          mr_step, nr_block_size, context->k_scaled,
+      XNN_UKERNEL_TIMING_RUN(
+          context->dq_qc2w_ukernel.function[uarch_index], mr_step,
+          nr_block_size, context->k_scaled,
           (const void*)((uintptr_t)context->a + mr_block_start * a_stride),
           a_stride,
           (const void*)((uintptr_t)context->packed_w +
@@ -1805,8 +1845,9 @@ void xnn_compute_hmp_dqgemm(struct gemm_context* restrict context,
           &context->row_sum[mr_block_start],
           &context->quantization_params[mr_block_start]);
     } else {
-      context->dq_ukernel.function[uarch_index](
-          mr_step, nr_block_size, context->k_scaled,
+      XNN_UKERNEL_TIMING_RUN(
+          context->dq_ukernel.function[uarch_index], mr_step, nr_block_size,
+          context->k_scaled,
           (const void*)((uintptr_t)context->a + mr_block_start * a_stride),
           a_stride,
           (const void*)((uintptr_t)context->packed_w +
@@ -1819,6 +1860,7 @@ void xnn_compute_hmp_dqgemm(struct gemm_context* restrict context,
     mr_block_size -= mr_step;
     mr_block_start += mr_step;
   }
+  XNN_UKERNEL_TIMING_COMMIT(context->ukernel_elapsed_us[uarch_index]);
 }
 
 void xnn_compute_hmp_igemm(struct igemm_context* restrict context,
@@ -1831,8 +1873,10 @@ void xnn_compute_hmp_igemm(struct igemm_context* restrict context,
 
   while (mr_block_size > 0) {
     const size_t mr_step = min(mr_block_size, context->mr);
-    context->ukernel.function[uarch_index](
-        mr_step, nr_block_size, context->kc, context->ks_scaled,
+    XNN_UKERNEL_TIMING_RUN_AND_COMMIT(
+        context->ukernel_elapsed_us[uarch_index],
+        context->ukernel.function[uarch_index], mr_step, nr_block_size,
+        context->kc, context->ks_scaled,
         (const void**)((uintptr_t)context->indirect_a +
                        mr_block_start * ks * sizeof(void*)),
         (const void*)((uintptr_t)context->packed_w +

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -31,12 +31,14 @@
 #include "src/xnnpack/math.h"
 #include "src/xnnpack/memory-planner.h"
 #include "src/xnnpack/memory.h"
+#include "src/xnnpack/microkernel-name-registry.h"
 #include "src/xnnpack/microkernel-type.h"
 #include "src/xnnpack/node-type.h"
 #include "src/xnnpack/operator-utils.h"
 #include "src/xnnpack/operator.h"
 #include "src/xnnpack/params.h"
 #include "src/xnnpack/subgraph.h"
+#include "src/xnnpack/timer.h"
 #include <pthreadpool.h>
 
 enum xnn_status xnn_reshape_external_value(
@@ -979,53 +981,155 @@ enum xnn_status xnn_setup_runtime_v2(
   return setup_runtime(runtime);
 }
 
-static xnn_timestamp xnn_read_timer() {
-  xnn_timestamp timestamp;
-#ifdef __MACH__
-  timestamp = clock_gettime_nsec_np(CLOCK_UPTIME_RAW);
-  if (timestamp == 0) {
-    xnn_log_warning("clock_gettime failed: error code %d", errno);
+// Returns the C symbol of whichever ukernel the operator currently
+// dispatches to, or "" if it can't be recovered. GEMM/IGEMM report the
+// bulk-loop ukernel (configured max MR); HMP returns the default-uarch
+// slot.
+static const char* resolve_operator_microkernel_name(
+    const struct xnn_operator* op) {
+  if (op == NULL) {
+    return "";
   }
-#elif __EMSCRIPTEN__
-  timestamp = emscripten_get_now();
-#elif XNN_PLATFORM_WINDOWS
-  BOOL res = QueryPerformanceCounter(&timestamp);
-  if (!res) {
-    xnn_log_error("QueryPerformanceCounter failed: error code %u", GetLastError());
-    memset(&timestamp, 0, sizeof(timestamp));
+  const void* fn = NULL;
+  switch (op->ukernel.type) {
+    case xnn_microkernel_type_gemm: {
+      const struct xnn_ukernel_gemm* g =
+          op->ukernel.gemm_ukernels ? &op->ukernel.gemm_ukernels->gemm : NULL;
+      if (g != NULL && g->mr > 0) {
+        fn = (const void*)g->gemm_cases[g->mr - 1].function[XNN_UARCH_DEFAULT];
+      }
+      break;
+    }
+    case xnn_microkernel_type_igemm: {
+      const struct xnn_ukernel_igemm* ig = op->ukernel.igemm;
+      if (ig != NULL && ig->mr > 0) {
+        fn = (const void*)ig->igemm_cases[ig->mr - 1]
+                 .function[XNN_UARCH_DEFAULT];
+      }
+      break;
+    }
+    case xnn_microkernel_type_dwconv:
+      fn = (const void*)op->ukernel.dwconv.ukernel;
+      break;
+    case xnn_microkernel_type_spmm:
+      fn = (const void*)op->ukernel.spmm.function;
+      break;
+    case xnn_microkernel_type_vmulcaddc:
+      fn = (const void*)op->ukernel.vmulcaddc.function;
+      break;
+    case xnn_microkernel_type_conv2d_hwc2chw:
+      fn = (const void*)op->ukernel.conv2d.hwc2chw_fn;
+      break;
+    case xnn_microkernel_type_default:
+      // vbinary/vunary install the selected fn on the per-execute compute
+      // context, not on op->ukernel.
+      switch (op->type) {
+        case xnn_operator_type_binary_elementwise:
+          fn = (const void*)op->context.elementwise_binary.ukernel;
+          break;
+        case xnn_operator_type_unary_elementwise:
+          // univector_{contiguous,strided} alias the same union slot.
+          fn = (const void*)op->context.univector_contiguous.ukernel;
+          break;
+        default:
+          if (op->ukernel.vunary.function != NULL) {
+            fn = (const void*)op->ukernel.vunary.function;
+          } else if (op->ukernel.vbinary.op_fn != NULL) {
+            fn = (const void*)op->ukernel.vbinary.op_fn;
+          }
+          break;
+      }
+      break;
+    case xnn_microkernel_type_transpose:
+      // const_size and variable_size alias the same union slot.
+      fn = (const void*)op->context.transpose.const_size_ukernel;
+      break;
+    case xnn_microkernel_type_reduce:
+    case xnn_microkernel_type_reduce2: {
+      // The three .ukernel union variants alias the same offset.
+      const struct reduce_context* rc = op->dynamic_context.reduce;
+      if (rc != NULL) {
+        fn = (const void*)rc->ukernel.contiguous_reduce;
+      }
+      break;
+    }
+    default:
+      // Pooling / subconv2d keep their fn on a config struct; not wired yet.
+      break;
   }
-#else
-  int res = clock_gettime(CLOCK_MONOTONIC, &timestamp);
-  if (res != 0) {
-    xnn_log_error("clock_gettime failed: error code %d", errno);
-    memset(&timestamp, 0, sizeof(timestamp));
-  }
-#endif
-  return timestamp;
+  const char* name = xnn_lookup_microkernel_name(fn);
+  return name != NULL ? name : "";
 }
 
-static inline uint64_t xnn_get_elapsed_time(const xnn_timestamp* start, const xnn_timestamp* end) {
-#ifdef __MACH__
-  const uint64_t kMicrosInNanos = 1000;
-  return (*end - *start) / kMicrosInNanos;
-#elif __EMSCRIPTEN__
-  const double kMillisInMicros = 1.0e3;
-  return (uint64_t) ((*end - *start) * kMillisInMicros);
-#elif XNN_PLATFORM_WINDOWS
-  const uint64_t kMicrosInSec = 1000 * 1000;
-  LARGE_INTEGER frequency;
-  BOOL res = QueryPerformanceFrequency(&frequency);
-  if (!res) {
-    xnn_log_error("QueryPerformanceFrequency failed: error code %u", GetLastError());
+// Microseconds summed across every ukernel-slot accumulator the operator
+// could have written to. Returns 0 when XNN_ENABLE_UKERNEL_TIMING is off
+// or when the op family hasn't been wired yet; callers can fall back to
+// the operator-level wall time.
+static uint64_t resolve_operator_microkernel_elapsed_us(
+    const struct xnn_operator* op) {
+#if XNN_ENABLE_UKERNEL_TIMING
+  if (op == NULL) {
     return 0;
   }
-  return ((end->QuadPart - start->QuadPart) * kMicrosInSec) / frequency.QuadPart;
+  uint64_t total = 0;
+  switch (op->ukernel.type) {
+    case xnn_microkernel_type_gemm: {
+      const struct gemm_op_context* goc = op->dynamic_context.gemm;
+      if (goc != NULL) {
+        for (size_t u = 0; u < XNN_MAX_UARCH_TYPES; u++) {
+          total += goc->gemm.ukernel_elapsed_us[u];
+        }
+      }
+      break;
+    }
+    case xnn_microkernel_type_igemm: {
+      const struct igemm_op_context* ioc = op->dynamic_context.igemm;
+      if (ioc != NULL) {
+        for (size_t u = 0; u < XNN_MAX_UARCH_TYPES; u++) {
+          total += ioc->igemm.ukernel_elapsed_us[u];
+        }
+      }
+      break;
+    }
+    case xnn_microkernel_type_default:
+      switch (op->type) {
+        case xnn_operator_type_binary_elementwise:
+          total = op->context.elementwise_binary.ukernel_elapsed_us;
+          break;
+        case xnn_operator_type_unary_elementwise:
+          // univector_{contiguous,strided} alias the same union slot.
+          total = op->context.univector_contiguous.ukernel_elapsed_us;
+          break;
+        default:
+          break;
+      }
+      break;
+    case xnn_microkernel_type_dwconv: {
+      const struct dwconv_op_context* doc = op->dynamic_context.dwconv;
+      if (doc != NULL) {
+        total = doc->dwconv.ukernel_elapsed_us;
+      }
+      break;
+    }
+    case xnn_microkernel_type_transpose:
+      total = op->context.transpose.ukernel_elapsed_us;
+      break;
+    case xnn_microkernel_type_reduce:
+    case xnn_microkernel_type_reduce2: {
+      const struct reduce_context* rc = op->dynamic_context.reduce;
+      if (rc != NULL) {
+        total = rc->ukernel_elapsed_us;
+      }
+      break;
+    }
+    default:
+      // Pooling / subconv2d keep their fn on a config struct; not wired yet.
+      break;
+  }
+  return total;
 #else
-  const uint64_t kNanosInMicro = UINT64_C(1000);
-  const uint64_t kNanosInSec = UINT64_C(1000000000);
-  const uint64_t secs = (end->tv_sec - start->tv_sec) * kNanosInSec;
-  const uint64_t ns_secs = (end->tv_nsec - start->tv_nsec);
-  return (secs + ns_secs) / kNanosInMicro;
+  (void)op;
+  return 0;
 #endif
 }
 
@@ -1116,6 +1220,62 @@ enum xnn_status xnn_get_runtime_profiling_info(xnn_runtime_t runtime,
               }
             }
             *data++ = op_time;
+          }
+        }
+      }
+      break;
+    }
+    case xnn_profile_info_microkernel_timing: {
+      // Same layout as xnn_profile_info_operator_timing; values are 0 when
+      // XNN_ENABLE_UKERNEL_TIMING is off.
+      size_t num_valid_ops = 0;
+      for (size_t i = 0; i < runtime->num_ops; ++i) {
+        if (opdata[i].operator_objects[0] != NULL) {
+          num_valid_ops += 1;
+        }
+      }
+      required_size = num_valid_ops * sizeof(uint64_t);
+      if (param_value_size < required_size) {
+        *param_value_size_ret = required_size;
+        status = xnn_status_out_of_memory;
+      } else {
+        uint64_t* data = (uint64_t*)param_value;
+        for (size_t i = 0; i < runtime->num_ops; ++i) {
+          if (opdata[i].operator_objects[0] != NULL) {
+            uint64_t op_us = 0;
+            for (size_t j = 0; j < XNN_MAX_OPERATOR_OBJECTS; j++) {
+              if (opdata[i].operator_objects[j] != NULL) {
+                op_us += resolve_operator_microkernel_elapsed_us(
+                    opdata[i].operator_objects[j]);
+              }
+            }
+            *data++ = op_us;
+          }
+        }
+      }
+      break;
+    }
+    case xnn_profile_info_microkernel_name: {
+      // Same NUL-separated layout as xnn_profile_info_operator_name.
+      for (size_t i = 0; i < runtime->num_ops; ++i) {
+        if (opdata[i].operator_objects[0] != NULL) {
+          const char* name =
+              resolve_operator_microkernel_name(opdata[i].operator_objects[0]);
+          required_size += strlen(name) + 1;
+        }
+      }
+      if (param_value_size < required_size) {
+        *param_value_size_ret = required_size;
+        status = xnn_status_out_of_memory;
+      } else {
+        char* out = (char*)param_value;
+        for (size_t i = 0; i < runtime->num_ops; ++i) {
+          if (opdata[i].operator_objects[0] != NULL) {
+            const char* name = resolve_operator_microkernel_name(
+                opdata[i].operator_objects[0]);
+            size_t n = strlen(name) + 1;
+            memcpy(out, name, n);
+            out += n;
           }
         }
       }

--- a/src/xnnpack/compute.h
+++ b/src/xnnpack/compute.h
@@ -14,6 +14,7 @@
 #include "src/xnnpack/config-types.h"
 #include "src/xnnpack/math.h"
 #include "src/xnnpack/microfnptr.h"
+#include "src/xnnpack/microkernel-timing.h"
 #include "src/xnnpack/microparams.h"
 #include <pthreadpool.h>
 
@@ -131,6 +132,10 @@ struct transpose_context {
   };
   size_t input_stride[XNN_MAX_TENSOR_DIMS];
   size_t output_stride[XNN_MAX_TENSOR_DIMS];
+#if XNN_ENABLE_UKERNEL_TIMING
+  // Shared by const_size / variable_size variants -- only one is live per op.
+  uint64_t ukernel_elapsed_us;
+#endif
 };
 
 XNN_PRIVATE void xnn_compute_transposec_2d(struct transpose_context* context,
@@ -371,6 +376,11 @@ struct gemm_context {
   // Whether to use the `dq_kernel` or not.
   bool dynamic_quantization;
   bool with_row_sum;
+#if XNN_ENABLE_UKERNEL_TIMING
+  // The ukernel/dq/dq_qc2w/qp8 variants alias the same union slot and only
+  // one is live per op; one accumulator covers all of them.
+  uint64_t ukernel_elapsed_us[XNN_MAX_UARCH_TYPES];
+#endif
 };
 
 XNN_PRIVATE void xnn_compute_grouped_gemm(
@@ -568,6 +578,10 @@ struct igemm_context {
   size_t workspace_offset;
   // Size, in bytes, of the workspace allocated to each thread.
   size_t per_thread_workspace_size;
+#if XNN_ENABLE_UKERNEL_TIMING
+  // ukernel and dq_ukernel alias the same union slot; one slot suffices.
+  uint64_t ukernel_elapsed_us[XNN_MAX_UARCH_TYPES];
+#endif
 };
 
 XNN_PRIVATE void xnn_compute_dqigemm(struct igemm_context* context,
@@ -728,6 +742,9 @@ struct dwconv_context {
     struct xnn_f32_minmax_params f32;
   } params;
   xnn_dwconv_ukernel_fn ukernel;
+#if XNN_ENABLE_UKERNEL_TIMING
+  uint64_t ukernel_elapsed_us;
+#endif
 };
 
 XNN_PRIVATE void xnn_compute_dwconv_indirection(
@@ -952,6 +969,9 @@ struct elementwise_binary_context {
   union xnn_binary_uparams params;
   xnn_vbinary_ukernel_fn ukernel;
   bool flip_a_b;
+#if XNN_ENABLE_UKERNEL_TIMING
+  uint64_t ukernel_elapsed_us;
+#endif
 };
 
 XNN_PRIVATE void xnn_compute_elementwise_binary_1d_tile(
@@ -1005,6 +1025,9 @@ struct univector_strided_context {
   size_t y_stride;
   xnn_vunary_ukernel_fn ukernel;
   union xnn_unary_uparams params;
+#if XNN_ENABLE_UKERNEL_TIMING
+  uint64_t ukernel_elapsed_us;
+#endif
 };
 
 XNN_PRIVATE void xnn_compute_univector_strided(
@@ -1018,6 +1041,9 @@ struct univector_contiguous_context {
   uint16_t log2_ysize;
   xnn_vunary_ukernel_fn ukernel;
   union xnn_unary_uparams params;
+#if XNN_ENABLE_UKERNEL_TIMING
+  uint64_t ukernel_elapsed_us;
+#endif
 };
 
 XNN_PRIVATE void xnn_compute_univector_contiguous(
@@ -1047,6 +1073,10 @@ struct reduce_context {
   // TODO(b/405244706): remove once all the datatypes and reductions are
   // supported.
   bool is_old_reduce;
+#if XNN_ENABLE_UKERNEL_TIMING
+  // Reduce-ukernel only; fill_ukernel / cvt_ukernel are bookkeeping.
+  uint64_t ukernel_elapsed_us;
+#endif
 };
 
 // Compute contiguous reduction over the 1st, 3rd and 5th dimensions of the

--- a/src/xnnpack/microkernel-name-registry.h
+++ b/src/xnnpack/microkernel-name-registry.h
@@ -1,0 +1,30 @@
+// Copyright 2026 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root of this source tree.
+
+// Function-pointer -> #ukernel symbol map populated as a side-effect of the
+// XNN_INIT_*_UKERNEL macros and consumed by xnn_get_runtime_profiling_info.
+
+#pragma once
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// First-registration wins; later calls with the same `fn_ptr` are no-ops.
+void xnn_register_microkernel_name(const void* fn_ptr, const char* name);
+
+// Returns NULL if `fn_ptr` was never registered or is NULL.
+const char* xnn_lookup_microkernel_name(const void* fn_ptr);
+
+// Use at every ukernel call site in src/configs/*-config.c so a release
+// build with the flag off can drop the `#ukernel` string literals entirely.
+#define XNN_REGISTER_UKERNEL_NAME(ukernel) \
+  xnn_register_microkernel_name((const void*)(ukernel), #ukernel)
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/xnnpack/microkernel-timing.h
+++ b/src/xnnpack/microkernel-timing.h
@@ -1,0 +1,75 @@
+// Copyright 2026 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root of this source tree.
+
+// Optional per-microkernel timing for the xnn_compute_* tile-task
+// callbacks. Gated behind XNN_ENABLE_UKERNEL_TIMING (default off) so
+// release builds get no extra fields and no overhead.
+//
+// Looped dispatcher (sum across iterations, one atomic-add at end):
+//   XNN_UKERNEL_TIMING_LOCAL;
+//   for (...) {
+//     XNN_UKERNEL_TIMING_RUN(ctx->ukernel, args, ...);
+//   }
+//   XNN_UKERNEL_TIMING_COMMIT(ctx->ukernel_elapsed_us);
+//
+// Single-call dispatcher (atomic-add inline):
+//   XNN_UKERNEL_TIMING_RUN_AND_COMMIT(ctx->ukernel_elapsed_us,
+//                                     ctx->ukernel, args, ...);
+//
+// Workers race the per-context slot via __atomic_fetch_add (RELAXED); the
+// reader runs after the pthreadpool join, which is the acquire barrier.
+
+#pragma once
+
+#ifndef XNN_ENABLE_UKERNEL_TIMING
+#define XNN_ENABLE_UKERNEL_TIMING 0
+#endif
+
+#if XNN_ENABLE_UKERNEL_TIMING
+
+#include <stdint.h>
+
+#include "src/xnnpack/subgraph.h"
+#include "src/xnnpack/timer.h"
+
+#define XNN_UKERNEL_TIMING_LOCAL uint64_t __ukernel_timing_local = 0
+
+#define XNN_UKERNEL_TIMING_RUN(fn_expr, ...)              \
+  do {                                                    \
+    const xnn_timestamp _xnn_ut_t0_ = xnn_read_timer();   \
+    (fn_expr)(__VA_ARGS__);                               \
+    const xnn_timestamp _xnn_ut_t1_ = xnn_read_timer();   \
+    __ukernel_timing_local +=                             \
+        xnn_get_elapsed_time(&_xnn_ut_t0_, &_xnn_ut_t1_); \
+  } while (0)
+
+#define XNN_UKERNEL_TIMING_COMMIT(target)                                      \
+  do {                                                                         \
+    if (__ukernel_timing_local != 0) {                                         \
+      __atomic_fetch_add(&(target), __ukernel_timing_local, __ATOMIC_RELAXED); \
+    }                                                                          \
+  } while (0)
+
+#define XNN_UKERNEL_TIMING_RUN_AND_COMMIT(target, fn_expr, ...)          \
+  do {                                                                   \
+    const xnn_timestamp _xnn_ut_t0_ = xnn_read_timer();                  \
+    (fn_expr)(__VA_ARGS__);                                              \
+    const xnn_timestamp _xnn_ut_t1_ = xnn_read_timer();                  \
+    const uint64_t _xnn_ut_elapsed_ =                                    \
+        xnn_get_elapsed_time(&_xnn_ut_t0_, &_xnn_ut_t1_);                \
+    if (_xnn_ut_elapsed_ != 0) {                                         \
+      __atomic_fetch_add(&(target), _xnn_ut_elapsed_, __ATOMIC_RELAXED); \
+    }                                                                    \
+  } while (0)
+
+#else  // !XNN_ENABLE_UKERNEL_TIMING
+
+#define XNN_UKERNEL_TIMING_LOCAL ((void)0)
+#define XNN_UKERNEL_TIMING_RUN(fn_expr, ...) ((fn_expr)(__VA_ARGS__))
+#define XNN_UKERNEL_TIMING_COMMIT(target) ((void)0)
+#define XNN_UKERNEL_TIMING_RUN_AND_COMMIT(target, fn_expr, ...) \
+  ((fn_expr)(__VA_ARGS__))
+
+#endif

--- a/src/xnnpack/timer.h
+++ b/src/xnnpack/timer.h
@@ -1,0 +1,73 @@
+// Copyright 2026 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root of this source tree.
+
+// Wall-clock timer shared between the runtime profiling path in
+// src/runtime.c and the per-microkernel timing in src/operator-run.c.
+// Deliberately does not include src/xnnpack/log.h: this header reaches
+// per-microkernel TUs that do not define XNN_LOG_LEVEL. Clock failures
+// silently zero the timestamp; the operator-level path keeps its
+// existing logging in src/runtime.c.
+
+#pragma once
+
+#include <stdint.h>
+#include <string.h>
+
+#include "src/xnnpack/common.h"
+#include "src/xnnpack/subgraph.h"
+
+#ifdef __MACH__
+#include <time.h>
+#elif defined(__EMSCRIPTEN__)
+#include <emscripten/emscripten.h>
+#elif XNN_PLATFORM_WINDOWS
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#else
+#include <time.h>
+#endif
+
+static inline xnn_timestamp xnn_read_timer(void) {
+  xnn_timestamp timestamp;
+#ifdef __MACH__
+  timestamp = clock_gettime_nsec_np(CLOCK_UPTIME_RAW);
+#elif defined(__EMSCRIPTEN__)
+  timestamp = emscripten_get_now();
+#elif XNN_PLATFORM_WINDOWS
+  if (!QueryPerformanceCounter(&timestamp)) {
+    memset(&timestamp, 0, sizeof(timestamp));
+  }
+#else
+  if (clock_gettime(CLOCK_MONOTONIC, &timestamp) != 0) {
+    memset(&timestamp, 0, sizeof(timestamp));
+  }
+#endif
+  return timestamp;
+}
+
+// Returns elapsed microseconds. The macOS branch divides nanoseconds; the
+// Emscripten branch scales milliseconds; the Windows branch normalises by
+// QueryPerformanceFrequency.
+static inline uint64_t xnn_get_elapsed_time(const xnn_timestamp* start,
+                                            const xnn_timestamp* end) {
+#ifdef __MACH__
+  return (*end - *start) / UINT64_C(1000);
+#elif defined(__EMSCRIPTEN__)
+  return (uint64_t)((*end - *start) * 1.0e3);
+#elif XNN_PLATFORM_WINDOWS
+  LARGE_INTEGER frequency;
+  if (!QueryPerformanceFrequency(&frequency)) {
+    return 0;
+  }
+  return ((end->QuadPart - start->QuadPart) * UINT64_C(1000000)) /
+         frequency.QuadPart;
+#else
+  const uint64_t secs = (end->tv_sec - start->tv_sec) * UINT64_C(1000000000);
+  const uint64_t ns_secs = end->tv_nsec - start->tv_nsec;
+  return (secs + ns_secs) / UINT64_C(1000);
+#endif
+}


### PR DESCRIPTION
XNNPACK exposes per-operator wall time but not the C symbol of the microkernel that dispatched nor the wall time spent inside it. This adds both to the public profiling API.

**Public API (`include/xnnpack.h`):**
```
enum xnn_profile_info {
  [...]
  xnn_profile_info_microkernel_name    -- NUL-separated C symbol names,
                                          parallel to operator_name.
  xnn_profile_info_microkernel_timing  -- uint64_t[] of microkernel wall
                                          time per operator (microseconds).
}
```

**Opt-in build flag:**
| Flag | Description |
| ---- | ---- |
| `-DXNN_ENABLE_UKERNEL_TIMING=1` (default off) | Bracket each ukernel call in `xnn_compute_*` with `xnn_read_timer` and fold the elapsed time into a per-context accumulator. Changes the layout of gemm/igemm/dwconv/transpose/reduce/elementwise_binary/univector_{contiguous,strided} contexts; must be set consistently across all XNNPACK TUs. |

Symbol-name registry
--------------------
Each `XNN_INIT_*_UKERNEL` macro in `src/configs/*-config.c` calls `XNN_REGISTER_UKERNEL_NAME(ukernel)`, which stores `(fn_ptr, "#ukernel")` in an open-addressed hash table (`src/microkernel-name-registry.{h,c}`).

Operator-side resolution
------------------------
`xnn_get_runtime_profiling_info` walks each operator's ukernel slot based on `op->ukernel.type` (and `op->type` for the "default" type used by vbinary/vunary), looks up the function pointer in the registry, and returns the matching symbol.

Per-microkernel timing
----------------------
`src/xnnpack/ukernel-timing.h` defines four macros driving the instrumentation; the storage they touch is an implicit `__ukernel_timing_local` accumulator plus per-context elapsed_us slots.

The looped form:
```
  XNN_UKERNEL_TIMING_LOCAL;
  for (...) {
    XNN_UKERNEL_TIMING_RUN(fn, args, ...);
  }
  XNN_UKERNEL_TIMING_COMMIT(target);
```

Or the single-call form:
```
  XNN_UKERNEL_TIMING_RUN_AND_COMMIT(target, fn, args);
```

The local accumulator sums inside the loop; one `__atomic_fetch_add` per tile-task publishes it to the per-context slot. Workers race the slot under RELAXED ordering; the reader runs after the pthreadpool join, which is the acquire barrier.

Each compute context (gemm, igemm, dwconv, transpose, reduce, elementwise_binary, univector_{contiguous,strided}) gains a single ukernel_elapsed_us slot under `#if XNN_ENABLE_UKERNEL_TIMING`. The gemm and igemm union variants (dq/dq_qc2w/qp8) alias the same union slot and only one is live per op, so one accumulator covers all of them.

`xnn_read_timer` / `xnn_get_elapsed_time` move out of `src/runtime.c` into `src/xnnpack/timer.h` so `operator-run.c` can share the platform shims. The header deliberately does not pull in `log.h`, which would require `XNN_LOG_LEVEL` set on every TU that transitively includes `compute.h`.

`XNN_ENABLE_UKERNEL_TIMING` adds a u64 per context plus a `read_timer` pair per ukernel call; the static-lib delta is in the low-percent range.