### PR TITLE
resize-bilinear: clamp source coordinate in legacy/align-corners mode (OOB read)

### DIFF
--- a/src/indirection.c
+++ b/src/indirection.c
@@ -496,17 +496,20 @@ void xnn_indirection_init_resize_bilinear2d_hwc_f16(
   const uint32_t input_x_max = (uint32_t) input_width - 1;
   if (tensorflow_legacy || align_corners) {
     for (size_t output_y = output_y_start; output_y < output_y_end; output_y++) {
-      const float input_y = (float) (int32_t) output_y * height_scale;
-      assert(input_y >= 0.0f);
-      assert(input_y < (float) input_height);
+      float input_y = (float) (int32_t) output_y * height_scale;
+      // Clamp the source coordinate as the half-pixel branch does. The legacy
+      // and align-corners formulas rely on input_y staying < input_height, but
+      // height_scale is float32 and for large output_height the rounded product
+      // can reach input_height, putting input_y_top one full row past the input
+      // (out-of-bounds read in the bilinear ukernel).
+      input_y = math_min_f32(math_max_f32(input_y, 0.0f), (float) input_y_max);
 
       const uint32_t input_y_top = (uint32_t) (int32_t) input_y;
       const uint32_t input_y_bottom = math_min_u32(input_y_top + 1, input_y_max);
       const float alpha_y = input_y - (float) input_y_top;
       for (size_t output_x = 0; output_x < output_width; output_x++) {
-        const float input_x = (float) (int32_t) output_x * width_scale;
-        assert(input_x >= 0.0f);
-        assert(input_x < (float) input_width);
+        float input_x = (float) (int32_t) output_x * width_scale;
+        input_x = math_min_f32(math_max_f32(input_x, 0.0f), (float) input_x_max);
 
         const uint32_t input_x_left = (uint32_t) (int32_t) input_x;
         const uint32_t input_x_right = math_min_u32(input_x_left + 1, input_x_max);
@@ -597,17 +600,20 @@ void xnn_indirection_init_resize_bilinear2d_hwc_f32(
 
   if (tensorflow_legacy || align_corners) {
     for (size_t output_y = output_y_start; output_y < output_y_end; output_y++) {
-      const float input_y = (float) (int32_t) output_y * height_scale;
-      assert(input_y >= 0.0f);
-      assert(input_y < (float) input_height);
+      float input_y = (float) (int32_t) output_y * height_scale;
+      // Clamp the source coordinate as the half-pixel branch does. The legacy
+      // and align-corners formulas rely on input_y staying < input_height, but
+      // height_scale is float32 and for large output_height the rounded product
+      // can reach input_height, putting input_y_top one full row past the input
+      // (out-of-bounds read in the bilinear ukernel).
+      input_y = math_min_f32(math_max_f32(input_y, 0.0f), (float) input_y_max);
 
       const uint32_t input_y_top = (uint32_t) (int32_t) input_y;
       const uint32_t input_y_bottom = math_min_u32(input_y_top + 1, input_y_max);
       const float alpha_y = input_y - (float) input_y_top;
       for (size_t output_x = 0; output_x < output_width; output_x++) {
-        const float input_x = (float) (int32_t) output_x * width_scale;
-        assert(input_x >= 0.0f);
-        assert(input_x < (float) input_width);
+        float input_x = (float) (int32_t) output_x * width_scale;
+        input_x = math_min_f32(math_max_f32(input_x, 0.0f), (float) input_x_max);
 
         const uint32_t input_x_left = (uint32_t) (int32_t) input_x;
         const uint32_t input_x_right = math_min_u32(input_x_left + 1, input_x_max);
@@ -698,17 +704,20 @@ void xnn_indirection_init_resize_bilinear2d_hwc_q11(
 
   if (tensorflow_legacy || align_corners) {
     for (size_t output_y = output_y_start; output_y < output_y_end; output_y++) {
-      const float input_y = (float) (int32_t) output_y * height_scale;
-      assert(input_y >= 0.0f);
-      assert(input_y < (float) input_height);
+      float input_y = (float) (int32_t) output_y * height_scale;
+      // Clamp the source coordinate as the half-pixel branch does. The legacy
+      // and align-corners formulas rely on input_y staying < input_height, but
+      // height_scale is float32 and for large output_height the rounded product
+      // can reach input_height, putting input_y_top one full row past the input
+      // (out-of-bounds read in the bilinear ukernel).
+      input_y = math_min_f32(math_max_f32(input_y, 0.0f), (float) input_y_max);
 
       const uint32_t input_y_top = (uint32_t) (int32_t) input_y;
       const uint32_t input_y_bottom = math_min_u32(input_y_top + 1, input_y_max);
       const float alpha_y = input_y - (float) input_y_top;
       for (size_t output_x = 0; output_x < output_width; output_x++) {
-        const float input_x = (float) (int32_t) output_x * width_scale;
-        assert(input_x >= 0.0f);
-        assert(input_x < (float) input_width);
+        float input_x = (float) (int32_t) output_x * width_scale;
+        input_x = math_min_f32(math_max_f32(input_x, 0.0f), (float) input_x_max);
 
         const uint32_t input_x_left = (uint32_t) (int32_t) input_x;
         const uint32_t input_x_right = math_min_u32(input_x_left + 1, input_x_max);
@@ -794,17 +803,20 @@ void xnn_indirection_init_resize_bilinear2d_chw_f16(
   const uint32_t input_x_max = (uint32_t) input_width - 1;
   if (tensorflow_legacy || align_corners) {
     for (size_t output_y = 0; output_y < output_height; output_y++) {
-      const float input_y = (float) (int32_t) output_y * height_scale;
-      assert(input_y >= 0.0f);
-      assert(input_y < (float) input_height);
+      float input_y = (float) (int32_t) output_y * height_scale;
+      // Clamp the source coordinate as the half-pixel branch does. The legacy
+      // and align-corners formulas rely on input_y staying < input_height, but
+      // height_scale is float32 and for large output_height the rounded product
+      // can reach input_height, putting input_y_top one full row past the input
+      // (out-of-bounds read in the bilinear ukernel).
+      input_y = math_min_f32(math_max_f32(input_y, 0.0f), (float) input_y_max);
 
       const uint32_t input_y_top = (uint32_t) (int32_t) input_y;
       const uint32_t input_y_bottom = math_min_u32(input_y_top + 1, input_y_max);
       const float alpha_y = input_y - (float) input_y_top;
       for (size_t output_x = 0; output_x < output_width; output_x++) {
-        const float input_x = (float) (int32_t) output_x * width_scale;
-        assert(input_x >= 0.0f);
-        assert(input_x < (float) input_width);
+        float input_x = (float) (int32_t) output_x * width_scale;
+        input_x = math_min_f32(math_max_f32(input_x, 0.0f), (float) input_x_max);
 
         uint32_t input_x_left = (uint32_t) (int32_t) input_x;
 
@@ -894,17 +906,20 @@ void xnn_indirection_init_resize_bilinear2d_chw_f32(
   const uint32_t input_x_max = (uint32_t) input_width - 1;
   if (tensorflow_legacy || align_corners) {
     for (size_t output_y = 0; output_y < output_height; output_y++) {
-      const float input_y = (float) (int32_t) output_y * height_scale;
-      assert(input_y >= 0.0f);
-      assert(input_y < (float) input_height);
+      float input_y = (float) (int32_t) output_y * height_scale;
+      // Clamp the source coordinate as the half-pixel branch does. The legacy
+      // and align-corners formulas rely on input_y staying < input_height, but
+      // height_scale is float32 and for large output_height the rounded product
+      // can reach input_height, putting input_y_top one full row past the input
+      // (out-of-bounds read in the bilinear ukernel).
+      input_y = math_min_f32(math_max_f32(input_y, 0.0f), (float) input_y_max);
 
       const uint32_t input_y_top = (uint32_t) (int32_t) input_y;
       const uint32_t input_y_bottom = math_min_u32(input_y_top + 1, input_y_max);
       const float alpha_y = input_y - (float) input_y_top;
       for (size_t output_x = 0; output_x < output_width; output_x++) {
-        const float input_x = (float) (int32_t) output_x * width_scale;
-        assert(input_x >= 0.0f);
-        assert(input_x < (float) input_width);
+        float input_x = (float) (int32_t) output_x * width_scale;
+        input_x = math_min_f32(math_max_f32(input_x, 0.0f), (float) input_x_max);
 
         uint32_t input_x_left = (uint32_t) (int32_t) input_x;
 


### PR DESCRIPTION
### Problem

In the resize-bilinear indirection initializers (`src/indirection.c`, e.g. `xnn_indirection_init_resize_bilinear2d_hwc_f32`), the `tensorflow_legacy || align_corners` branch computes the source coordinate and casts it to the top index **without clamping**:

```c
const float input_y = (float) (int32_t) output_y * height_scale;
assert(input_y < (float) input_height);                 // compiled out in release
const uint32_t input_y_top = (uint32_t) (int32_t) input_y;   // NOT clamped to input_y_max
const uint32_t input_y_bottom = math_min_u32(input_y_top + 1, input_y_max);  // only this is clamped
```

The code relies on `input_y` staying `< input_height`, but `height_scale` is float32 and for a large `output_height` the rounded product `(output_height - 1) * height_scale` can round up to exactly `input_height`. `input_y_top` is then `input_height`, and the indirection buffer references input row `input_height` — one full row past the input tensor:

```c
indirection_buffer[0] = input + (input_y_top * input_width + input_x_left) * input_pixel_stride;
```

The `ibilinear` ukernel dereferences it, reading out of bounds (CWE-125). The default (half-pixel) branch does not have this problem because it clamps the coordinate first (`input_y = math_min_f32(math_max_f32(input_y, 0.0f), (float) input_y_max);`). The same unclamped pattern is in all five resize initializers (f16/f32/qs8/qu8 NHWC and the CHW variant), for both the height and width coordinate.

Reproduced deterministically: an exact-size input tensor (`2x2x8`) placed at the end of a mapped page with an unmapped guard page immediately after, resized to `output_height = 13103685, output_width = 2` in `XNN_FLAG_TENSORFLOW_LEGACY_MODE`. On the last output row, `input_y` rounds to `2.0` so `input_y_top == input_height == 2`, and the over-read of input row 2 faults on the guard page (`EXC_BAD_ACCESS`). `output_height < 2**24`, so the shape is accepted by `xnn_create_resize_bilinear2d_nhwc`. A normal heap buffer hides the fault but silently reads adjacent heap into the interpolated output (information disclosure).

### Fix

Clamp `input_y` and `input_x` with `math_min_f32`/`math_max_f32` in the legacy/align-corners branch, exactly as the default branch already does, in all five resize indirection initializers. For valid shapes the coordinate is already `< input_height`, so the clamp is a no-op and the output is unchanged.

### Testing

- The guard-page reproducer above faults before the fix and runs cleanly after it.
- A normal legacy-mode resize (e.g. `4x4 -> 8x8`) still runs and produces the same output (the clamp is a no-op for in-range coordinates; corner values are preserved).