### PR TITLE
Fix sqrt(+inf) evaluates to NaN under -ffast-math due to x * rsqrt(x) approximation

### DIFF
--- a/src/f32-vsqrt/gen/f32-vsqrt-avx-rsqrt.c
+++ b/src/f32-vsqrt/gen/f32-vsqrt-avx-rsqrt.c
@@ -1,7 +1,7 @@
 // clang-format off
 // Auto-generated file. Do not edit!
 //   Template: src/f32-vsqrt/simd-rsqrt.c.in
-//   Generator: tools/xngen
+//   Generator: tools/xngen.py
 //
 // Copyright 2025 Google LLC
 //
@@ -62,6 +62,8 @@ void xnn_f32_vsqrt_ukernel__avx_rsqrt_u8(
   // Constants for the Newton-Raphson iteration.
   const xnn_simd_f32_t kOne = xnn_set1_f32(1.0f);
   const xnn_simd_f32_t kHalf = xnn_set1_f32(0.5f);
+  // +inf represented as exact IEEE 754 bit pattern, safe under -ffast-math.
+  XNN_SIMD_CONST_F32_FROM_INT32(vinf, INT32_C(0x7F800000));
 
 
   for (; batch >= xnn_simd_bytes_f32; batch -= xnn_simd_bytes_f32) {
@@ -89,7 +91,13 @@ void xnn_f32_vsqrt_ukernel__avx_rsqrt_u8(
 
     // Extract the square root by multiplying the original value with the
     // inverse square root.
-    const xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+    xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+
+    // Blend +inf back for +inf inputs: rsqrt(+inf)=0, so inf*0=NaN without this.
+    const xnn_simd_f32_t vposinf_mask = xnn_cmpeq_f32(vx, vinf);
+    vy = xnn_or_f32(
+        xnn_and_f32(vposinf_mask, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask), vy));
 
     xnn_storeu_f32(output, vy);
     output += xnn_simd_size_f32;
@@ -121,11 +129,18 @@ void xnn_f32_vsqrt_ukernel__avx_rsqrt_u8(
 
     // Extract the square root by multiplying the original value with the
     // inverse square root.
-    const xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+    xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+
+    // Blend +inf back for +inf inputs: rsqrt(+inf)=0, so inf*0=NaN without this.
+    const xnn_simd_f32_t vposinf_mask = xnn_cmpeq_f32(vx, vinf);
+    vy = xnn_or_f32(
+        xnn_and_f32(vposinf_mask, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask), vy));
 
     xnn_store_tail_f32(output, vy, batch >> XNN_LOG2_SIZEOF_FLOAT);
   }
 }
+
 
 void xnn_f32_vsqrt_ukernel__avx_rsqrt_u16(
     size_t batch, const float* input, float* output,
@@ -138,6 +153,8 @@ void xnn_f32_vsqrt_ukernel__avx_rsqrt_u16(
   // Constants for the Newton-Raphson iteration.
   const xnn_simd_f32_t kOne = xnn_set1_f32(1.0f);
   const xnn_simd_f32_t kHalf = xnn_set1_f32(0.5f);
+  // +inf represented as exact IEEE 754 bit pattern, safe under -ffast-math.
+  XNN_SIMD_CONST_F32_FROM_INT32(vinf, INT32_C(0x7F800000));
 
   for (; batch >= 16 * sizeof(float); batch -= 16 * sizeof(float)) {
     const xnn_simd_f32_t vx0 = xnn_loadu_f32(input);
@@ -174,8 +191,17 @@ void xnn_f32_vsqrt_ukernel__avx_rsqrt_u16(
 
     // Extract the square root by multiplying the original value with the
     // inverse square root.
-    const xnn_simd_f32_t vy0 = xnn_mul_f32(vx0, vt7_0);
-    const xnn_simd_f32_t vy1 = xnn_mul_f32(vx1, vt7_1);
+    xnn_simd_f32_t vy0 = xnn_mul_f32(vx0, vt7_0);
+    xnn_simd_f32_t vy1 = xnn_mul_f32(vx1, vt7_1);
+    // Blend +inf back for +inf inputs: rsqrt(+inf)=0, so inf*0=NaN without this.
+    const xnn_simd_f32_t vposinf_mask_0 = xnn_cmpeq_f32(vx0, vinf);
+    const xnn_simd_f32_t vposinf_mask_1 = xnn_cmpeq_f32(vx1, vinf);
+    vy0 = xnn_or_f32(
+        xnn_and_f32(vposinf_mask_0, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask_0), vy0));
+    vy1 = xnn_or_f32(
+        xnn_and_f32(vposinf_mask_1, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask_1), vy1));
 
     // Store the results.
     xnn_storeu_f32(output, vy0);
@@ -208,7 +234,13 @@ void xnn_f32_vsqrt_ukernel__avx_rsqrt_u16(
 
     // Extract the square root by multiplying the original value with the
     // inverse square root.
-    const xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+    xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+
+    // Blend +inf back for +inf inputs: rsqrt(+inf)=0, so inf*0=NaN without this.
+    const xnn_simd_f32_t vposinf_mask = xnn_cmpeq_f32(vx, vinf);
+    vy = xnn_or_f32(
+        xnn_and_f32(vposinf_mask, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask), vy));
 
     xnn_storeu_f32(output, vy);
     output += xnn_simd_size_f32;
@@ -240,11 +272,18 @@ void xnn_f32_vsqrt_ukernel__avx_rsqrt_u16(
 
     // Extract the square root by multiplying the original value with the
     // inverse square root.
-    const xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+    xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+
+    // Blend +inf back for +inf inputs: rsqrt(+inf)=0, so inf*0=NaN without this.
+    const xnn_simd_f32_t vposinf_mask = xnn_cmpeq_f32(vx, vinf);
+    vy = xnn_or_f32(
+        xnn_and_f32(vposinf_mask, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask), vy));
 
     xnn_store_tail_f32(output, vy, batch >> XNN_LOG2_SIZEOF_FLOAT);
   }
 }
