### PR TITLE
validate index tensor shape in unpooling reshape

### DIFF
--- a/src/subgraph/unpooling-2d.c
+++ b/src/subgraph/unpooling-2d.c
@@ -67,8 +67,24 @@ static enum xnn_status reshape_unpooling_operator(
   const size_t old_workspace_size = opdata->workspace_size;
   size_t output_height, output_width;
 
-  (void)index_id;
-  assert(channel_dim == values[index_id].shape.dim[3]);
+  // The compute kernel walks the index input with strides taken from the value
+  // shape (one index per value element), so the index input must carry the same
+  // shape as the value input. This was only an assert, which is compiled out
+  // under NDEBUG and left an out-of-bounds read of the index buffer when a
+  // smaller index tensor was supplied at runtime.
+  const struct xnn_runtime_value* index_value = values + index_id;
+  if (index_value->shape.num_dims != 4 ||
+      index_value->shape.dim[0] != batch_size ||
+      index_value->shape.dim[1] != input_height ||
+      index_value->shape.dim[2] != input_width ||
+      index_value->shape.dim[3] != channel_dim) {
+    xnn_log_error(
+      "failed to reshape %s operator with index ID #%" PRIu32
+      ": index shape must match the value shape [%zu, %zu, %zu, %zu]",
+      xnn_node_type_to_string(xnn_node_type_unpooling_2d), index_id,
+      batch_size, input_height, input_width, channel_dim);
+    return xnn_status_invalid_parameter;
+  }
 
   status = xnn_reshape_unpooling2d_nhwc_x32(
     opdata->operator_objects[0],

--- a/test/subgraph/unpooling-2d.cc
+++ b/test/subgraph/unpooling-2d.cc
@@ -124,4 +124,32 @@ void TestImpl() {
 
 TEST(Unpooling2DF32, test) { TestImpl<float>(); }
 
+#ifndef XNNPACK_USE_YNNPACK
+TEST(Unpooling2D, reshape_rejects_index_shape_mismatch) {
+  ASSERT_EQ(xnn_status_success, xnn_initialize(nullptr /* allocator */));
+
+  SubgraphTester subgraph(3);
+  subgraph.AddInputTensor(4, xnn_datatype_fp32, 0)
+      .AddInputTensor(4, xnn_datatype_int32, 1)
+      .AddOutputTensor(4, xnn_datatype_fp32, 2)
+      .AddUnpooling2D(0, 0, 0, 0, 2, 2, 0, 1, 2);
+  if (subgraph.CreateRuntime() == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+
+  // The index input is consumed with strides taken from the value shape, so an
+  // index tensor smaller than the value tensor reads past the end of the index
+  // buffer. The reshape must reject the mismatch rather than carry it through.
+  const std::vector<size_t> value_shape = {1, 4, 4, 8};
+  const std::vector<size_t> index_shape = {1, 2, 2, 8};
+  Tensor<float> value(value_shape, XnnExtraBytes);
+  Tensor<int32_t> index(index_shape, XnnExtraBytes);
+
+  subgraph.ReshapeExternalTensor(value_shape, value.base(), 0)
+      .ReshapeExternalTensor(index_shape, index.base(), 1)
+      .ReshapeRuntime();
+  EXPECT_EQ(subgraph.Status(), xnn_status_invalid_parameter);
+}
+#endif  // XNNPACK_USE_YNNPACK
+
 }  // namespace xnnpack


### PR DESCRIPTION
1. reshape_unpooling_operator takes batch, height, width and channels from the value input (inputs[0]); reading the two-input path, the index input (inputs[1]) is tied to it only by an assert comparing the channel dim.
2. that assert is compiled out under NDEBUG, so the index shape is never checked at runtime.
3. setup builds the index strides from the value shape (index_height_stride = input_width * channels) and xnn_compute_unpooling walks batch*height*width*channels uint32s of the index buffer, ignoring the index tensor's own size.

A smaller index input than the value input then reads past the end of the index buffer. The reshape now rejects an index shape that does not match the value shape.