### PR TITLE
ci: add cmake-windows-arm64-native job using windows-11-arm runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -189,6 +189,27 @@ jobs:
         run: ccache -s
         shell: bash
 
+  cmake-windows-arm64-native:
+    runs-on: windows-11-arm
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup build environment
+        shell: bash
+        run: |
+          echo "VCVARSALL=$(vswhere -products \* -latest -property installationPath)\\VC\\Auxiliary\\Build\\vcvarsall.bat" >> $GITHUB_ENV
+      - name: Configure and build
+        run: scripts/build-windows-arm64-native.cmd
+        shell: cmd
+        working-directory: ${{ github.workspace }}
+        env:
+          CFLAGS: "/UNDEBUG"
+          CXXFLAGS: "/UNDEBUG"
+      - name: Run tests
+        if: ${{ inputs.run-tests }}
+        run: ctest -C Release --output-on-failure --parallel $NUMBER_OF_PROCESSORS
+        working-directory: ${{ github.workspace }}/build/windows/arm64
+
   cmake-windows-x64:
     runs-on: windows-2022-8core
     timeout-minutes: 60

--- a/scripts/build-windows-arm64-native.cmd
+++ b/scripts/build-windows-arm64-native.cmd
@@ -1,0 +1,29 @@
+mkdir build\windows
+mkdir build\windows\arm64
+
+rem Native ARM64 host build (e.g. GHA windows-11-arm runner, or a Snapdragon
+rem X dev box). Uses the arm64 native cl.exe rather than the x64 -> arm64
+rem cross used by scripts\build-windows-arm64.cmd. No CMAKE_TOOLCHAIN_FILE
+rem is needed because we are not cross-compiling, which also lets ctest run
+rem the produced binaries directly.
+echo VCVARSALL: %VCVARSALL%
+call "%VCVARSALL%" arm64
+
+rem Set up the CMake arguments. Same minimal feature set as
+rem scripts\build-windows-arm64.cmd so the two cl.exe baselines stay
+rem comparable; clang-cl + ASM + FP16 lives in a separate script.
+set CMAKE_ARGS=-DXNNPACK_LIBRARY_TYPE=static -G="Ninja" -DCMAKE_BUILD_TYPE=Release
+set CMAKE_ARGS=%CMAKE_ARGS% -DXNNPACK_ENABLE_ASSEMBLY=OFF -DXNNPACK_ENABLE_ARM_FP16_SCALAR=OFF -DXNNPACK_ENABLE_ARM_BF16=OFF
+rem set CMAKE_ARGS=%CMAKE_ARGS% -DCMAKE_VERBOSE_MAKEFILE=ON
+
+rem User-specified CMake arguments go last to allow overriding defaults.
+set CMAKE_ARGS=%CMAKE_ARGS% %*
+
+echo CMAKE_ARGS: %CMAKE_ARGS%
+
+rem Configure the build.
+cd build\windows\arm64
+cmake ..\..\.. %CMAKE_ARGS%
+
+rem Run the build.
+cmake --build . --config Release -- -j %NUMBER_OF_PROCESSORS%


### PR DESCRIPTION
Add a native arm64-on-arm64 CI job and the matching build script.

The existing cmake-windows-arm64 job runs an x64 -> arm64 cross from windows-2022-8core and therefore cannot exercise ctest on the produced binaries. The new cmake-windows-arm64-native job runs on the windows-11-arm runner (publicly available since April 2025) with the native arm64 v143 toolset that ships in the image, and runs ctest when the caller workflow sets inputs.run-tests.

Changes:

  * scripts/build-windows-arm64-native.cmd (new): mirrors the cl.exe feature set of scripts/build-windows-arm64.cmd, but does not pass a CMAKE_TOOLCHAIN_FILE so CMAKE_CROSSCOMPILING stays FALSE and ctest can launch the binaries.
  * .github/workflows/build.yml: new cmake-windows-arm64-native job inserted next to the existing cmake-windows-arm64 cross job. Same style as cmake-windows-x64 (vswhere + vcvarsall + ninja + ctest).

The new job is additive; the existing cross job is unchanged so users building on x64 hosts keep working.

Tested locally on Snapdragon X Plus (X1P-64-100, Surface Laptop 7) by running scripts/build-windows-arm64-native.cmd in a fresh repo clone under VS 2022 17.14 Developer Prompt. Build completes; ctest run launches without CMAKE_CROSSCOMPILING errors.