### PR TITLE
Fix fp8 e4m3 classification, sub-byte cast saturation, and LUT read bounds

### DIFF
--- a/ynnpack/base/arithmetic.h
+++ b/ynnpack/base/arithmetic.h
@@ -46,12 +46,20 @@ auto cast(float x) {
   if constexpr (is_integral<Unwrapped>::value) {
     x = std::isnan(x) ? 0.0f : x;
     x = std::nearbyint(x);
-    constexpr int half_mantissa = sizeof(Unwrapped) * 8 > 23 ? 127 : 0;
-    if (x > type_info<Unwrapped>::max() - half_mantissa) {
-      return static_cast<Element>(type_info<Unwrapped>::max());
-    }
-    if (x < type_info<Unwrapped>::min()) {
-      return static_cast<Element>(type_info<Unwrapped>::min());
+    if constexpr (ToInfo::element_count() > 1 &&
+                  std::is_integral<decltype(ToInfo::max())>::value) {
+      // Packed sub-byte elements saturate to their logical range (e.g. int2
+      // is [-2, 1]), not the range of the byte-sized storage type.
+      if (x > ToInfo::max()) return static_cast<Element>(ToInfo::max());
+      if (x < ToInfo::min()) return static_cast<Element>(ToInfo::min());
+    } else {
+      constexpr int half_mantissa = sizeof(Unwrapped) * 8 > 23 ? 127 : 0;
+      if (x > type_info<Unwrapped>::max() - half_mantissa) {
+        return static_cast<Element>(type_info<Unwrapped>::max());
+      }
+      if (x < type_info<Unwrapped>::min()) {
+        return static_cast<Element>(type_info<Unwrapped>::min());
+      }
     }
     return static_cast<Element>(
         static_cast<typename unwrap_quantized<Element>::type>(x));

--- a/ynnpack/base/fp8.h
+++ b/ynnpack/base/fp8.h
@@ -190,9 +190,9 @@ class fp8_e4m3 {
 
   // Constants (E4M3FN)
   static constexpr fp8_e4m3 epsilon() { return from_bits(0x20); }  // 2^-3
-  static constexpr fp8_e4m3 infinity() {
-    return from_bits(0x78);
-  }
+  // E4M3FN has no infinity encoding; NaN is the conventional substitute
+  // (matches ml_dtypes float8_e4m3fn).
+  static constexpr fp8_e4m3 infinity() { return from_bits(0x7F); }
   static constexpr fp8_e4m3 min() { return from_bits(0xFE); }  // -448
   static constexpr fp8_e4m3 max() { return from_bits(0x7E); }  // 448
   static constexpr fp8_e4m3 smallest_normal() {
@@ -213,13 +213,11 @@ inline bool isinf(fp8_e5m2 x) {
   return !isfinite(x) && (x.to_bits() & 0x03) == 0;
 }
 
-inline bool isfinite(fp8_e4m3 x) { return (x.to_bits() & 0x78) != 0x78; }
-inline bool isnan(fp8_e4m3 x) {
-  return !isfinite(x) && (x.to_bits() & 0x07) != 0;
-}
-inline bool isinf(fp8_e4m3 x) {
-  return !isfinite(x) && (x.to_bits() & 0x07) == 0;
-}
+// E4M3FN has no infinity: exponent 15 with mantissa < 7 encodes the finite
+// values 256..448, and only 0x7F/0xFF is NaN.
+inline bool isfinite(fp8_e4m3 x) { return (x.to_bits() & 0x7F) != 0x7F; }
+inline bool isnan(fp8_e4m3 x) { return (x.to_bits() & 0x7F) == 0x7F; }
+inline bool isinf(fp8_e4m3 x) { return false; }
 
 }  // namespace ynn
 

--- a/ynnpack/subgraph/elementwise.cc
+++ b/ynnpack/subgraph/elementwise.cc
@@ -284,7 +284,7 @@ ynn_status create_lut(const ynn_node& node, ynn_runtime& runtime,
   slinky::box_expr bounds = make_elementwise_bounds(dims, a.physical_extents());
 
   slinky::box_expr lut_bounds = {
-      slinky::interval_expr(0, 1 << type_size_bytes(a.type))};
+      slinky::interval_expr(0, 1 << type_size_bits(a.type))};
 
   slinky::call_stmt::attributes attrs;
   attrs.name = "lut";


### PR DESCRIPTION
## Summary

Three numeric/bounds fixes in `ynnpack`.

- `base/fp8.h`: E4M3FN has no infinity; exponent 15 with mantissa < 7 encodes
  the finite values 256..448, and only `0x7F`/`0xFF` is NaN. The
  `isfinite`/`isnan`/`isinf` predicates treated the whole top binade as
  inf/NaN (`isnan(max())` was `true`) and `infinity()` returned a finite 256.
  Correct the masks and make `infinity()` the NaN sentinel. Verified
  exhaustively over all 256 encodings against an independent OCP-spec
  reference decoder. (The e5m2 predicates were already correct and are
  unchanged.)
- `base/arithmetic.h`: `cast<To>()` to a packed sub-byte type
  (`int2x4`/`int4x2`/...) saturated to the byte storage range and then wrapped
  in the low-bit mask, e.g. `cast<int2x4>(3.0f)` gave `-1` instead of the int2
  max `+1`. Clamp to the logical sub-byte range; byte/word and scalar
  quantized types are unchanged.
- `subgraph/elementwise.cc`: the LUT input read footprint used
  `type_size_bytes` (1) instead of `type_size_bits` (256), under-declaring the
  table bound.