+
 
 void xnn_f32_vsqrt_ukernel__avx_rsqrt_u32(
     size_t batch, const float* input, float* output,
@@ -257,6 +296,8 @@ void xnn_f32_vsqrt_ukernel__avx_rsqrt_u32(
   // Constants for the Newton-Raphson iteration.
   const xnn_simd_f32_t kOne = xnn_set1_f32(1.0f);
   const xnn_simd_f32_t kHalf = xnn_set1_f32(0.5f);
+  // +inf represented as exact IEEE 754 bit pattern, safe under -ffast-math.
+  XNN_SIMD_CONST_F32_FROM_INT32(vinf, INT32_C(0x7F800000));
 
   for (; batch >= 32 * sizeof(float); batch -= 32 * sizeof(float)) {
     const xnn_simd_f32_t vx0 = xnn_loadu_f32(input);
@@ -313,10 +354,27 @@ void xnn_f32_vsqrt_ukernel__avx_rsqrt_u32(
 
     // Extract the square root by multiplying the original value with the
     // inverse square root.
-    const xnn_simd_f32_t vy0 = xnn_mul_f32(vx0, vt7_0);
-    const xnn_simd_f32_t vy1 = xnn_mul_f32(vx1, vt7_1);
-    const xnn_simd_f32_t vy2 = xnn_mul_f32(vx2, vt7_2);
-    const xnn_simd_f32_t vy3 = xnn_mul_f32(vx3, vt7_3);
+    xnn_simd_f32_t vy0 = xnn_mul_f32(vx0, vt7_0);
+    xnn_simd_f32_t vy1 = xnn_mul_f32(vx1, vt7_1);
+    xnn_simd_f32_t vy2 = xnn_mul_f32(vx2, vt7_2);
+    xnn_simd_f32_t vy3 = xnn_mul_f32(vx3, vt7_3);
+    // Blend +inf back for +inf inputs: rsqrt(+inf)=0, so inf*0=NaN without this.
+    const xnn_simd_f32_t vposinf_mask_0 = xnn_cmpeq_f32(vx0, vinf);
+    const xnn_simd_f32_t vposinf_mask_1 = xnn_cmpeq_f32(vx1, vinf);
+    const xnn_simd_f32_t vposinf_mask_2 = xnn_cmpeq_f32(vx2, vinf);
+    const xnn_simd_f32_t vposinf_mask_3 = xnn_cmpeq_f32(vx3, vinf);
+    vy0 = xnn_or_f32(
+        xnn_and_f32(vposinf_mask_0, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask_0), vy0));
+    vy1 = xnn_or_f32(
+        xnn_and_f32(vposinf_mask_1, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask_1), vy1));
+    vy2 = xnn_or_f32(
+        xnn_and_f32(vposinf_mask_2, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask_2), vy2));
+    vy3 = xnn_or_f32(
+        xnn_and_f32(vposinf_mask_3, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask_3), vy3));
 
     // Store the results.
     xnn_storeu_f32(output, vy0);
@@ -351,7 +409,13 @@ void xnn_f32_vsqrt_ukernel__avx_rsqrt_u32(
 
     // Extract the square root by multiplying the original value with the
     // inverse square root.
-    const xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+    xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+
+    // Blend +inf back for +inf inputs: rsqrt(+inf)=0, so inf*0=NaN without this.
+    const xnn_simd_f32_t vposinf_mask = xnn_cmpeq_f32(vx, vinf);
+    vy = xnn_or_f32(
+        xnn_and_f32(vposinf_mask, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask), vy));
 
     xnn_storeu_f32(output, vy);
     output += xnn_simd_size_f32;
@@ -383,8 +447,15 @@ void xnn_f32_vsqrt_ukernel__avx_rsqrt_u32(
 
     // Extract the square root by multiplying the original value with the
     // inverse square root.
-    const xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+    xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+
+    // Blend +inf back for +inf inputs: rsqrt(+inf)=0, so inf*0=NaN without this.
+    const xnn_simd_f32_t vposinf_mask = xnn_cmpeq_f32(vx, vinf);
+    vy = xnn_or_f32(
+        xnn_and_f32(vposinf_mask, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask), vy));
 
     xnn_store_tail_f32(output, vy, batch >> XNN_LOG2_SIZEOF_FLOAT);
   }
 }
+

--- a/src/f32-vsqrt/gen/f32-vsqrt-avx512f-rsqrt.c
+++ b/src/f32-vsqrt/gen/f32-vsqrt-avx512f-rsqrt.c
@@ -1,7 +1,7 @@
 // clang-format off
 // Auto-generated file. Do not edit!
 //   Template: src/f32-vsqrt/simd-rsqrt.c.in
-//   Generator: tools/xngen
+//   Generator: tools/xngen.py
 //
 // Copyright 2025 Google LLC
 //
@@ -62,6 +62,8 @@ void xnn_f32_vsqrt_ukernel__avx512f_rsqrt_u16(
   // Constants for the Newton-Raphson iteration.
   const xnn_simd_f32_t kOne = xnn_set1_f32(1.0f);
   const xnn_simd_f32_t kHalf = xnn_set1_f32(0.5f);
+  // +inf represented as exact IEEE 754 bit pattern, safe under -ffast-math.
+  XNN_SIMD_CONST_F32_FROM_INT32(vinf, INT32_C(0x7F800000));
 
 
   for (; batch >= xnn_simd_bytes_f32; batch -= xnn_simd_bytes_f32) {
@@ -89,7 +91,13 @@ void xnn_f32_vsqrt_ukernel__avx512f_rsqrt_u16(
 
     // Extract the square root by multiplying the original value with the
     // inverse square root.
-    const xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+    xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+
+    // Blend +inf back for +inf inputs: rsqrt(+inf)=0, so inf*0=NaN without this.
+    const xnn_simd_f32_t vposinf_mask = xnn_cmpeq_f32(vx, vinf);
+    vy = xnn_or_f32(
+        xnn_and_f32(vposinf_mask, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask), vy));
 
     xnn_storeu_f32(output, vy);
     output += xnn_simd_size_f32;
@@ -121,11 +129,18 @@ void xnn_f32_vsqrt_ukernel__avx512f_rsqrt_u16(
 
     // Extract the square root by multiplying the original value with the
     // inverse square root.
-    const xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+    xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+
+    // Blend +inf back for +inf inputs: rsqrt(+inf)=0, so inf*0=NaN without this.
+    const xnn_simd_f32_t vposinf_mask = xnn_cmpeq_f32(vx, vinf);
+    vy = xnn_or_f32(
+        xnn_and_f32(vposinf_mask, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask), vy));
 
     xnn_store_tail_f32(output, vy, batch >> XNN_LOG2_SIZEOF_FLOAT);
   }
 }
