### PR TITLE
Bounds-check data-derived axes and quantization params in tensor builder

### DIFF
--- a/litert/tensor/arithmetic.h
+++ b/litert/tensor/arithmetic.h
@@ -560,6 +560,11 @@ Tensor<Mixins...> ExpandDims(Tensor<Mixins...> input, Tensor<Mixins...> axis,
     if (real_axis < 0) {
       real_axis += input_info.shape.size() + 1;
     }
+    if (real_axis < 0 ||
+        real_axis > static_cast<int>(input_info.shape.size())) {
+      return Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
+          "The ExpandDims axis is out of range.")));
+    }
     output_info.shape.insert(output_info.shape.begin() + real_axis, 1);
   }
 
@@ -1260,11 +1265,19 @@ Tensor<Mixins...> Pack(absl::Span<Tensor<Mixins...>> inputs, int axis,
   op->axis = axis;
   AddInputs(op, inputs);
   Tensor<Mixins...> output = AddOutput(op, loc);
+  if (inputs.empty()) {
+    return Tensor<Mixins...>(graph::ErrorTensor(
+        absl::InvalidArgumentError("Pack requires at least one input.")));
+  }
   const graph::TensorInformation& first_input_info =
       *GetInfo(inputs[0].GetRaw());
   graph::TensorInformation& output_info = *GetInfo(output.GetRaw());
   output_info.type = first_input_info.type;
   output_info.shape = first_input_info.shape;
+  if (axis < 0 || axis > static_cast<int>(first_input_info.shape.size())) {
+    return Tensor<Mixins...>(graph::ErrorTensor(
+        absl::InvalidArgumentError("The Pack axis is out of range.")));
+  }
   output_info.shape.insert(output_info.shape.begin() + axis, inputs.size());
 
   graph::OpDebugger::DebugOp(*op);
@@ -1930,6 +1943,11 @@ Tensor<Mixins...> OneHot(Tensor<Mixins...> indices, Tensor<Mixins...> depth,
   if (depth_info.buffer) {
     depth_val =
         depth_info.buffer->Lock().template As<const int32_t>().data()[0];
+  }
+  if (resolved_axis < 0 ||
+      resolved_axis > static_cast<int>(indices_info.shape.size())) {
+    return Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
+        "The OneHot axis is out of range.")));
   }
   output_info.shape.insert(output_info.shape.begin() + resolved_axis,
                            depth_val);

--- a/litert/tensor/backends/xnnpack/arithmetic.cc
+++ b/litert/tensor/backends/xnnpack/arithmetic.cc
@@ -1190,6 +1190,10 @@ absl::Status OpMixin<ExpandDimsOperation, XnnpackMixinTag>::ToXnnpack(
         absl::StrFormat("%s: axis must be a constant tensor", op_name));
   }
   auto locked_axis = axis_info.buffer->Lock().As<const int32_t>();
+  if (locked_axis.size() == 0) {
+    return absl::InvalidArgumentError(
+        absl::StrFormat("%s: axis tensor must not be empty", op_name));
+  }
   int real_axis = locked_axis.data()[0];
 
   LRT_TENSOR_ASSIGN_OR_RETURN(const auto& input_info, graph::GetInfo(input));
@@ -1201,6 +1205,12 @@ absl::Status OpMixin<ExpandDimsOperation, XnnpackMixinTag>::ToXnnpack(
 
   if (real_axis < 0) {
     real_axis += input_info.shape.size() + 1;
+  }
+  if (real_axis < 0 ||
+      real_axis > static_cast<int>(input_info.shape.size())) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "%s: axis %d is out of range for input of rank %d", op_name,
+        locked_axis.data()[0], static_cast<int>(input_info.shape.size())));
   }
   new_shape.insert(new_shape.begin() + real_axis, 1);
 

--- a/litert/tensor/backends/xnnpack/conversion.cc
+++ b/litert/tensor/backends/xnnpack/conversion.cc
@@ -381,7 +381,8 @@ absl::StatusOr<uint32_t> XnnpackBuildContext::DefineValue(
     const auto& pcq = maybe_pcq.value();
     if (pcq.scales.size() == 1) {
       LRT_TENSOR_RETURN_IF_ERROR(xnn_define_quantized_tensor_value(
-          subgraph_, GetXnnpackType(value), pcq.zero_points[0], pcq.scales[0],
+          subgraph_, GetXnnpackType(value),
+          pcq.zero_points.empty() ? 0 : pcq.zero_points[0], pcq.scales[0],
           dims.size(), dims.empty() ? nullptr : dims.data(), data_ptr,
           external_id, value.flags, &value.id))
           << "Could not define a new quantized tensor value.";


### PR DESCRIPTION
## Summary

Bounds-check data-derived values in the litert tensor graph builder.

- `ExpandDims`, `Pack`, and `OneHot` read an axis (from tensor data or an
  argument) and passed it straight to `std::vector::insert` without range
  checking, so an out-of-range axis produced a heap out-of-bounds write.
  Validate the resolved axis against `[0, rank]` (negative axes for ExpandDims
  and OneHot are still accepted via the existing `+ rank + 1` adjustment) and
  reject an empty axis tensor / empty input list before `insert`.
- `DefineValue` read `pcq.zero_points[0]` in the single-scale branch without
  checking that `zero_points` is non-empty (the vector carries no size
  invariant tying it to `scales`); default to 0 when empty, matching the
  blockwise branch.

