### PR TITLE
Fix out-of-bounds read when packing transposed qb4w weights

### DIFF
--- a/src/reference/packing.cc
+++ b/src/reference/packing.cc
@@ -2386,6 +2386,10 @@ XNN_NO_SANITIZE_FUNCTION void xnn_pack_qb4_weights_and_biases(
   const size_t extra_bytes_bl = sizeof(uint16_t);
   const size_t extra_bytes_n = sizeof(uint32_t);
   if (flags & XNN_FLAG_TRANSPOSE_WEIGHTS) {
+    // In the transposed (GIO) layout the source kernel is
+    // [input_channels][output_channels] nibbles, so the source row stride is
+    // output_channels; `k_stride` above is the packed-output stride and would
+    // read out of bounds here.
     xnn_pack_qs8_qb4w_gemm_gio_w(
         /*g=*/groups,
         /*nc=*/output_channels,
@@ -2393,7 +2397,7 @@ XNN_NO_SANITIZE_FUNCTION void xnn_pack_qb4_weights_and_biases(
         /*nr=*/nr,
         /*kr=*/kr,
         /*sr=*/sr,
-        /*k_stride=*/k_stride,
+        /*k_stride=*/output_channels,
         /*bl=*/block_size,
         /*kernel=*/(const uint8_t*)weights,
         /*bias=*/nullptr,


### PR DESCRIPTION
## Summary

`xnn_pack_qb4_weights_and_biases` passes the wrong source stride to the GIO
packer on the `XNN_FLAG_TRANSPOSE_WEIGHTS` path, causing an out-of-bounds read
of the kernel buffer (and silently wrong packed weights for other shapes).

In the transposed (GIO) layout the source kernel is
`[input_channels][output_channels]` int4, so the source row stride must be
`output_channels`. The function instead passed its locally recomputed
*packed-output* stride `round_up_po2(input_channels, kr*sr*planes) >> 1`
(roughly `input_channels/2`). For shapes where `input_channels > 2*output_channels`
the GIO packer reads past the end of the kernel buffer (e.g. IC=256, OC=32
reads ~12 KB past a 4 KB buffer); for other shapes it packs the wrong weights.
The qb4w fully-connected variants set `check_flags = UNUSED`, so the transpose
flag is accepted and reaches this path, and three live gemm configs
(`qd8_f16_qb4w`, `qdu8_f32_qb4w`, `qd8_f32_qb4w`) wire this packer in.

Pass `output_channels` as the source stride, matching the `qc4w` sibling and
the existing standalone test (`test/packing.cc` calls the same GIO packer with
`/*k_stride =*/nc`). The non-transpose path and the local `k_stride` used for
the packed layout are unchanged. `groups > 1` is also correct: the source
advances one full group as `[g][ic][oc]` with intra-group row stride `nc`.

This is a memory-safety issue reachable with attacker-influenced weight
metadata; maintainers may wish to treat it as security-relevant.

