### PR TITLE
bound split axis to input rank in split_dims reshape

### DIFF
--- a/src/subgraph/copy.c
+++ b/src/subgraph/copy.c
@@ -263,6 +263,16 @@ static enum xnn_status resize_split_dims_output_tensor(
   const struct xnn_shape* input_shape = &input->shape;
   struct xnn_shape* output_shape = &output->shape;
 
+  if (axis >= input_shape->num_dims) {
+    xnn_log_error("failed to split dims in %s operator with input ID #%" PRIu32
+                  " and output ID #%" PRIu32
+                  ": split axis, %zu, is out of range for an input with %zu "
+                  "dimensions",
+                  xnn_node_type_to_string(xnn_node_type_split_dims),
+                  input_id, output_id, axis, input_shape->num_dims);
+    return xnn_status_invalid_parameter;
+  }
+
   if (input_shape->num_dims - 1 + num_dims > XNN_MAX_TENSOR_DIMS) {
     xnn_log_error("failed to split dims in %s operator with input ID #%" PRIu32
                   " and output ID #%" PRIu32

--- a/test/subgraph/split-fuse.cc
+++ b/test/subgraph/split-fuse.cc
@@ -212,6 +212,28 @@ TEST(SplitDim, large_axis_rejected) {
 }
 #endif  // XNNPACK_USE_YNNPACK
 
+// A split axis at or beyond the input rank has no dimension to split. Before
+// it was rejected the reshape read input_shape->dim[axis] from past the live
+// rank and emitted an output element count that no longer matched the input,
+// which the copy kernel then overran.
+TEST(SplitDims, RejectsAxisOutOfRange) {
+  ASSERT_EQ(xnn_status_success, xnn_initialize(nullptr /* allocator */));
+
+  const std::vector<size_t> input_shape = {4, 4};
+  Tensor<float> input(input_shape, XnnExtraBytes);
+  Tensor<float> output({4, 4});
+
+  SubgraphTester subgraph(2);
+  subgraph.AddInputTensor(input_shape, input.data(), /*external_id=*/0)
+      .AddOutputTensor(output.shape(), output.data(), /*external_id=*/1)
+      .AddSplitDim(/*axis=*/3, /*splits=*/{2, 2}, /*input_id=*/0,
+                   /*output_id=*/1);
+  ASSERT_EQ(xnn_status_success, subgraph.CreateRuntime());
+
+  subgraph.ReshapeExternalTensor(input_shape, input.data(), 0).ReshapeRuntime();
+  EXPECT_EQ(subgraph.Status(), xnn_status_invalid_parameter);
+}
+
 TEST(FuseAndSplitQS8, test) { FuseAndSplit<quantized<int8_t>>(); }
 TEST(FuseAndSplitQU8, test) { FuseAndSplit<quantized<uint8_t>>(); }
 TEST(FuseAndSplitBF16, test) { FuseAndSplit<xnn_bfloat16>(); }


### PR DESCRIPTION
Tracing the static reshape helpers in copy.c, split_dims is the one that never checks its split axis against the live input rank:

    split_dims, rank-2 input {4,4}, axis=3:
      input elements = 16
      output buffer  = 0   (axis past the rank pulls a stale dim into the count)
      copy writes 16 elements into a 0-element buffer -> out-of-bounds write

axis comes from the node and is only bounded against XNN_MAX_TENSOR_DIMS at define time, never against the input tensor. The runtime rank can be smaller, or change later through xnn_reshape_external_value. With axis at or past the rank, resize_split_dims_output_tensor reads input_shape->dim[axis] from beyond the live rank and emits an output element count that no longer matches the input. reshape_copy_operator then copies xnn_shape_multiply_all_dims(input) elements into that undersized output.

fuse_dims already rejects this (input_shape->num_dims < first_dim + num_dims), and even-split and concatenate both reject an axis past the rank. split_dims was the gap, so it gets the same guard. Added a regression test that fails on the old tree and passes with the check.