### PR TITLE
size both argmax pooling outputs before returning reallocation

### DIFF
--- a/src/subgraph/argmax-pooling-2d.c
+++ b/src/subgraph/argmax-pooling-2d.c
@@ -97,14 +97,18 @@ static enum xnn_status reshape_argmax_pooling_operator(
 
   output_value->shape.num_dims = 4;
   output_index->shape.num_dims = 4;
+  bool reallocation_required = false;
   const size_t new_output_size = xnn_runtime_tensor_get_size(output_value);
   if (new_output_size > output_value->size) {
     output_value->size = new_output_size;
-    return xnn_status_reallocation_required;
+    reallocation_required = true;
   }
   const size_t new_index_size = xnn_runtime_tensor_get_size(output_index);
   if (new_index_size > output_index->size) {
     output_index->size = new_index_size;
+    reallocation_required = true;
+  }
+  if (reallocation_required) {
     return xnn_status_reallocation_required;
   }
   return xnn_status_success;


### PR DESCRIPTION
Tracing a graph where the argmax-pooling index output feeds a later node, so the index tensor is internal rather than external, then growing the input between two reshapes:

    src/runtime.c:882   each op's reshape runs exactly once
    src/runtime.c:912   reallocation_required -> xnn_plan_memory(); reshape is not re-run

reshape_argmax_pooling_operator sizes two outputs but bails out the moment the value tensor grows:

    new_output_size > output_value->size
      -> output_value->size = new_output_size
      -> return xnn_status_reallocation_required   // index size never recomputed

When a dynamic input grows both outputs on the same pass, output_index->size keeps its old value. xnn_plan_memory then under-allocates the index buffer and setup_argmax_pooling writes batch*oh*ow*channels int32 indices into it, a write past the end. With external index buffers the user sizes them, so this only bites when the index is an internal tensor.

even-split has the same multi-output shape and handles it correctly: it accumulates a reallocation_required flag across every output and returns once at the end. Did the same here.

Found while auditing the multi-output reshape paths against the single-pass reshape contract in xnn_reshape_runtime.