+
 
 void xnn_f32_vsqrt_ukernel__avx512f_rsqrt_u32(
     size_t batch, const float* input, float* output,
@@ -138,6 +153,8 @@ void xnn_f32_vsqrt_ukernel__avx512f_rsqrt_u32(
   // Constants for the Newton-Raphson iteration.
   const xnn_simd_f32_t kOne = xnn_set1_f32(1.0f);
   const xnn_simd_f32_t kHalf = xnn_set1_f32(0.5f);
+  // +inf represented as exact IEEE 754 bit pattern, safe under -ffast-math.
+  XNN_SIMD_CONST_F32_FROM_INT32(vinf, INT32_C(0x7F800000));
 
   for (; batch >= 32 * sizeof(float); batch -= 32 * sizeof(float)) {
     const xnn_simd_f32_t vx0 = xnn_loadu_f32(input);
@@ -174,8 +191,17 @@ void xnn_f32_vsqrt_ukernel__avx512f_rsqrt_u32(
 
     // Extract the square root by multiplying the original value with the
     // inverse square root.
-    const xnn_simd_f32_t vy0 = xnn_mul_f32(vx0, vt7_0);
-    const xnn_simd_f32_t vy1 = xnn_mul_f32(vx1, vt7_1);
+    xnn_simd_f32_t vy0 = xnn_mul_f32(vx0, vt7_0);
+    xnn_simd_f32_t vy1 = xnn_mul_f32(vx1, vt7_1);
+    // Blend +inf back for +inf inputs: rsqrt(+inf)=0, so inf*0=NaN without this.
+    const xnn_simd_f32_t vposinf_mask_0 = xnn_cmpeq_f32(vx0, vinf);
+    const xnn_simd_f32_t vposinf_mask_1 = xnn_cmpeq_f32(vx1, vinf);
+    vy0 = xnn_or_f32(
+        xnn_and_f32(vposinf_mask_0, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask_0), vy0));
+    vy1 = xnn_or_f32(
+        xnn_and_f32(vposinf_mask_1, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask_1), vy1));
 
     // Store the results.
     xnn_storeu_f32(output, vy0);
@@ -208,7 +234,13 @@ void xnn_f32_vsqrt_ukernel__avx512f_rsqrt_u32(
 
     // Extract the square root by multiplying the original value with the
     // inverse square root.
-    const xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+    xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+
+    // Blend +inf back for +inf inputs: rsqrt(+inf)=0, so inf*0=NaN without this.
+    const xnn_simd_f32_t vposinf_mask = xnn_cmpeq_f32(vx, vinf);
+    vy = xnn_or_f32(
+        xnn_and_f32(vposinf_mask, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask), vy));
 
     xnn_storeu_f32(output, vy);
     output += xnn_simd_size_f32;
@@ -240,11 +272,18 @@ void xnn_f32_vsqrt_ukernel__avx512f_rsqrt_u32(
 
     // Extract the square root by multiplying the original value with the
     // inverse square root.
-    const xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+    xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+
+    // Blend +inf back for +inf inputs: rsqrt(+inf)=0, so inf*0=NaN without this.
+    const xnn_simd_f32_t vposinf_mask = xnn_cmpeq_f32(vx, vinf);
+    vy = xnn_or_f32(
+        xnn_and_f32(vposinf_mask, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask), vy));
 
     xnn_store_tail_f32(output, vy, batch >> XNN_LOG2_SIZEOF_FLOAT);
   }
 }
+
 
 void xnn_f32_vsqrt_ukernel__avx512f_rsqrt_u48(
     size_t batch, const float* input, float* output,
@@ -257,6 +296,8 @@ void xnn_f32_vsqrt_ukernel__avx512f_rsqrt_u48(
   // Constants for the Newton-Raphson iteration.
   const xnn_simd_f32_t kOne = xnn_set1_f32(1.0f);
   const xnn_simd_f32_t kHalf = xnn_set1_f32(0.5f);
+  // +inf represented as exact IEEE 754 bit pattern, safe under -ffast-math.
+  XNN_SIMD_CONST_F32_FROM_INT32(vinf, INT32_C(0x7F800000));
 
   for (; batch >= 48 * sizeof(float); batch -= 48 * sizeof(float)) {
     const xnn_simd_f32_t vx0 = xnn_loadu_f32(input);
@@ -303,9 +344,22 @@ void xnn_f32_vsqrt_ukernel__avx512f_rsqrt_u48(
 
     // Extract the square root by multiplying the original value with the
     // inverse square root.
-    const xnn_simd_f32_t vy0 = xnn_mul_f32(vx0, vt7_0);
-    const xnn_simd_f32_t vy1 = xnn_mul_f32(vx1, vt7_1);
-    const xnn_simd_f32_t vy2 = xnn_mul_f32(vx2, vt7_2);
+    xnn_simd_f32_t vy0 = xnn_mul_f32(vx0, vt7_0);
+    xnn_simd_f32_t vy1 = xnn_mul_f32(vx1, vt7_1);
+    xnn_simd_f32_t vy2 = xnn_mul_f32(vx2, vt7_2);
+    // Blend +inf back for +inf inputs: rsqrt(+inf)=0, so inf*0=NaN without this.
+    const xnn_simd_f32_t vposinf_mask_0 = xnn_cmpeq_f32(vx0, vinf);
+    const xnn_simd_f32_t vposinf_mask_1 = xnn_cmpeq_f32(vx1, vinf);
+    const xnn_simd_f32_t vposinf_mask_2 = xnn_cmpeq_f32(vx2, vinf);
+    vy0 = xnn_or_f32(
+        xnn_and_f32(vposinf_mask_0, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask_0), vy0));
+    vy1 = xnn_or_f32(
+        xnn_and_f32(vposinf_mask_1, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask_1), vy1));
+    vy2 = xnn_or_f32(
+        xnn_and_f32(vposinf_mask_2, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask_2), vy2));
 
     // Store the results.
     xnn_storeu_f32(output, vy0);
@@ -339,7 +393,13 @@ void xnn_f32_vsqrt_ukernel__avx512f_rsqrt_u48(
 
     // Extract the square root by multiplying the original value with the
     // inverse square root.
-    const xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+    xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+
+    // Blend +inf back for +inf inputs: rsqrt(+inf)=0, so inf*0=NaN without this.
+    const xnn_simd_f32_t vposinf_mask = xnn_cmpeq_f32(vx, vinf);
+    vy = xnn_or_f32(
+        xnn_and_f32(vposinf_mask, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask), vy));
 
     xnn_storeu_f32(output, vy);
     output += xnn_simd_size_f32;
@@ -371,8 +431,15 @@ void xnn_f32_vsqrt_ukernel__avx512f_rsqrt_u48(
 
     // Extract the square root by multiplying the original value with the
     // inverse square root.
-    const xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+    xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+
+    // Blend +inf back for +inf inputs: rsqrt(+inf)=0, so inf*0=NaN without this.
+    const xnn_simd_f32_t vposinf_mask = xnn_cmpeq_f32(vx, vinf);
+    vy = xnn_or_f32(
+        xnn_and_f32(vposinf_mask, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask), vy));
 
     xnn_store_tail_f32(output, vy, batch >> XNN_LOG2_SIZEOF_FLOAT);
   }
 }
