### PR TITLE
softmax: reject input/output datatype mismatch

### DIFF
--- a/src/subgraph/softmax.c
+++ b/src/subgraph/softmax.c
@@ -197,6 +197,12 @@ enum xnn_status xnn_define_softmax(
       return xnn_status_invalid_parameter;
   }
 
+  status = xnn_subgraph_check_datatype_matches(
+    xnn_node_type_softmax, input_id, input_value, output_id, output_value);
+  if (status != xnn_status_success) {
+    return status;
+  }
+
   struct xnn_node* node = xnn_subgraph_new_node(subgraph);
   if (node == NULL) {
     return xnn_status_out_of_memory;

--- a/test/subgraph/softmax.cc
+++ b/test/subgraph/softmax.cc
@@ -119,6 +119,20 @@ TEST(Softmax, reshape_rejects_scalar_input) {
   subgraph.ReshapeExternalTensor(TensorShape(), &data, 0).ReshapeRuntime();
   EXPECT_EQ(subgraph.Status(), xnn_status_invalid_parameter);
 }
+
+TEST(Softmax, define_rejects_input_output_datatype_mismatch) {
+  ASSERT_EQ(xnn_status_success, xnn_initialize(nullptr /* allocator */));
+
+  // Input fp32, output fp16: the two datatypes are individually valid for
+  // softmax, but they must match. Without the check the f32 kernel would
+  // write 4-byte elements into a buffer sized for 2-byte fp16 elements.
+  SubgraphTester subgraph(2);
+  subgraph.AddInputTensor(1, xnn_datatype_fp32, 0)
+      .AddOutputTensor(1, xnn_datatype_fp16, 1);
+  EXPECT_EQ(
+      xnn_define_softmax(subgraph.Subgraph(), 0, 1, /*flags=*/0),
+      xnn_status_invalid_parameter);
+}
 #else
 // This is not an error in YNNPACK (and it doesn't crash either).
 #endif  // XNNPACK_USE_YNNPACK


### PR DESCRIPTION
**Bug**: `xnn_define_softmax` validates the input datatype (fp16/fp32) and the output datatype (fp16/fp32) independently but never verifies they match. Unlike 11 sibling operators (binary, concatenate, copy, depth-to-space, even-split, max-pooling, rope, space-to-depth, static-constant-pad, static-slice, static-transpose) which call `xnn_subgraph_check_datatype_matches`, softmax omits this check.

**Impact**: When input=fp32 and output=fp16:
1. `create_softmax_operator` selects the f32 kernel (based on input type)
2. `resize_unary_elementwise_output_tensor` sizes the output buffer using fp16 (2 bytes/element)
3. The f32 softmax kernel writes 4 bytes/element into the fp16-sized buffer
4. Result: heap-buffer-overflow write of `num_elements * 2` bytes

Verified with clang/ASan:
\\\
==11==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x7b03bcee2100
WRITE of size 32 at 0x7b03bcee2100 thread T0
    #0 xnn_f32_raddstoreexpminusmax_ukernel__avx2_rr2_p5_u32_acc2
0x7b03bcee2100 is located 0 bytes after 8192-byte region
\\\

**Fix**: Add the missing `xnn_subgraph_check_datatype_matches` call between the output datatype switch and the node commit, matching the pattern used by `static-constant-pad` and other sibling operators.

**Test**: Added `define_rejects_input_output_datatype_mismatch` that creates a softmax with fp32 input / fp16 output and expects `xnn_status_invalid_parameter`.