### PR TITLE
Harden allocation, overflow, and error-handling paths in operators

### DIFF
--- a/src/operators/batch-matrix-multiply-nc.c
+++ b/src/operators/batch-matrix-multiply-nc.c
@@ -333,8 +333,11 @@ static enum xnn_status setup_packing_params_qs8(
   } else {  // Non const weights.
     if (context->scale_b != NULL) {
       xnn_operator_t batch_matrix_multiply_op = *context->op_out;
-      xnn_allocate_extra_params(batch_matrix_multiply_op,
-                                /*extra_params_size=*/1);
+      const enum xnn_status alloc_status = xnn_allocate_extra_params(
+          batch_matrix_multiply_op, /*extra_params_size=*/1);
+      if (alloc_status != xnn_status_success) {
+        return alloc_status;
+      }
 
       context->packing_params_.qs8_qc8w = (struct xnn_qs8_qc8w_packing_params){
           .input_zero_point = context->input_zero_point,
@@ -548,7 +551,7 @@ enum xnn_status create_batch_matrix_multiply_nc_helper(
 
 error:
   variant->cleanup(variant, context);
-  return xnn_status_success;
+  return status;
 }
 
 enum xnn_status xnn_create_batch_matrix_multiply_nc_f16(
@@ -1394,6 +1397,13 @@ enum xnn_status xnn_reshape_batch_matrix_multiply_nc_qs8(
     xnn_operator_t batch_matrix_multiply_op, size_t num_batch_dims,
     const size_t* batch_dims_a, const size_t* batch_dims_b, size_t m, size_t k,
     size_t n, size_t* workspace_size, pthreadpool_t threadpool) {
+  if (batch_matrix_multiply_op->extra_params == NULL) {
+    xnn_log_error(
+        "failed to reshape %s operator: missing packing extra params",
+        xnn_operator_type_to_string(
+            xnn_operator_type_batch_matrix_multiply_nc_qs8));
+    return xnn_status_invalid_state;
+  }
   return reshape_batch_matrix_multiply_nc(
       batch_matrix_multiply_op,
       xnn_operator_type_batch_matrix_multiply_nc_qs8,

--- a/src/operators/convolution-nchw.c
+++ b/src/operators/convolution-nchw.c
@@ -1215,8 +1215,14 @@ enum xnn_status xnn_create_convolution2d_nchw_f32_f16(
   const size_t num_kernel_entries = groups * group_input_channels *
                                     group_output_channels * kernel_width *
                                     kernel_height;
+  if (num_kernel_entries > SIZE_MAX / sizeof(float)) {
+    return xnn_status_out_of_memory;
+  }
   float* fp32_kernel_buffer =
       (float*)xnn_allocate_memory(num_kernel_entries * sizeof(float));
+  if (fp32_kernel_buffer == NULL) {
+    return xnn_status_out_of_memory;
+  }
   float* fp32_bias_buffer = NULL;
   const xnn_float16* f16_kernel = (const xnn_float16*)kernel;
   const xnn_float16* f16_bias = (const xnn_float16*)bias;
@@ -1226,6 +1232,10 @@ enum xnn_status xnn_create_convolution2d_nchw_f32_f16(
   if (bias && !(flags & XNN_FLAG_FP32_STATIC_BIASES)) {
     fp32_bias_buffer = (float*)xnn_allocate_memory(
         groups * group_output_channels * sizeof(float));
+    if (fp32_bias_buffer == NULL) {
+      xnn_release_memory(fp32_kernel_buffer);
+      return xnn_status_out_of_memory;
+    }
     for (size_t i = 0; i < groups * group_output_channels; ++i) {
       fp32_bias_buffer[i] = xnn_float16_to_float(f16_bias[i]);
     }

--- a/src/operators/convolution-nhwc.c
+++ b/src/operators/convolution-nhwc.c
@@ -2432,8 +2432,14 @@ enum xnn_status xnn_create_convolution2d_nhwc_f32_f16(
   const size_t num_kernel_entries = groups * group_input_channels *
                                     group_output_channels * kernel_width *
                                     kernel_height;
+  if (num_kernel_entries > SIZE_MAX / sizeof(float)) {
+    return xnn_status_out_of_memory;
+  }
   float* fp32_kernel_buffer =
       (float*)xnn_allocate_memory(num_kernel_entries * sizeof(float));
+  if (fp32_kernel_buffer == NULL) {
+    return xnn_status_out_of_memory;
+  }
   const void* bias_buffer = NULL;
   float* fp32_bias_buffer = NULL;
   const xnn_float16* f16_kernel = (const xnn_float16*)kernel;
@@ -2444,6 +2450,10 @@ enum xnn_status xnn_create_convolution2d_nhwc_f32_f16(
   if (bias && !(flags & XNN_FLAG_FP32_STATIC_BIASES)) {
     fp32_bias_buffer = (float*)xnn_allocate_memory(
         groups * group_output_channels * sizeof(float));
+    if (fp32_bias_buffer == NULL) {
+      xnn_release_memory(fp32_kernel_buffer);
+      return xnn_status_out_of_memory;
+    }
     bias_buffer = fp32_bias_buffer;
     for (size_t i = 0; i < groups * group_output_channels; ++i) {
       fp32_bias_buffer[i] = xnn_float16_to_float(f16_bias[i]);
@@ -2503,8 +2513,14 @@ enum xnn_status xnn_create_convolution2d_nhwc_pf32_f16(
   const size_t num_kernel_entries = groups * group_input_channels *
                                     group_output_channels * kernel_width *
                                     kernel_height;
+  if (num_kernel_entries > SIZE_MAX / sizeof(float)) {
+    return xnn_status_out_of_memory;
+  }
   float* fp32_kernel_buffer =
       (float*)xnn_allocate_memory(num_kernel_entries * sizeof(float));
+  if (fp32_kernel_buffer == NULL) {
+    return xnn_status_out_of_memory;
+  }
   const void* bias_buffer = NULL;
   float* fp32_bias_buffer = NULL;
   const xnn_float16* f16_kernel = (const xnn_float16*)kernel;
@@ -2515,6 +2531,10 @@ enum xnn_status xnn_create_convolution2d_nhwc_pf32_f16(
   if (bias && !(flags & XNN_FLAG_FP32_STATIC_BIASES)) {
     fp32_bias_buffer = (float*)xnn_allocate_memory(
         groups * group_output_channels * sizeof(float));
+    if (fp32_bias_buffer == NULL) {
+      xnn_release_memory(fp32_kernel_buffer);
+      return xnn_status_out_of_memory;
+    }
     bias_buffer = fp32_bias_buffer;
     for (size_t i = 0; i < groups * group_output_channels; ++i) {
       fp32_bias_buffer[i] = xnn_float16_to_float(f16_bias[i]);
@@ -3263,9 +3283,16 @@ enum xnn_status reshape_convolution2d_nhwc_qx8_f16_qc8w(
             convolution_op->convolution_op->zero_buffers[i]);
       }
     }
-    convolution_op->convolution_op->zero_buffers =
-        xnn_reallocate_memory(convolution_op->convolution_op->zero_buffers,
-                              batch_size * sizeof(void*));
+    void* zero_buffers = xnn_reallocate_memory(
+        convolution_op->convolution_op->zero_buffers,
+        batch_size * sizeof(void*));
+    if (zero_buffers == NULL) {
+      xnn_log_error("failed to allocate %zu bytes for %s operator zero buffers",
+                    batch_size * sizeof(void*),
+                    xnn_operator_type_to_string(convolution_op->type));
+      return xnn_status_out_of_memory;
+    }
+    convolution_op->convolution_op->zero_buffers = zero_buffers;
     convolution_op->convolution_op->zero_buffers[0] =
         convolution_op->zero_buffer;
     for (size_t i = 1; i < batch_size; ++i) {
@@ -3325,9 +3352,16 @@ enum xnn_status reshape_convolution2d_nhwc_qx8_f32_qc8w(
             convolution_op->convolution_op->zero_buffers[i]);
       }
     }
-    convolution_op->convolution_op->zero_buffers =
-        xnn_reallocate_memory(convolution_op->convolution_op->zero_buffers,
-                              batch_size * sizeof(void*));
+    void* zero_buffers = xnn_reallocate_memory(
+        convolution_op->convolution_op->zero_buffers,
+        batch_size * sizeof(void*));
+    if (zero_buffers == NULL) {
+      xnn_log_error("failed to allocate %zu bytes for %s operator zero buffers",
+                    batch_size * sizeof(void*),
+                    xnn_operator_type_to_string(convolution_op->type));
+      return xnn_status_out_of_memory;
+    }
+    convolution_op->convolution_op->zero_buffers = zero_buffers;
     convolution_op->convolution_op->zero_buffers[0] =
         convolution_op->zero_buffer;
     for (size_t i = 1; i < batch_size; ++i) {

--- a/src/operators/deconvolution-nhwc.c
+++ b/src/operators/deconvolution-nhwc.c
@@ -604,6 +604,13 @@ static enum xnn_status compute_scale_params_qs8_qc8w(
     // This buffer is released in the `cleanup` function.
     context->kernel_scale_for_cleanup = xnn_allocate_simd_memory(
       output_channels * sizeof(float));
+    if (context->kernel_scale_for_cleanup == NULL) {
+      xnn_log_error(
+          "failed to allocate %zu bytes for %s operator kernel scale buffer",
+          output_channels * sizeof(float),
+          xnn_operator_type_to_string(context->operator_type));
+      return xnn_status_out_of_memory;
+    }
     context->kernel_scale = context->kernel_scale_for_cleanup;
     float* const kernel_scale = context->kernel_scale_for_cleanup;
     for (size_t output_channel = 0; output_channel < output_channels; ++output_channel) {
@@ -1698,8 +1705,14 @@ enum xnn_status xnn_create_deconvolution2d_nhwc_f32_f16(
   const size_t num_kernel_entries = groups * group_input_channels *
                                     group_output_channels * kernel_width *
                                     kernel_height;
+  if (num_kernel_entries > SIZE_MAX / sizeof(float)) {
+    return xnn_status_out_of_memory;
+  }
   float* fp32_kernel_buffer =
       (float*)xnn_allocate_memory(num_kernel_entries * sizeof(float));
+  if (fp32_kernel_buffer == NULL) {
+    return xnn_status_out_of_memory;
+  }
   float* fp32_bias_buffer = NULL;
   const xnn_float16* f16_kernel = (const xnn_float16*)kernel;
   const xnn_float16* f16_bias = (const xnn_float16*)bias;
@@ -1709,6 +1722,10 @@ enum xnn_status xnn_create_deconvolution2d_nhwc_f32_f16(
   if (bias && !(flags & XNN_FLAG_FP32_STATIC_BIASES)) {
     fp32_bias_buffer = (float*)xnn_allocate_memory(
         groups * group_output_channels * sizeof(float));
+    if (fp32_bias_buffer == NULL) {
+      xnn_release_memory(fp32_kernel_buffer);
+      return xnn_status_out_of_memory;
+    }
     for (size_t i = 0; i < groups * group_output_channels; ++i) {
       fp32_bias_buffer[i] = xnn_float16_to_float(f16_bias[i]);
     }
@@ -2473,9 +2490,16 @@ enum xnn_status reshape_deconvolution2d_nhwc_qx8_f32_qc8w(
       }
     }
 
-    deconvolution_op->convolution_op->zero_buffers =
-        xnn_reallocate_memory(deconvolution_op->convolution_op->zero_buffers,
-                              batch_size * sizeof(void*));
+    void* zero_buffers = xnn_reallocate_memory(
+        deconvolution_op->convolution_op->zero_buffers,
+        batch_size * sizeof(void*));
+    if (zero_buffers == NULL) {
+      xnn_log_error("failed to allocate %zu bytes for %s operator zero buffers",
+                    batch_size * sizeof(void*),
+                    xnn_operator_type_to_string(deconvolution_op->type));
+      return xnn_status_out_of_memory;
+    }
+    deconvolution_op->convolution_op->zero_buffers = zero_buffers;
     deconvolution_op->convolution_op->zero_buffers[0] =
         deconvolution_op->zero_buffer;
     for (size_t i = 1; i < batch_size; ++i) {

--- a/src/operators/fully-connected-nc.c
+++ b/src/operators/fully-connected-nc.c
@@ -2119,10 +2119,26 @@ enum xnn_status xnn_create_fully_connected_nc_qd8_f32_qb4w_f16_scales(
     const xnn_float16* kernel_scale, const void* kernel, const float* bias,
     float output_min, float output_max, uint32_t flags,
     xnn_weights_cache_t weights_cache, xnn_operator_t* fully_connected_op_out) {
+  if (block_size == 0) {
+    xnn_log_error(
+        "failed to create %s operator with block_size=0: block_size must be "
+        "nonzero",
+        xnn_operator_type_to_string(
+            xnn_operator_type_fully_connected_nc_qd8_f32_qb4w));
+    return xnn_status_invalid_parameter;
+  }
   const size_t num_blocks =
       (input_channels + block_size - 1) / block_size * output_channels;
   xnn_bfloat16* bf16_scale_buffer =
       (xnn_bfloat16*)xnn_allocate_memory(num_blocks * sizeof(xnn_bfloat16));
+  if (bf16_scale_buffer == NULL) {
+    xnn_log_error(
+        "failed to allocate %zu bytes for %s operator kernel scales",
+        num_blocks * sizeof(xnn_bfloat16),
+        xnn_operator_type_to_string(
+            xnn_operator_type_fully_connected_nc_qd8_f32_qb4w));
+    return xnn_status_out_of_memory;
+  }
   for (size_t i = 0; i < num_blocks; ++i) {
     bf16_scale_buffer[i] =
         xnn_bfloat16_from_float(xnn_float16_to_float(kernel_scale[i]));
@@ -2168,10 +2184,26 @@ enum xnn_status xnn_create_fully_connected_nc_qdu8_f32_qb4w_f16_scales(
     const xnn_float16* kernel_scale, const void* kernel, const float* bias,
     float output_min, float output_max, uint32_t flags,
     xnn_weights_cache_t weights_cache, xnn_operator_t* fully_connected_op_out) {
+  if (block_size == 0) {
+    xnn_log_error(
+        "failed to create %s operator with block_size=0: block_size must be "
+        "nonzero",
+        xnn_operator_type_to_string(
+            xnn_operator_type_fully_connected_nc_qdu8_f32_qb4w));
+    return xnn_status_invalid_parameter;
+  }
   const size_t num_blocks =
       (input_channels + block_size - 1) / block_size * output_channels;
   xnn_bfloat16* bf16_scale_buffer =
       (xnn_bfloat16*)xnn_allocate_memory(num_blocks * sizeof(xnn_bfloat16));
+  if (bf16_scale_buffer == NULL) {
+    xnn_log_error(
+        "failed to allocate %zu bytes for %s operator kernel scales",
+        num_blocks * sizeof(xnn_bfloat16),
+        xnn_operator_type_to_string(
+            xnn_operator_type_fully_connected_nc_qdu8_f32_qb4w));
+    return xnn_status_out_of_memory;
+  }
   for (size_t i = 0; i < num_blocks; ++i) {
     bf16_scale_buffer[i] =
         xnn_bfloat16_from_float(xnn_float16_to_float(kernel_scale[i]));
@@ -2285,8 +2317,15 @@ enum xnn_status xnn_create_fully_connected_nc_f32_f16(
     size_t output_stride, const void* kernel, const void* bias,
     float output_min, float output_max, uint32_t flags,
     xnn_weights_cache_t weights_cache, xnn_operator_t* fully_connected_op_out) {
+  if (input_channels != 0 &&
+      output_channels > SIZE_MAX / sizeof(float) / input_channels) {
+    return xnn_status_out_of_memory;
+  }
   float* fp32_kernel_buffer = (float*)xnn_allocate_memory(
       input_channels * output_channels * sizeof(float));
+  if (fp32_kernel_buffer == NULL) {
+    return xnn_status_out_of_memory;
+  }
   float* fp32_bias_buffer = NULL;
   float* fp32_bias_buffer_to_release = NULL;
   const xnn_float16* f16_kernel = (const xnn_float16*)kernel;
@@ -2297,6 +2336,10 @@ enum xnn_status xnn_create_fully_connected_nc_f32_f16(
   if (bias && !(flags & XNN_FLAG_FP32_STATIC_BIASES)) {
     fp32_bias_buffer_to_release =
         (float*)xnn_allocate_memory(output_channels * sizeof(float));
+    if (fp32_bias_buffer_to_release == NULL) {
+      xnn_release_memory(fp32_kernel_buffer);
+      return xnn_status_out_of_memory;
+    }
     fp32_bias_buffer = fp32_bias_buffer_to_release;
     for (size_t i = 0; i < output_channels; ++i) {
       fp32_bias_buffer[i] = xnn_float16_to_float(f16_bias[i]);
@@ -2333,8 +2376,15 @@ enum xnn_status xnn_create_fully_connected_nc_pf32_f16(
     size_t output_stride, const void* kernel, const void* bias,
     float output_min, float output_max, uint32_t flags,
     xnn_weights_cache_t weights_cache, xnn_operator_t* fully_connected_op_out) {
+  if (input_channels != 0 &&
+      output_channels > SIZE_MAX / sizeof(float) / input_channels) {
+    return xnn_status_out_of_memory;
+  }
   float* fp32_kernel_buffer = (float*)xnn_allocate_memory(
       input_channels * output_channels * sizeof(float));
+  if (fp32_kernel_buffer == NULL) {
+    return xnn_status_out_of_memory;
+  }
   float* fp32_bias_buffer = NULL;
   float* fp32_bias_buffer_to_release = NULL;
   const xnn_float16* f16_kernel = (const xnn_float16*)kernel;
@@ -2345,6 +2395,10 @@ enum xnn_status xnn_create_fully_connected_nc_pf32_f16(
   if (bias && !(flags & XNN_FLAG_FP32_STATIC_BIASES)) {
     fp32_bias_buffer_to_release =
         (float*)xnn_allocate_memory(output_channels * sizeof(float));
+    if (fp32_bias_buffer_to_release == NULL) {
+      xnn_release_memory(fp32_kernel_buffer);
+      return xnn_status_out_of_memory;
+    }
     fp32_bias_buffer = fp32_bias_buffer_to_release;
     for (size_t i = 0; i < output_channels; ++i) {
       fp32_bias_buffer[i] = xnn_float16_to_float(f16_bias[i]);

--- a/src/subgraph.c
+++ b/src/subgraph.c
@@ -2682,12 +2682,22 @@ static enum xnn_status optimize_common_subgraphs_broadcast(
       shape[k] = (new_shape[k] == 0 || new_shape[k] == old_shape[k])
                      ? 1
                      : new_shape[k];
+      if (shape[k] != 0 && num_elements > SIZE_MAX / shape[k]) {
+        return xnn_status_out_of_memory;
+      }
       num_elements *= shape[k];
     }
 
     // Create a static right-hand side value filled with zeros.
-    void* data = xnn_allocate_zero_memory(
-        num_elements * xnn_datatype_size_bytes(input_value->datatype));
+    const size_t datatype_size =
+        xnn_datatype_size_bytes(input_value->datatype);
+    if (datatype_size != 0 && num_elements > SIZE_MAX / datatype_size) {
+      return xnn_status_out_of_memory;
+    }
+    void* data = xnn_allocate_zero_memory(num_elements * datatype_size);
+    if (data == NULL) {
+      return xnn_status_out_of_memory;
+    }
     uint32_t new_value_id;
     XNN_RETURN_IF_ERROR(
         xnn_datatype_is_quantized(input_value->datatype)


### PR DESCRIPTION
## Summary

Hardening of allocation, integer-overflow, and error-handling paths in the
operator create/reshape code. No functional change on the success paths.

- f32<-f16 create paths (fully-connected, convolution nhwc/nchw,
  deconvolution): guard the kernel/bias byte-size products against `size_t`
  overflow and NULL-check every `xnn_allocate_memory` before the conversion
  loops write through it; reject `block_size == 0` in the qb4w f16-scale
  wrappers before the division.
- convolution/deconvolution `zero_buffers` reshape: realloc into a temp and
  check it before overwriting the field and indexing `[0]`, so a failed
  realloc no longer leaks the old buffer and writes through NULL.
- deconvolution qc8w scale params: NULL-check `kernel_scale_for_cleanup`
  before filling it (its sibling allocation was already checked).
- batch-matrix-multiply create: the error label returned `xnn_status_success`,
  reporting OOM/packing failures as success with a NULL/partial operator;
  return the real `status`. Also check the `xnn_allocate_extra_params` result,
  and reject a qs8 reshape when `extra_params` was never allocated (previously
  an unconditional NULL deref).
- subgraph broadcast->add rewrite: guard the element-count and byte-size
  products against overflow and NULL-check the zero-tensor buffer.