+

--- a/src/f32-vsqrt/gen/f32-vsqrt-neon-rsqrt.c
+++ b/src/f32-vsqrt/gen/f32-vsqrt-neon-rsqrt.c
@@ -1,7 +1,7 @@
 // clang-format off
 // Auto-generated file. Do not edit!
 //   Template: src/f32-vsqrt/simd-rsqrt.c.in
-//   Generator: tools/xngen
+//   Generator: tools/xngen.py
 //
 // Copyright 2025 Google LLC
 //
@@ -62,6 +62,8 @@ void xnn_f32_vsqrt_ukernel__neon_rsqrt_u4(
   // Constants for the Newton-Raphson iteration.
   const xnn_simd_f32_t kOne = xnn_set1_f32(1.0f);
   const xnn_simd_f32_t kHalf = xnn_set1_f32(0.5f);
+  // +inf represented as exact IEEE 754 bit pattern, safe under -ffast-math.
+  XNN_SIMD_CONST_F32_FROM_INT32(vinf, INT32_C(0x7F800000));
 
 
   for (; batch >= xnn_simd_bytes_f32; batch -= xnn_simd_bytes_f32) {
@@ -89,7 +91,13 @@ void xnn_f32_vsqrt_ukernel__neon_rsqrt_u4(
 
     // Extract the square root by multiplying the original value with the
     // inverse square root.
-    const xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+    xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+
+    // Blend +inf back for +inf inputs: rsqrt(+inf)=0, so inf*0=NaN without this.
+    const xnn_simd_f32_t vposinf_mask = xnn_cmpeq_f32(vx, vinf);
+    vy = xnn_or_f32(
+        xnn_and_f32(vposinf_mask, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask), vy));
 
     xnn_storeu_f32(output, vy);
     output += xnn_simd_size_f32;
@@ -121,11 +129,18 @@ void xnn_f32_vsqrt_ukernel__neon_rsqrt_u4(
 
     // Extract the square root by multiplying the original value with the
     // inverse square root.
-    const xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+    xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+
+    // Blend +inf back for +inf inputs: rsqrt(+inf)=0, so inf*0=NaN without this.
+    const xnn_simd_f32_t vposinf_mask = xnn_cmpeq_f32(vx, vinf);
+    vy = xnn_or_f32(
+        xnn_and_f32(vposinf_mask, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask), vy));
 
     xnn_store_tail_f32(output, vy, batch >> XNN_LOG2_SIZEOF_FLOAT);
   }
 }
+
 
 void xnn_f32_vsqrt_ukernel__neon_rsqrt_u8(
     size_t batch, const float* input, float* output,
@@ -138,6 +153,8 @@ void xnn_f32_vsqrt_ukernel__neon_rsqrt_u8(
   // Constants for the Newton-Raphson iteration.
   const xnn_simd_f32_t kOne = xnn_set1_f32(1.0f);
   const xnn_simd_f32_t kHalf = xnn_set1_f32(0.5f);
+  // +inf represented as exact IEEE 754 bit pattern, safe under -ffast-math.
+  XNN_SIMD_CONST_F32_FROM_INT32(vinf, INT32_C(0x7F800000));
 
   for (; batch >= 8 * sizeof(float); batch -= 8 * sizeof(float)) {
     const xnn_simd_f32_t vx0 = xnn_loadu_f32(input);
@@ -174,8 +191,17 @@ void xnn_f32_vsqrt_ukernel__neon_rsqrt_u8(
 
     // Extract the square root by multiplying the original value with the
     // inverse square root.
-    const xnn_simd_f32_t vy0 = xnn_mul_f32(vx0, vt7_0);
-    const xnn_simd_f32_t vy1 = xnn_mul_f32(vx1, vt7_1);
+    xnn_simd_f32_t vy0 = xnn_mul_f32(vx0, vt7_0);
+    xnn_simd_f32_t vy1 = xnn_mul_f32(vx1, vt7_1);
+    // Blend +inf back for +inf inputs: rsqrt(+inf)=0, so inf*0=NaN without this.
+    const xnn_simd_f32_t vposinf_mask_0 = xnn_cmpeq_f32(vx0, vinf);
+    const xnn_simd_f32_t vposinf_mask_1 = xnn_cmpeq_f32(vx1, vinf);
+    vy0 = xnn_or_f32(
+        xnn_and_f32(vposinf_mask_0, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask_0), vy0));
+    vy1 = xnn_or_f32(
+        xnn_and_f32(vposinf_mask_1, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask_1), vy1));
 
     // Store the results.
     xnn_storeu_f32(output, vy0);
@@ -208,7 +234,13 @@ void xnn_f32_vsqrt_ukernel__neon_rsqrt_u8(
 
     // Extract the square root by multiplying the original value with the
     // inverse square root.
-    const xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+    xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+
+    // Blend +inf back for +inf inputs: rsqrt(+inf)=0, so inf*0=NaN without this.
+    const xnn_simd_f32_t vposinf_mask = xnn_cmpeq_f32(vx, vinf);
+    vy = xnn_or_f32(
+        xnn_and_f32(vposinf_mask, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask), vy));
 
     xnn_storeu_f32(output, vy);
     output += xnn_simd_size_f32;
@@ -240,11 +272,18 @@ void xnn_f32_vsqrt_ukernel__neon_rsqrt_u8(
 
     // Extract the square root by multiplying the original value with the
     // inverse square root.
-    const xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+    xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+
+    // Blend +inf back for +inf inputs: rsqrt(+inf)=0, so inf*0=NaN without this.
+    const xnn_simd_f32_t vposinf_mask = xnn_cmpeq_f32(vx, vinf);
+    vy = xnn_or_f32(
+        xnn_and_f32(vposinf_mask, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask), vy));
 
     xnn_store_tail_f32(output, vy, batch >> XNN_LOG2_SIZEOF_FLOAT);
   }
 }
