### PR TITLE
Reject convolution reshape when the kernel does not fit the padded input (OOB read)

### DIFF
--- a/src/operators/convolution-nchw.c
+++ b/src/operators/convolution-nchw.c
@@ -1323,8 +1323,34 @@ static enum xnn_status reshape_convolution2d_nchw(
   convolution_op->convolution_op->input_height = input_height;
   convolution_op->convolution_op->input_width = input_width;
 
+  // The (dilated) kernel must fit inside the padded input. Otherwise
+  // xnn_compute_convolution_output_dimension() clamps the spilled dimension to
+  // 1 via the trailing `+ 1`, producing a phantom output for which no valid
+  // receptive field exists, and the run-time kernel then addresses input
+  // pixels outside the input tensor (out-of-bounds read).
+  const size_t padded_input_height = convolution_op->convolution_op->padding_top +
+      input_height + convolution_op->convolution_op->padding_bottom;
+  const size_t padded_input_width = convolution_op->convolution_op->padding_left +
+      input_width + convolution_op->convolution_op->padding_right;
+  const size_t effective_kernel_height =
+      (convolution_op->convolution_op->kernel_height - 1) *
+          convolution_op->convolution_op->dilation_height + 1;
+  const size_t effective_kernel_width =
+      (convolution_op->convolution_op->kernel_width - 1) *
+          convolution_op->convolution_op->dilation_width + 1;
+  if (padded_input_height < effective_kernel_height ||
+      padded_input_width < effective_kernel_width) {
+    xnn_log_error(
+        "failed to reshape %s operator with %zux%zu input: the padded input "
+        "(%zux%zu) is smaller than the effective kernel (%zux%zu)",
+        xnn_operator_type_to_string_v2(convolution_op), input_width,
+        input_height, padded_input_width, padded_input_height,
+        effective_kernel_width, effective_kernel_height);
+    return xnn_status_invalid_parameter;
+  }
+
   const size_t output_height = xnn_compute_convolution_output_dimension(
-      convolution_op->convolution_op->padding_top + input_height + convolution_op->convolution_op->padding_bottom,
+      padded_input_height,
       convolution_op->convolution_op->kernel_height,
       convolution_op->convolution_op->dilation_height,
       convolution_op->convolution_op->stride_height);
@@ -1332,7 +1358,7 @@ static enum xnn_status reshape_convolution2d_nchw(
     *output_height_out = output_height;
   }
   const size_t output_width = xnn_compute_convolution_output_dimension(
-      convolution_op->convolution_op->padding_left + input_width + convolution_op->convolution_op->padding_right,
+      padded_input_width,
       convolution_op->convolution_op->kernel_width,
       convolution_op->convolution_op->dilation_width,
       convolution_op->convolution_op->stride_width);

--- a/src/operators/convolution-nhwc.c
+++ b/src/operators/convolution-nhwc.c
@@ -3200,17 +3200,40 @@ static enum xnn_status reshape_convolution2d_nhwc(
     convolution_op->convolution_op->padding_right =
         total_padding_width - convolution_op->convolution_op->padding_left;
   } else {
+    // The (dilated) kernel must fit inside the padded input. Otherwise
+    // xnn_compute_convolution_output_dimension() clamps the spilled dimension
+    // to 1 via the trailing `+ 1`, producing a phantom output for which no
+    // valid receptive field exists, and the indirection buffer then addresses
+    // input pixels outside the input tensor (out-of-bounds read at run time).
+    const size_t padded_input_height = convolution_op->convolution_op->padding_top +
+        input_height + convolution_op->convolution_op->padding_bottom;
+    const size_t padded_input_width = convolution_op->convolution_op->padding_left +
+        input_width + convolution_op->convolution_op->padding_right;
+    const size_t effective_kernel_height =
+        (convolution_op->convolution_op->kernel_height - 1) *
+            convolution_op->convolution_op->dilation_height + 1;
+    const size_t effective_kernel_width =
+        (convolution_op->convolution_op->kernel_width - 1) *
+            convolution_op->convolution_op->dilation_width + 1;
+    if (padded_input_height < effective_kernel_height ||
+        padded_input_width < effective_kernel_width) {
+      xnn_log_error(
+          "failed to reshape %s operator with %zux%zu input: the padded input "
+          "(%zux%zu) is smaller than the effective kernel (%zux%zu)",
+          xnn_operator_type_to_string_v2(convolution_op), input_width,
+          input_height, padded_input_width, padded_input_height,
+          effective_kernel_width, effective_kernel_height);
+      return xnn_status_invalid_parameter;
+    }
     convolution_op->convolution_op->output_height =
         xnn_compute_convolution_output_dimension(
-            convolution_op->convolution_op->padding_top + input_height +
-                convolution_op->convolution_op->padding_bottom,
+            padded_input_height,
             convolution_op->convolution_op->kernel_height,
             convolution_op->convolution_op->dilation_height,
             convolution_op->convolution_op->stride_height);
     convolution_op->convolution_op->output_width =
         xnn_compute_convolution_output_dimension(
-            convolution_op->convolution_op->padding_left + input_width +
-                convolution_op->convolution_op->padding_right,
+            padded_input_width,
             convolution_op->convolution_op->kernel_width,
             convolution_op->convolution_op->dilation_width,
             convolution_op->convolution_op->stride_width);


### PR DESCRIPTION
### Problem

`xnn_reshape_convolution2d_nhwc_*` / `xnn_reshape_convolution2d_nchw_*` only reject zero-sized inputs (`input_width == 0 || input_height == 0`). They never check that the (dilated) kernel fits inside the padded input.

When the effective kernel is larger than the padded input, `xnn_compute_convolution_output_dimension()` returns `doz(padded_input, effective_kernel) / stride + 1`. `doz` clamps to 0, so the trailing `+ 1` yields a **phantom output of size 1** for a dimension that has no valid receptive field. The operator accepts the reshape (`xnn_status_success`, output `1x1`), builds an indirection buffer that addresses input pixels outside the input tensor, and the run-time IGEMM/DWCONV microkernel then reads out of bounds.

This is reachable from the public operator API (and therefore the subgraph/runtime API and the TFLite/PyTorch XNNPACK delegate) with attacker-controlled tensor dimensions — a convolution whose input, at reshape time, is smaller than the kernel with insufficient padding.

Minimal reproducer (pure public operator API): a normal grouped f32 conv (`groups=2, gic=3, goc=2, 3x3` kernel, stride 1, no padding), reshaped to a `2x2` input, with the input buffer sized exactly to the reshaped shape. `xnn_run_operator` then dereferences an input pointer outside the tensor:

```
reshape=0 output=1x1            <- phantom output accepted
ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (READ)
  #0 xnn_f32_igemm_minmax_ukernel_4x2__asm_aarch64_neonfma_cortex_a75_prfm
  #1 pthreadpool_parallelize_4d_tile_2d_dynamic
  #2 xnn_run_operator_with_index
  #3 main
```

The trigger condition is exactly `padded_input_dim < (kernel_dim - 1) * dilation + 1` on the height or width. The DWCONV path (`groups`/depthwise) crashes identically.

### Fix

In both `reshape_convolution2d_nhwc` and `reshape_convolution2d_nchw`, reject the reshape with `xnn_status_invalid_parameter` when the padded input is smaller than the effective (dilated) kernel, before computing the output dimensions. Valid convolutions (padded input >= effective kernel) are unaffected and produce identical output dimensions.

### Testing

- The reproducer above is rejected after the fix (`reshape` returns `xnn_status_invalid_parameter`, no AddressSanitizer report).
- A valid convolution (e.g. the same operator reshaped to a `5x5` input) still succeeds, produces the correct `3x3` output, and runs cleanly under ASan.
- Fuzzing the convolution reshape path with randomized but self-consistent shapes produces no further crashes.