### PR TITLE
max-pooling: clamp dilated indirection coordinates to avoid index underflow (OOB read)

### DIFF
--- a/src/indirection.c
+++ b/src/indirection.c
@@ -415,7 +415,10 @@ void xnn_indirection_init_maxpool2d(
         while (input_y >= input_height + input_padding_top) {
           input_y = doz(input_y, dilation_height);
         }
-        input_y -= input_padding_top;
+        // When dilation_height > input_height the loop above can step below
+        // input_padding_top, so the subtraction would underflow. Clamp the
+        // result to the last valid input row to stay in bounds.
+        input_y = min(doz(input_y, input_padding_top), input_height - 1);
 
         for (size_t output_x = 0; output_x < output_width; output_x++) {
           size_t safe_input_x = output_x * stride_width;
@@ -432,7 +435,10 @@ void xnn_indirection_init_maxpool2d(
             while (input_x >= input_width + input_padding_left) {
               input_x = doz(input_x, dilation_width);
             }
-            input_x -= input_padding_left;
+            // When dilation_width > input_width the loop above can step below
+            // input_padding_left, so the subtraction would underflow. Clamp the
+            // result to the last valid input column to stay in bounds.
+            input_x = min(doz(input_x, input_padding_left), input_width - 1);
 
             const size_t index = output_y * step_height + output_x * step_width * kernel_height + pooling_x * kernel_height + pooling_y;
             indirection_buffer[index] = (const void*) ((uintptr_t) input + (input_y * input_width + input_x) * input_pixel_stride);


### PR DESCRIPTION
### Problem

`xnn_indirection_init_maxpool2d` (`src/indirection.c`), in the **dilation** branch, reduces the source coordinate with a `doz()` loop and then subtracts the padding:

```c
while (input_y >= input_height + input_padding_top) {
  input_y = doz(input_y, dilation_height);
}
input_y -= input_padding_top;          // underflows when the loop stepped below input_padding_top
```

When `dilation_height > input_height` (or `dilation_width > input_width`), the loop can step the coordinate **below** `input_padding_top`/`input_padding_left`, so the subtraction underflows to `~SIZE_MAX`. The indirection buffer then gets an input pointer computed from the wrapped offset — `input + (SIZE_MAX * input_width + input_x) * stride`, which points **before** the input tensor — and the max-pooling microkernel reads out of bounds (heap OOB read; information disclosure of adjacent heap into the pooling output, or a crash).

`dilation` is only validated as non-zero (`max-pooling-nhwc.c`), so this is reachable from the public `xnn_create_max_pooling2d_nhwc_*` API. Every **sibling** indirection initializer (`conv2d`, `deconv2d`, `subconv2d`, `dwconv2d`) guards the post-subtraction coordinate (`input_y < input_height`, falling back to the zero buffer), and the **non-dilated** max-pooling branch clamps with `min(doz(...), dim - 1)` — only the dilated branch is missing the guard.

Reproduced deterministically: `xnn_create_max_pooling2d_nhwc_f32(pad_top=1, …, pooling 1×1, dilation_h=3, dilation_w=1)`, reshape `input 2×8×16`. At `output_y=0`: `input_y = 0 → +3 → doz(3,3)=0 → 0-1 = SIZE_MAX`. With the input tensor placed at the start of a mapped page and a `PROT_NONE` guard page immediately **before** it, the under-flowed read faults on the guard page:

```
EXC_BAD_ACCESS (read)  in xnn_f32_maxpool_minmax_ukernel_9p__neon_u4
  <- xnn_compute_max_pooling <- pthreadpool_parallelize_2d <- xnn_run_operator_with_index
input=0x...4000  leading_guard=[0x...0000, 0x...4000)
```

### Fix

Clamp the dilated coordinate with the file's own `min(doz(coord, padding), dim - 1)` border idiom (matching the non-dilated branch and the sibling initializers), for both the height and width coordinate. For valid windows the coordinate is already `< dim`, so the clamp is a no-op and the max-pooling output is unchanged.

### Testing

- The reproducer faults before the fix and runs cleanly after it.
- Three valid configurations (valid-dilated 5×5, valid-dilated with asymmetric padding 3×3, non-dilated 4×4) produce output identical to a reference max-pooling implementation (0 mismatches).