+
 
 void xnn_f32_vsqrt_ukernel__neon_rsqrt_u16(
     size_t batch, const float* input, float* output,
@@ -257,6 +296,8 @@ void xnn_f32_vsqrt_ukernel__neon_rsqrt_u16(
   // Constants for the Newton-Raphson iteration.
   const xnn_simd_f32_t kOne = xnn_set1_f32(1.0f);
   const xnn_simd_f32_t kHalf = xnn_set1_f32(0.5f);
+  // +inf represented as exact IEEE 754 bit pattern, safe under -ffast-math.
+  XNN_SIMD_CONST_F32_FROM_INT32(vinf, INT32_C(0x7F800000));
 
   for (; batch >= 16 * sizeof(float); batch -= 16 * sizeof(float)) {
     const xnn_simd_f32_t vx0 = xnn_loadu_f32(input);
@@ -313,10 +354,27 @@ void xnn_f32_vsqrt_ukernel__neon_rsqrt_u16(
 
     // Extract the square root by multiplying the original value with the
     // inverse square root.
-    const xnn_simd_f32_t vy0 = xnn_mul_f32(vx0, vt7_0);
-    const xnn_simd_f32_t vy1 = xnn_mul_f32(vx1, vt7_1);
-    const xnn_simd_f32_t vy2 = xnn_mul_f32(vx2, vt7_2);
-    const xnn_simd_f32_t vy3 = xnn_mul_f32(vx3, vt7_3);
+    xnn_simd_f32_t vy0 = xnn_mul_f32(vx0, vt7_0);
+    xnn_simd_f32_t vy1 = xnn_mul_f32(vx1, vt7_1);
+    xnn_simd_f32_t vy2 = xnn_mul_f32(vx2, vt7_2);
+    xnn_simd_f32_t vy3 = xnn_mul_f32(vx3, vt7_3);
+    // Blend +inf back for +inf inputs: rsqrt(+inf)=0, so inf*0=NaN without this.
+    const xnn_simd_f32_t vposinf_mask_0 = xnn_cmpeq_f32(vx0, vinf);
+    const xnn_simd_f32_t vposinf_mask_1 = xnn_cmpeq_f32(vx1, vinf);
+    const xnn_simd_f32_t vposinf_mask_2 = xnn_cmpeq_f32(vx2, vinf);
+    const xnn_simd_f32_t vposinf_mask_3 = xnn_cmpeq_f32(vx3, vinf);
+    vy0 = xnn_or_f32(
+        xnn_and_f32(vposinf_mask_0, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask_0), vy0));
+    vy1 = xnn_or_f32(
+        xnn_and_f32(vposinf_mask_1, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask_1), vy1));
+    vy2 = xnn_or_f32(
+        xnn_and_f32(vposinf_mask_2, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask_2), vy2));
+    vy3 = xnn_or_f32(
+        xnn_and_f32(vposinf_mask_3, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask_3), vy3));
 
     // Store the results.
     xnn_storeu_f32(output, vy0);
@@ -351,7 +409,13 @@ void xnn_f32_vsqrt_ukernel__neon_rsqrt_u16(
 
     // Extract the square root by multiplying the original value with the
     // inverse square root.
-    const xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+    xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+
+    // Blend +inf back for +inf inputs: rsqrt(+inf)=0, so inf*0=NaN without this.
+    const xnn_simd_f32_t vposinf_mask = xnn_cmpeq_f32(vx, vinf);
+    vy = xnn_or_f32(
+        xnn_and_f32(vposinf_mask, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask), vy));
 
     xnn_storeu_f32(output, vy);
     output += xnn_simd_size_f32;
@@ -383,8 +447,15 @@ void xnn_f32_vsqrt_ukernel__neon_rsqrt_u16(
 
     // Extract the square root by multiplying the original value with the
     // inverse square root.
-    const xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+    xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+
+    // Blend +inf back for +inf inputs: rsqrt(+inf)=0, so inf*0=NaN without this.
+    const xnn_simd_f32_t vposinf_mask = xnn_cmpeq_f32(vx, vinf);
+    vy = xnn_or_f32(
+        xnn_and_f32(vposinf_mask, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask), vy));
 
     xnn_store_tail_f32(output, vy, batch >> XNN_LOG2_SIZEOF_FLOAT);
   }
 }
+

--- a/src/f32-vsqrt/gen/f32-vsqrt-sse2-rsqrt.c
+++ b/src/f32-vsqrt/gen/f32-vsqrt-sse2-rsqrt.c
@@ -1,7 +1,7 @@
 // clang-format off
 // Auto-generated file. Do not edit!
 //   Template: src/f32-vsqrt/simd-rsqrt.c.in
-//   Generator: tools/xngen
+//   Generator: tools/xngen.py
 //
 // Copyright 2025 Google LLC
 //
@@ -62,6 +62,8 @@ void xnn_f32_vsqrt_ukernel__sse2_rsqrt_u4(
   // Constants for the Newton-Raphson iteration.
   const xnn_simd_f32_t kOne = xnn_set1_f32(1.0f);
   const xnn_simd_f32_t kHalf = xnn_set1_f32(0.5f);
+  // +inf represented as exact IEEE 754 bit pattern, safe under -ffast-math.
+  XNN_SIMD_CONST_F32_FROM_INT32(vinf, INT32_C(0x7F800000));
 
 
   for (; batch >= xnn_simd_bytes_f32; batch -= xnn_simd_bytes_f32) {
@@ -89,7 +91,13 @@ void xnn_f32_vsqrt_ukernel__sse2_rsqrt_u4(
 
     // Extract the square root by multiplying the original value with the
     // inverse square root.
-    const xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+    xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+
+    // Blend +inf back for +inf inputs: rsqrt(+inf)=0, so inf*0=NaN without this.
+    const xnn_simd_f32_t vposinf_mask = xnn_cmpeq_f32(vx, vinf);
+    vy = xnn_or_f32(
+        xnn_and_f32(vposinf_mask, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask), vy));
 
     xnn_storeu_f32(output, vy);
     output += xnn_simd_size_f32;
@@ -121,11 +129,18 @@ void xnn_f32_vsqrt_ukernel__sse2_rsqrt_u4(
 
     // Extract the square root by multiplying the original value with the
     // inverse square root.
-    const xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+    xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+
+    // Blend +inf back for +inf inputs: rsqrt(+inf)=0, so inf*0=NaN without this.
+    const xnn_simd_f32_t vposinf_mask = xnn_cmpeq_f32(vx, vinf);
+    vy = xnn_or_f32(
+        xnn_and_f32(vposinf_mask, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask), vy));
 
     xnn_store_tail_f32(output, vy, batch >> XNN_LOG2_SIZEOF_FLOAT);
   }
 }
