### PR TITLE
Guard indirection buffer size against overflow in igemm reshape

### DIFF
--- a/src/operators/convolution-nhwc.c
+++ b/src/operators/convolution-nhwc.c
@@ -2621,8 +2621,17 @@ static enum xnn_status reshape_igemm(
   struct xnn_hmp_igemm_ukernel igemm_ukernel = igemm_cases[mr - 1];
 
   const size_t tiled_output_size = round_up(output_size, mr);
-  const size_t indirection_buffer_size =
-      sizeof(void*) * kernel_size * tiled_output_size;
+  size_t indirection_buffer_size = 0;
+  if (!xnn_safe_mul(kernel_size, tiled_output_size, &indirection_buffer_size) ||
+      !xnn_safe_mul(indirection_buffer_size, sizeof(void*),
+                    &indirection_buffer_size)) {
+    xnn_log_error(
+        "failed to reshape %s operator: indirection buffer size overflows for "
+        "kernel size %zu and tiled output size %zu",
+        xnn_operator_type_to_string_v2(convolution_op), kernel_size,
+        tiled_output_size);
+    return xnn_status_out_of_memory;
+  }
   struct compute_parameters* igemm_compute = &convolution_op->compute[0];
 
   if (convolution_op->flags & XNN_FLAG_TRANSIENT_INDIRECTION_BUFFER) {

--- a/src/operators/deconvolution-nhwc.c
+++ b/src/operators/deconvolution-nhwc.c
@@ -1762,8 +1762,17 @@ static enum xnn_status reshape_igemm_path(
   struct xnn_hmp_igemm_ukernel igemm_ukernel = igemm_cases[mr - 1];
 
   const size_t tiled_output_size = round_up(output_size, mr);
-  const size_t indirection_buffer_size =
-      sizeof(void*) * kernel_size * tiled_output_size;
+  size_t indirection_buffer_size = 0;
+  if (!xnn_safe_mul(kernel_size, tiled_output_size, &indirection_buffer_size) ||
+      !xnn_safe_mul(indirection_buffer_size, sizeof(void*),
+                    &indirection_buffer_size)) {
+    xnn_log_error(
+        "failed to reshape %s operator: indirection buffer size overflows for "
+        "kernel size %zu and tiled output size %zu",
+        xnn_operator_type_to_string_v2(deconvolution_op), kernel_size,
+        tiled_output_size);
+    return xnn_status_out_of_memory;
+  }
 
   if (input_height != deconvolution_op->convolution_op->last_input_height ||
       input_width != deconvolution_op->convolution_op->last_input_width) {


### PR DESCRIPTION
Reading through the igemm reshape paths, the indirection buffer size is a raw product:

    sizeof(void*) * kernel_size * tiled_output_size

With kernel_size around 2^32 and tiled_output_size around 2^30 this wraps to 0, so xnn_reallocate_memory hands back a tiny (or NULL) buffer while xnn_indirection_init_conv2d still writes kernel_size * tiled_output_size pointers into it. That is a heap overflow on the first write, not a benign allocation failure.

tensor.c already routes its allocation-size maths through xnn_safe_mul; the operator indirection sizing was the spot that still multiplied raw. Same guard applied to both the convolution and deconvolution igemm paths, rejecting the reshape with out_of_memory when the product overflows.