### PR TITLE
validate input_id before values lookup in global pooling define

### DIFF
--- a/src/subgraph/deprecated.c
+++ b/src/subgraph/deprecated.c
@@ -106,6 +106,12 @@ enum xnn_status xnn_define_global_average_pooling_1d(
   uint32_t output_id,
   uint32_t flags)
 {
+  if (input_id >= subgraph->num_values) {
+    xnn_log_error(
+      "failed to define %s operator with input ID #%" PRIu32 ": invalid Value ID",
+      xnn_node_type_to_string(xnn_node_type_global_average_pooling_1d), input_id);
+    return xnn_status_invalid_parameter;
+  }
   const struct xnn_value* input_value = &subgraph->values[input_id];
 
   size_t reduction_axes[XNN_MAX_TENSOR_DIMS];
@@ -136,6 +142,12 @@ enum xnn_status xnn_define_global_average_pooling_2d(
   uint32_t output_id,
   uint32_t flags)
 {
+  if (input_id >= subgraph->num_values) {
+    xnn_log_error(
+      "failed to define %s operator with input ID #%" PRIu32 ": invalid Value ID",
+      xnn_node_type_to_string(xnn_node_type_global_average_pooling_2d), input_id);
+    return xnn_status_invalid_parameter;
+  }
   const struct xnn_value* input_value = &subgraph->values[input_id];
 
   size_t reduction_axes[XNN_MAX_TENSOR_DIMS];
@@ -167,6 +179,12 @@ enum xnn_status xnn_define_global_sum_pooling_1d(
   uint32_t output_id,
   uint32_t flags)
 {
+  if (input_id >= subgraph->num_values) {
+    xnn_log_error(
+      "failed to define %s operator with input ID #%" PRIu32 ": invalid Value ID",
+      xnn_node_type_to_string(xnn_node_type_global_sum_pooling_1d), input_id);
+    return xnn_status_invalid_parameter;
+  }
   const struct xnn_value* input_value = &subgraph->values[input_id];
   size_t reduction_axes[XNN_MAX_TENSOR_DIMS];
   reduction_axes[0] = input_value->shape.num_dims - 2;
@@ -195,6 +213,12 @@ enum xnn_status xnn_define_global_sum_pooling_2d(
   uint32_t output_id,
   uint32_t flags)
 {
+  if (input_id >= subgraph->num_values) {
+    xnn_log_error(
+      "failed to define %s operator with input ID #%" PRIu32 ": invalid Value ID",
+      xnn_node_type_to_string(xnn_node_type_global_sum_pooling_2d), input_id);
+    return xnn_status_invalid_parameter;
+  }
   const struct xnn_value* input_value = &subgraph->values[input_id];
   size_t reduction_axes[XNN_MAX_TENSOR_DIMS];
   reduction_axes[0] = input_value->shape.num_dims - 3;


### PR DESCRIPTION
The four global pooling define helpers in `deprecated.c` read the input shape before they check the value ID:

    enum xnn_status xnn_define_global_average_pooling_2d(...) {
      const struct xnn_value* input_value = &subgraph->values[input_id];
      reduction_axes[0] = input_value->shape.num_dims - 3;

`subgraph->values` is allocated with `subgraph->num_values` entries. `input_id` comes straight from the caller and is unbounded, so an out-of-range id reads past that array. With a large id the offset is well outside the allocation.

Noticed it whilst comparing these helpers against `xnn_define_static_constant_pad` in the same file, which already guards `input_id >= subgraph->num_values` before touching the value.

`xnn_define_static_reduce` (which these delegate to) does validate the id, but only after the wrapper has already dereferenced it, so the read still happens first. Same guard added to all four helpers (average/sum, 1d/2d), matching the constant-pad check.