+
 
 void xnn_f32_vsqrt_ukernel__sse2_rsqrt_u8(
     size_t batch, const float* input, float* output,
@@ -138,6 +153,8 @@ void xnn_f32_vsqrt_ukernel__sse2_rsqrt_u8(
   // Constants for the Newton-Raphson iteration.
   const xnn_simd_f32_t kOne = xnn_set1_f32(1.0f);
   const xnn_simd_f32_t kHalf = xnn_set1_f32(0.5f);
+  // +inf represented as exact IEEE 754 bit pattern, safe under -ffast-math.
+  XNN_SIMD_CONST_F32_FROM_INT32(vinf, INT32_C(0x7F800000));
 
   for (; batch >= 8 * sizeof(float); batch -= 8 * sizeof(float)) {
     const xnn_simd_f32_t vx0 = xnn_loadu_f32(input);
@@ -174,8 +191,17 @@ void xnn_f32_vsqrt_ukernel__sse2_rsqrt_u8(
 
     // Extract the square root by multiplying the original value with the
     // inverse square root.
-    const xnn_simd_f32_t vy0 = xnn_mul_f32(vx0, vt7_0);
-    const xnn_simd_f32_t vy1 = xnn_mul_f32(vx1, vt7_1);
+    xnn_simd_f32_t vy0 = xnn_mul_f32(vx0, vt7_0);
+    xnn_simd_f32_t vy1 = xnn_mul_f32(vx1, vt7_1);
+    // Blend +inf back for +inf inputs: rsqrt(+inf)=0, so inf*0=NaN without this.
+    const xnn_simd_f32_t vposinf_mask_0 = xnn_cmpeq_f32(vx0, vinf);
+    const xnn_simd_f32_t vposinf_mask_1 = xnn_cmpeq_f32(vx1, vinf);
+    vy0 = xnn_or_f32(
+        xnn_and_f32(vposinf_mask_0, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask_0), vy0));
+    vy1 = xnn_or_f32(
+        xnn_and_f32(vposinf_mask_1, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask_1), vy1));
 
     // Store the results.
     xnn_storeu_f32(output, vy0);
@@ -208,7 +234,13 @@ void xnn_f32_vsqrt_ukernel__sse2_rsqrt_u8(
 
     // Extract the square root by multiplying the original value with the
     // inverse square root.
-    const xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+    xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+
+    // Blend +inf back for +inf inputs: rsqrt(+inf)=0, so inf*0=NaN without this.
+    const xnn_simd_f32_t vposinf_mask = xnn_cmpeq_f32(vx, vinf);
+    vy = xnn_or_f32(
+        xnn_and_f32(vposinf_mask, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask), vy));
 
     xnn_storeu_f32(output, vy);
     output += xnn_simd_size_f32;
@@ -240,11 +272,18 @@ void xnn_f32_vsqrt_ukernel__sse2_rsqrt_u8(
 
     // Extract the square root by multiplying the original value with the
     // inverse square root.
-    const xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+    xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+
+    // Blend +inf back for +inf inputs: rsqrt(+inf)=0, so inf*0=NaN without this.
+    const xnn_simd_f32_t vposinf_mask = xnn_cmpeq_f32(vx, vinf);
+    vy = xnn_or_f32(
+        xnn_and_f32(vposinf_mask, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask), vy));
 
     xnn_store_tail_f32(output, vy, batch >> XNN_LOG2_SIZEOF_FLOAT);
   }
 }
+
 
 void xnn_f32_vsqrt_ukernel__sse2_rsqrt_u16(
     size_t batch, const float* input, float* output,
@@ -257,6 +296,8 @@ void xnn_f32_vsqrt_ukernel__sse2_rsqrt_u16(
   // Constants for the Newton-Raphson iteration.
   const xnn_simd_f32_t kOne = xnn_set1_f32(1.0f);
   const xnn_simd_f32_t kHalf = xnn_set1_f32(0.5f);
+  // +inf represented as exact IEEE 754 bit pattern, safe under -ffast-math.
+  XNN_SIMD_CONST_F32_FROM_INT32(vinf, INT32_C(0x7F800000));
 
   for (; batch >= 16 * sizeof(float); batch -= 16 * sizeof(float)) {
     const xnn_simd_f32_t vx0 = xnn_loadu_f32(input);
@@ -313,10 +354,27 @@ void xnn_f32_vsqrt_ukernel__sse2_rsqrt_u16(
 
     // Extract the square root by multiplying the original value with the
     // inverse square root.
-    const xnn_simd_f32_t vy0 = xnn_mul_f32(vx0, vt7_0);
-    const xnn_simd_f32_t vy1 = xnn_mul_f32(vx1, vt7_1);
-    const xnn_simd_f32_t vy2 = xnn_mul_f32(vx2, vt7_2);
-    const xnn_simd_f32_t vy3 = xnn_mul_f32(vx3, vt7_3);
+    xnn_simd_f32_t vy0 = xnn_mul_f32(vx0, vt7_0);
+    xnn_simd_f32_t vy1 = xnn_mul_f32(vx1, vt7_1);
+    xnn_simd_f32_t vy2 = xnn_mul_f32(vx2, vt7_2);
+    xnn_simd_f32_t vy3 = xnn_mul_f32(vx3, vt7_3);
+    // Blend +inf back for +inf inputs: rsqrt(+inf)=0, so inf*0=NaN without this.
+    const xnn_simd_f32_t vposinf_mask_0 = xnn_cmpeq_f32(vx0, vinf);
+    const xnn_simd_f32_t vposinf_mask_1 = xnn_cmpeq_f32(vx1, vinf);
+    const xnn_simd_f32_t vposinf_mask_2 = xnn_cmpeq_f32(vx2, vinf);
+    const xnn_simd_f32_t vposinf_mask_3 = xnn_cmpeq_f32(vx3, vinf);
+    vy0 = xnn_or_f32(
+        xnn_and_f32(vposinf_mask_0, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask_0), vy0));
+    vy1 = xnn_or_f32(
+        xnn_and_f32(vposinf_mask_1, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask_1), vy1));
+    vy2 = xnn_or_f32(
+        xnn_and_f32(vposinf_mask_2, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask_2), vy2));
+    vy3 = xnn_or_f32(
+        xnn_and_f32(vposinf_mask_3, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask_3), vy3));
 
     // Store the results.
     xnn_storeu_f32(output, vy0);
