### PR TITLE
reject overflowing output dimensions in constant pad reshape

### DIFF
--- a/src/operators/constant-pad-nd.c
+++ b/src/operators/constant-pad-nd.c
@@ -16,6 +16,7 @@
 #include "src/xnnpack/config-types.h"
 #include "src/xnnpack/config.h"
 #include "src/xnnpack/log.h"
+#include "src/xnnpack/math.h"
 #include "src/xnnpack/operator-type.h"
 #include "src/xnnpack/operator-utils.h"
 #include "src/xnnpack/operator.h"
@@ -183,9 +184,17 @@ static enum xnn_status reshape_constant_pad_nd(
 
     const bool is_current_dim_padded = (pre_padding | post_padding) != 0;
     if (is_current_dim_padded || is_previous_dim_padded) {
+      size_t output_dim;
+      if (!xnn_safe_add(pre_padding, input_dim, &output_dim) ||
+          !xnn_safe_add(output_dim, post_padding, &output_dim)) {
+        xnn_log_error(
+            "failed to reshape %s operator: padded dimension overflows size_t",
+            xnn_operator_type_to_string_v2(constant_pad_op));
+        return xnn_status_unsupported_parameter;
+      }
       normalized_pre_paddings[XNN_MAX_TENSOR_DIMS - 1 - num_squeezed_dims] = pre_padding;
       normalized_input_shape[XNN_MAX_TENSOR_DIMS - 1 - num_squeezed_dims] = input_dim;
-      normalized_output_shape[XNN_MAX_TENSOR_DIMS - 1 - num_squeezed_dims] = pre_padding + input_dim + post_padding;
+      normalized_output_shape[XNN_MAX_TENSOR_DIMS - 1 - num_squeezed_dims] = output_dim;
 
       num_squeezed_dims += 1;
       is_previous_dim_padded = is_current_dim_padded;

--- a/src/subgraph/static-constant-pad.c
+++ b/src/subgraph/static-constant-pad.c
@@ -117,7 +117,16 @@ static enum xnn_status reshape_constant_pad_operator(
   struct xnn_runtime_value* output_value = values + output_id;
   output_value->shape.num_dims = input_value->shape.num_dims;
   for (size_t i = 0; i < input_value->shape.num_dims; ++i) {
-    output_value->shape.dim[i] = input_value->shape.dim[i] + opdata->pre_paddings[i] + opdata->post_paddings[i];
+    size_t output_dim;
+    if (!xnn_safe_add(input_value->shape.dim[i], opdata->pre_paddings[i], &output_dim) ||
+        !xnn_safe_add(output_dim, opdata->post_paddings[i], &output_dim)) {
+      xnn_log_error(
+          "failed to reshape %s operator with output ID #%" PRIu32
+          ": padded dimension #%zu overflows size_t",
+          xnn_node_type_to_string(xnn_node_type_static_constant_pad), output_id, i);
+      return xnn_status_invalid_parameter;
+    }
+    output_value->shape.dim[i] = output_dim;
   }
   const size_t new_size = xnn_runtime_tensor_get_size(output_value);
   if (new_size > output_value->size || opdata->workspace_size > old_workspace_size) {


### PR DESCRIPTION
Each padded output dimension is computed as `input_dim + pre_padding + post_padding` in `size_t` with no overflow check (constant-pad-nd.c:188 and static-constant-pad.c:120), so a large padding value wraps the sum to a small dimension that slips past the multiply-only overflow guard in `xnn_runtime_tensor_get_size`, producing an undersized output tensor. Use `xnn_safe_add` and reject the reshape when the addition overflows.