### PR TITLE
Validate expand-dims axes in resize_expand_dims_output_tensor

### DIFF
--- a/src/subgraph/copy.c
+++ b/src/subgraph/copy.c
@@ -175,12 +175,20 @@ static enum xnn_status resize_expand_dims_output_tensor(
     return xnn_status_success;
   }
   for (int i = 0; i < num_output_dims; ++i) {
-    if (new_axes[axes_iter] == i) {
+    if (axes_iter < opdata->num_reshape_dims && new_axes[axes_iter] == i) {
       output_shape->dim[i] = 1;
       ++axes_iter;
     } else {
       output_shape->dim[i] = input_shape->dim[input_iter++];
     }
+  }
+  if (axes_iter != opdata->num_reshape_dims) {
+    xnn_log_error("failed to expand dims in %s operator with input ID #%" PRIu32
+                  " and output ID #%" PRIu32
+                  ": expansion axes must be sorted and within [0, %zu)",
+                  xnn_node_type_to_string(xnn_node_type_static_expand_dims),
+                  input_id, output_id, num_output_dims);
+    return xnn_status_invalid_parameter;
   }
 
   const size_t new_size = xnn_runtime_tensor_get_size(output);


### PR DESCRIPTION
Reading expand-dims next to the matching fold in subgraph.c, the runtime loop is missing the axis-iterator bound that fold has. The define entry point never range-checks the axes, so a model can pass an out-of-range axis and walk off the input rank:

    input    [4, 4]    -> 16 elements
    new_axes [9]       -> matches no output position
    output   [4, 4, 0] -> 0 elements

input_iter runs past num_dims and the output element count no longer matches the input, but reshape_copy_operator still copies batch_size (taken from the input shape) into the smaller output buffer, an out-of-bounds write in the copy kernel. static_reshape in this file already rejects an element-count mismatch; expand-dims did not.

Bound axes_iter in the loop and reject the reshape when the axes are not all consumed (out-of-range, duplicate or unsorted).