@@ -351,7 +409,13 @@ void xnn_f32_vsqrt_ukernel__sse2_rsqrt_u16(
 
     // Extract the square root by multiplying the original value with the
     // inverse square root.
-    const xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+    xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+
+    // Blend +inf back for +inf inputs: rsqrt(+inf)=0, so inf*0=NaN without this.
+    const xnn_simd_f32_t vposinf_mask = xnn_cmpeq_f32(vx, vinf);
+    vy = xnn_or_f32(
+        xnn_and_f32(vposinf_mask, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask), vy));
 
     xnn_storeu_f32(output, vy);
     output += xnn_simd_size_f32;
@@ -383,8 +447,15 @@ void xnn_f32_vsqrt_ukernel__sse2_rsqrt_u16(
 
     // Extract the square root by multiplying the original value with the
     // inverse square root.
-    const xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+    xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+
+    // Blend +inf back for +inf inputs: rsqrt(+inf)=0, so inf*0=NaN without this.
+    const xnn_simd_f32_t vposinf_mask = xnn_cmpeq_f32(vx, vinf);
+    vy = xnn_or_f32(
+        xnn_and_f32(vposinf_mask, vinf),
+        xnn_and_f32(xnn_not_f32(vposinf_mask), vy));
 
     xnn_store_tail_f32(output, vy, batch >> XNN_LOG2_SIZEOF_FLOAT);
   }
 }
+

--- a/src/f32-vsqrt/simd-rsqrt.c.in
+++ b/src/f32-vsqrt/simd-rsqrt.c.in
@@ -64,6 +64,8 @@ $for BATCH_TILE in BATCH_TILES:
     // Constants for the Newton-Raphson iteration.
     const xnn_simd_f32_t kOne = xnn_set1_f32(1.0f);
     const xnn_simd_f32_t kHalf = xnn_set1_f32(0.5f);
+    // +inf represented as exact IEEE 754 bit pattern, safe under -ffast-math.
+    XNN_SIMD_CONST_F32_FROM_INT32(vinf, INT32_C(0x7F800000));
 
     $if BATCH_TILE > SIMD_SIZE:
       for (; batch >= ${BATCH_TILE} * sizeof(float); batch -= ${BATCH_TILE} * sizeof(float)) {
@@ -103,7 +105,14 @@ $for BATCH_TILE in BATCH_TILES:
         // Extract the square root by multiplying the original value with the
         // inverse square root.
         $for N in range(SIMD_TILE):
-          const xnn_simd_f32_t vy${ABC[N]} = xnn_mul_f32(vx${ABC[N]}, vt7_${ABC[N]});
+          xnn_simd_f32_t vy${ABC[N]} = xnn_mul_f32(vx${ABC[N]}, vt7_${ABC[N]});
+        // Blend +inf back for +inf inputs: rsqrt(+inf)=0, so inf*0=NaN without this.
+        $for N in range(SIMD_TILE):
+          const xnn_simd_f32_t vposinf_mask_${ABC[N]} = xnn_cmpeq_f32(vx${ABC[N]}, vinf);
+        $for N in range(SIMD_TILE):
+          vy${ABC[N]} = xnn_or_f32(
+              xnn_and_f32(vposinf_mask_${ABC[N]}, vinf),
+              xnn_and_f32(xnn_not_f32(vposinf_mask_${ABC[N]}), vy${ABC[N]}));
 
         // Store the results.
         xnn_storeu_f32(output, vy${ABC[0]});
@@ -137,7 +146,13 @@ $for BATCH_TILE in BATCH_TILES:
 
       // Extract the square root by multiplying the original value with the
       // inverse square root.
-      const xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+      xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+
+      // Blend +inf back for +inf inputs: rsqrt(+inf)=0, so inf*0=NaN without this.
+      const xnn_simd_f32_t vposinf_mask = xnn_cmpeq_f32(vx, vinf);
+      vy = xnn_or_f32(
+          xnn_and_f32(vposinf_mask, vinf),
+          xnn_and_f32(xnn_not_f32(vposinf_mask), vy));
 
       xnn_storeu_f32(output, vy);
       output += xnn_simd_size_f32;
@@ -169,8 +184,15 @@ $for BATCH_TILE in BATCH_TILES:
 
       // Extract the square root by multiplying the original value with the
       // inverse square root.
-      const xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+      xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
+
+      // Blend +inf back for +inf inputs: rsqrt(+inf)=0, so inf*0=NaN without this.
+      const xnn_simd_f32_t vposinf_mask = xnn_cmpeq_f32(vx, vinf);
+      vy = xnn_or_f32(
+          xnn_and_f32(vposinf_mask, vinf),
+          xnn_and_f32(xnn_not_f32(vposinf_mask), vy));
 
       xnn_store_tail_f32(output, vy, batch >> XNN_LOG2_SIZEOF_FLOAT);
     }
   }
+

--- a/test/f32-vsqrt.cc
+++ b/test/f32-vsqrt.cc
@@ -38,8 +38,8 @@ using TestInfo = SquareRoot;
 TEST(ukernel, special_values) {                                                                                         \
   TEST_REQUIRES_ARCH_FLAGS(arch_flags);                                                                                 \
   VUnaryMicrokernelTester().Test<TestInfo, datatype, datatype>(ukernel, init_params,                                    \
-    /*inputs=*/{0.0f, -0.0f, 1.0f, -1.0f},                                                                              \
-    /*outputs=*/{0.0f, -0.0f, 1.0f, NAN},                                                                               \
+    /*inputs=*/{0.0f, -0.0f, 1.0f, -1.0f, INFINITY, NAN},                                                               \
+    /*outputs=*/{0.0f, -0.0f, 1.0f, NAN, INFINITY, NAN},                                                                \
     /*tolerance_ulp=*/1);                                                                                               \
 }
 #include "src/f32-vsqrt/f32-vsqrt.inc"

