### PR TITLE
validate input rank in softmax and qp8 convert reshape

### DIFF
--- a/src/subgraph/softmax.c
+++ b/src/subgraph/softmax.c
@@ -61,7 +61,13 @@ static enum xnn_status reshape_softmax_operator(
   assert(input_id < num_values);
 
   const size_t num_input_dims = values[input_id].shape.num_dims;
-  assert(num_input_dims > 0);
+  if (num_input_dims == 0) {
+    xnn_log_error(
+      "failed to reshape %s operator with input ID #%" PRIu32
+      ": number of dimensions (%zu) must be at least 1",
+      xnn_node_type_to_string(xnn_node_type_softmax), input_id, num_input_dims);
+    return xnn_status_invalid_parameter;
+  }
   const size_t channel_dim = values[input_id].shape.dim[num_input_dims - 1];
   const size_t batch_size = xnn_shape_multiply_non_channel_dims(&values[input_id].shape);
 

--- a/src/subgraph/unary.c
+++ b/src/subgraph/unary.c
@@ -167,6 +167,14 @@ static enum xnn_status reshape_convert_operator(
       break;
     }
     case xnn_operator_type_convert_nc_f32_qp8: {
+      if (num_input_dims < 2) {
+        xnn_log_error(
+          "failed to reshape %s operator with input ID #%" PRIu32
+          ": number of dimensions (%zu) must be at least 2",
+          xnn_node_type_to_string(xnn_node_type_convert), input_id,
+          num_input_dims);
+        return xnn_status_invalid_parameter;
+      }
       size_t num_groups = xnn_shape_multiply_batch_dims(&input_value->shape, 2);
       size_t batch_size = input_value->shape.dim[num_input_dims - 2];
       const size_t channels = input_value->shape.dim[num_input_dims - 1];

--- a/test/subgraph/softmax.cc
+++ b/test/subgraph/softmax.cc
@@ -101,4 +101,22 @@ auto rank_params = testing::Range(1, XNN_MAX_TENSOR_DIMS);
 INSTANTIATE_TEST_SUITE_P(Softmax, SoftmaxF16, rank_params);
 INSTANTIATE_TEST_SUITE_P(Softmax, SoftmaxF32, rank_params);
 
+TEST(Softmax, reshape_rejects_scalar_input) {
+  ASSERT_EQ(xnn_status_success, xnn_initialize(nullptr /* allocator */));
+
+  SubgraphTester subgraph(2);
+  subgraph.AddInputTensor(1, xnn_datatype_fp32, 0)
+      .AddOutputTensor(1, xnn_datatype_fp32, 1)
+      .AddSoftmax(0, 1);
+  if (subgraph.CreateRuntime() == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+
+  // An external input may be reshaped to a scalar (rank 0) at runtime. The
+  // reshape must reject it, not index shape.dim[num_dims - 1] with num_dims 0.
+  float data = 0.0f;
+  subgraph.ReshapeExternalTensor(TensorShape(), &data, 0).ReshapeRuntime();
+  EXPECT_EQ(subgraph.Status(), xnn_status_invalid_parameter);
+}
+
 }  // namespace xnnpack


### PR DESCRIPTION
UBSan, clang -fsanitize=undefined (NDEBUG build, so the assert is gone):

    src/subgraph/softmax.c:65:30: runtime error: addition of unsigned offset to 0x000104c20cb0 overflowed to 0x000104c20ca8

Found this fuzzing the runtime reshape path with low-rank inputs. reshape_softmax_operator reads the channel size as shape.dim[num_input_dims - 1]. The only guard is assert(num_input_dims > 0), which is compiled out under NDEBUG. xnn_reshape_external_value accepts num_dims == 0 (it only rejects ranks above XNN_MAX_TENSOR_DIMS), so an external input reshaped to a scalar makes num_input_dims - 1 wrap to SIZE_MAX and the dim[] read goes out of bounds. The offset lands exactly 8 bytes back, on num_dims itself, which is why it stays quiet on a normal build.

fully-connected and rope reshape already reject a too-small rank, softmax did not. The same unchecked read sits in the qp8 path of reshape_convert_operator (dim[num_input_dims - 2]); the other convert cases in that function already clamp num_dims == 0, so the qp8 case was the odd one out. Both now reject the reshape when the rank is too small.

Test reshapes a softmax input to rank 0 and expects xnn_status_invalid_parameter.
