### PR TITLE
Fix heap out-of-bounds write in `CONCATENATE` with mismatched non-axis input dimensions

### DIFF
--- a/src/subgraph/concatenate.c
+++ b/src/subgraph/concatenate.c
@@ -126,6 +126,37 @@ static enum xnn_status reshape_concatenate_operator(
   if (axis < 0) {
     axis += values[input_id[0]].shape.num_dims;
   }
+
+  // All inputs must share the same rank and identical dimensions on every axis
+  // except the concatenation axis. Without this check, an input whose post-axis
+  // dimensions differ from input0's would make the per-row copy stride exceed
+  // the output buffer size computed below (which is derived from input0's
+  // shape), producing an out-of-bounds write in the copy micro-kernel.
+  const size_t num_dims = values[input_id[0]].shape.num_dims;
+  for (size_t i = 1; i < num_inputs; ++i) {
+    if (values[input_id[i]].shape.num_dims != num_dims) {
+      xnn_log_error(
+          "failed to reshape %s operator: input #%zu has %zu dimensions but "
+          "input #0 has %zu dimensions; all inputs must have the same rank",
+          xnn_node_type_to_string(xnn_node_type_concatenate), i,
+          values[input_id[i]].shape.num_dims, num_dims);
+      return xnn_status_invalid_parameter;
+    }
+    for (size_t j = 0; j < num_dims; ++j) {
+      if ((int32_t) j != axis &&
+          values[input_id[i]].shape.dim[j] != values[input_id[0]].shape.dim[j]) {
+        xnn_log_error(
+            "failed to reshape %s operator: input #%zu dimension %zu (%zu) does "
+            "not match input #0 dimension %zu (%zu); all inputs must have "
+            "identical dimensions except along the concatenation axis (%d)",
+            xnn_node_type_to_string(xnn_node_type_concatenate), i, j,
+            values[input_id[i]].shape.dim[j], j,
+            values[input_id[0]].shape.dim[j], axis);
+        return xnn_status_invalid_parameter;
+      }
+    }
+  }
+
   size_t output_stride = 0;
   for (size_t i = 0; i < num_inputs; ++i) {
     for (size_t j = axis; j < values[input_id[0]].shape.num_dims; j++) {


### PR DESCRIPTION
## Summary

`reshape_concatenate_operator` (`src/subgraph/concatenate.c`) does not verify that the
concatenation inputs share the same rank and the same dimensions on every axis except the
concatenation axis. When an input `i > 0` has a larger trailing (post-axis) dimension product
than input 0, the per-row copy stride (`output_stride`, summed from each input's own post-axis
product) exceeds the output buffer size (which is derived from input 0's shape). The copy
micro-kernel then writes past the end of the output allocation.

This is a heap out-of-bounds **write** with attacker control of both length and content, reachable
from an untrusted model through the default float XNNPACK delegate. It violates the documented
guarantee in `include/xnnpack.h` that XNNPACK "never writes beyond array bounds."

## Root cause

In `reshape_concatenate_operator`:

- `output_stride` is accumulated from **each input's own** post-axis dimension product.
- The output value's non-axis dimensions are copied from **input 0 only**, and only `dim[axis]`
  is summed across inputs to size the output.

If a sibling input's post-axis product is larger than input 0's, `output_stride` becomes larger
than the number of elements the output buffer is sized for, and the copy
(`xnn_xx_copy_ukernel__scalar_memcpy`, a plain `memcpy`) overruns the output. The asserts in this
file are compiled out in release builds (`-DNDEBUG`), so nothing else catches the mismatch.

## Fix

Add an explicit shape check at the start of `reshape_concatenate_operator`, after axis
normalization and before `output_stride` is computed: every input must have the same number of
dimensions as input 0, and must match input 0 on every axis except the concatenation axis.
Otherwise the operator returns `xnn_status_invalid_parameter` and logs a descriptive error.

The check is placed in `reshape` rather than `xnn_define_concatenate` because that is where the
concrete shapes are available and where the unsafe stride is computed; this also covers
dynamically reshaped runtimes. It is the minimal change that closes the overflow without affecting
the valid path.

## Validation

Built with AddressSanitizer (`RelWithDebInfo`, asserts off — production-like).

**Before the fix** — fp32 concat, axis=1, input0=`[1,1,1]`, input1=`[1,1,4096]`, output declared
`[1,2,1]`, output buffer allocated at XNN-reported size **plus** the full `XNN_EXTRA_BYTES`:

```
ERROR: AddressSanitizer: heap-buffer-overflow
WRITE of size 16384 ... in __asan_memcpy
    #1 xnn_xx_copy_ukernel__scalar_memcpy src/xx-copy/xx-copy-scalar-memcpy.c:18
    #3 xnn_run_operator_with_index src/operator-run.c:1993
    #4 xnn_invoke_runtime src/runtime.c:1168
0x... is located 0 bytes after 24-byte region   # 8 reported + 16 XNN_EXTRA_BYTES
```

**After the fix** — same input: `xnn_reshape_runtime` returns `xnn_status_invalid_parameter`. No
overflow, no ASan report, no crash.

**Positive control (regression check)** — a valid concat (input0=`[1,2,3]`, input1=`[1,4,3]`,
axis=1, output=`[1,6,3]`) still succeeds and produces correct output (18 elements) with no ASan
report. Valid concatenation is unaffected.

## Related but distinct

This is the concatenate code path. A separate report (#9982) describes an over-**read** in
`xnn_compute_univector_strided` (univector elementwise), within the `XNN_EXTRA_BYTES` slack. This
PR fixes a different defect: an over-**write** in the concatenate path, past a fully padded buffer,
caused by missing cross-input shape validation.

## Suggested companion change (TensorFlow Lite delegate)

`VisitConcatenationNode` in `tensorflow/lite/delegates/xnnpack/xnnpack_delegate.cc` does not call
`CheckTensorsDimensionMatch` (unlike sibling visitors), so a mismatched-trailing-dim concat is
accepted and delegated, bypassing the builtin `CONCATENATION` `Prepare` validation. Adding that
check there would reject such models at delegation time. (Filed/should be filed against the
tensorflow/tensorflow repository; this PR fixes the underlying XNNPACK defect.)