--- a/tools/generate-vunary-test.py
+++ b/tools/generate-vunary-test.py
@@ -69,9 +69,9 @@ PARAMS_TYPES = ["Clamp", "ELU", "LeakyReLU"]
 
 SPECIAL_VALUES_BY_OP_TYPE_F32 = types.MappingProxyType({
     "SquareRoot": SpecialValues(
-        num_elements=4,
-        inputs="{0.0f, -0.0f, 1.0f, -1.0f}",
-        expected_outputs="{0.0f, -0.0f, 1.0f, NAN}",
+        num_elements=6,
+        inputs="{0.0f, -0.0f, 1.0f, -1.0f, INFINITY, NAN}",
+        expected_outputs="{0.0f, -0.0f, 1.0f, NAN, INFINITY, NAN}",
         tolerance_ulp=1,
     ),
     "ReciprocalSquareRoot": SpecialValues(


### PR DESCRIPTION
# Fix sqrt(+inf) returning NaN under `-ffast-math`

When XNNPACK is compiled with `-ffast-math`, `sqrt(+inf)` incorrectly returns `NaN` instead of `+inf`.

This affects both the scalar fallback implementation and all rsqrt-based SIMD sqrt microkernels (`neon_rsqrt`, `sse2_rsqrt`, `avx_rsqrt`, and `avx512f_rsqrt`).

The issue was discovered while investigating TensorFlow issue #120303, where `tf.math.sqrt(+inf)` returned `NaN` through the TFLite XNNPACK delegate.

## Root Cause

With `-ffast-math` (specifically `-funsafe-math-optimizations` and `-freciprocal-math`), compilers may transform:

```cpp
sqrtf(x)
```

into:

```cpp
x * rsqrtf(x)
```

For `x = +inf`:

```text
rsqrt(+inf) = 0
+inf * 0 = NaN
```

under IEEE 754 arithmetic.

As a result, `sqrt(+inf)` incorrectly evaluates to `NaN`.

---

## Fix 1: Scalar fallback

### Affected file

```text
src/xnnpack/simd/f32-scalar.h
```

### Previous implementation

```cpp
static XNN_INLINE xnn_simd_f32_t xnn_sqrt_f32(xnn_simd_f32_t a) {
  return sqrtf(a);
}
```

### Problem

Under `-ffast-math`, the compiler may lower `sqrtf()` to an rsqrt-based implementation and produce `NaN` for positive infinity.

### Fix

Detect positive infinity using a bit-level comparison before calling `sqrtf()`.

The check compares against the IEEE 754 bit pattern:

```cpp
0x7F800000
```

This avoids reliance on floating-point comparisons and remains correct even under `-ffinite-math-only`.

---

## Fix 2: SIMD rsqrt sqrt microkernels

### Affected file

```text
src/f32-vsqrt/simd-rsqrt.c.in
```

### Problem

All rsqrt-based kernels compute:

```text
sqrt(x) ~= x * rsqrt(x)
```

After Newton-Raphson refinement:

```text
rsqrt(+inf) -> 0
```

and therefore:

```text
+inf * 0 -> NaN
```

The existing zero-input mask does not handle positive infinity, so the final result remains `NaN`.

### Fix

After computing:

```cpp
xnn_simd_f32_t vy = xnn_mul_f32(vx, vt7);
```

detect positive infinity inputs and blend `+inf` back into the output:

```cpp
const xnn_simd_f32_t vposinf_mask = xnn_cmpeq_f32(vx, vinf);

vy = xnn_or_f32(
    xnn_and_f32(vposinf_mask, vinf),
    xnn_and_f32(xnn_not_f32(vposinf_mask), vy));
```

### Why this is safe

- `xnn_cmpeq_f32()` uses hardware SIMD comparison instructions (`vceqq_f32`, `_mm_cmpeq_ps`, etc.).
- Infinity comparisons remain correct regardless of compiler floating-point optimization flags.
- The infinity constant is constructed from the exact IEEE 754 bit pattern:

```cpp
XNN_SIMD_CONST_F32_FROM_INT32(vinf, INT32_C(0x7F800000))
```

avoiding dependence on `<math.h>` or floating-point constant folding.

### Coverage

The fix is applied to all execution paths:

- Batched SIMD tile loop
- Main vector loop
- Tail processing loop

---

## Fix 3: Add missing test coverage

### Affected files

```text
tools/generate-vunary-test.py
test/f32-vsqrt.cc
```

### Problem

The SquareRoot special-value tests only covered:

```cpp
{0.0f, -0.0f, 1.0f, -1.0f}
```

Unlike ReciprocalSquareRoot and TanH, positive infinity and NaN were not tested.

### Fix

Extend the test cases to include:

```cpp
{0.0f, -0.0f, 1.0f, -1.0f, INFINITY, NAN}
```

Expected outputs:

```cpp
{0.0f, -0.0f, 1.0f, NAN, INFINITY, NAN}
```

Regenerated:

```text
test/f32-vsqrt.cc
```

---

## Correctness Verification

| Input | Expected | Scalar (fixed) | SIMD rsqrt (fixed) |
|---------|---------|---------|---------|
| +inf | +inf | +inf | +inf |
| -inf | NaN | NaN | NaN |
| NaN | NaN | NaN | NaN |
| 0.0f | 0.0f | 0.0f | 0.0f |
| -0.0f | -0.0f | -0.0f | -0.0f |
| finite > 0 | sqrt(x) | correct | correct |

---

## Files Changed

### `src/xnnpack/simd/f32-scalar.h`

- Add bit-level positive infinity check before `sqrtf()`

### `src/f32-vsqrt/simd-rsqrt.c.in`

- Add positive infinity detection and result blending in:
  - Batched SIMD tile loop
  - Main vector loop
  - Tail processing loop

### `tools/generate-vunary-test.py`

- Add `INFINITY` and `NAN` coverage to SquareRoot special-value tests

### `test/f32-vsqrt.cc`

- Regenerated auto-generated test file

---

## Result

After this change:

```text
sqrt(+inf) = +inf
```

for both scalar and SIMD implementations, even when XNNPACK is built with `-ffast-math`.

All existing tests pass, and new coverage prevents future regressions involving infinity and NaN handling.

Close: #10399