### PR TITLE
reject overflowing axis in fuse_dims and split_dim define

### DIFF
--- a/src/subgraph/copy.c
+++ b/src/subgraph/copy.c
@@ -562,7 +562,8 @@ enum xnn_status xnn_define_static_expand_dims(
 enum xnn_status xnn_define_fuse_dims(
     xnn_subgraph_t subgraph, size_t axis, size_t axes_count,
     uint32_t input_id, uint32_t output_id, uint32_t flags) {
-  if (axis + axes_count > XNN_MAX_TENSOR_DIMS) {
+  if (axis > XNN_MAX_TENSOR_DIMS || axes_count > XNN_MAX_TENSOR_DIMS ||
+      axis + axes_count > XNN_MAX_TENSOR_DIMS) {
     xnn_log_error(
         "failed to define %s operator with %zu-dimensional input shape: at "
         "most %zu dimensions are supported",
@@ -585,7 +586,8 @@ enum xnn_status xnn_define_split_dim(xnn_subgraph_t subgraph,
                                              uint32_t input_id,
                                              uint32_t output_id,
                                              uint32_t flags) {
-  if (axis + num_splits > XNN_MAX_TENSOR_DIMS) {
+  if (axis > XNN_MAX_TENSOR_DIMS || num_splits > XNN_MAX_TENSOR_DIMS ||
+      axis + num_splits > XNN_MAX_TENSOR_DIMS) {
     xnn_log_error(
         "failed to define %s operator with %zu-dimensional output shape: at "
         "most %zu dimensions are supported",

--- a/test/subgraph/split-fuse.cc
+++ b/test/subgraph/split-fuse.cc
@@ -154,6 +154,62 @@ void FuseAndSplit() {
   }
 }
 
+// A large fuse/split axis makes `axis + count` wrap past SIZE_MAX, so the
+// `> XNN_MAX_TENSOR_DIMS` range check used to pass. For fuse_dims the oversized
+// count then writes past the end of a XNN_MAX_TENSOR_DIMS stack array, and the
+// wrapped axis is stored as the fuse start dimension. The define must reject it.
+TEST(FuseDims, large_axis_rejected) {
+  ASSERT_EQ(xnn_status_success, xnn_initialize(nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(2, 0, &subgraph));
+
+  const size_t dims[] = {2, 3};
+  uint32_t input_id = XNN_INVALID_VALUE_ID;
+  ASSERT_EQ(xnn_status_success,
+            xnn_define_tensor_value(subgraph, xnn_datatype_fp32, 2, dims,
+                                    nullptr, 0, XNN_VALUE_FLAG_EXTERNAL_INPUT,
+                                    &input_id));
+  uint32_t output_id = XNN_INVALID_VALUE_ID;
+  ASSERT_EQ(xnn_status_success,
+            xnn_define_tensor_value(subgraph, xnn_datatype_fp32, 2, dims,
+                                    nullptr, 1, XNN_VALUE_FLAG_EXTERNAL_OUTPUT,
+                                    &output_id));
+
+  EXPECT_NE(xnn_status_success,
+            xnn_define_fuse_dims(subgraph, /*first_dim=*/SIZE_MAX,
+                                 /*num_dims=*/2, input_id, output_id,
+                                 /*flags=*/0));
+
+  xnn_delete_subgraph(subgraph);
+}
+
+TEST(SplitDim, large_axis_rejected) {
+  ASSERT_EQ(xnn_status_success, xnn_initialize(nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(2, 0, &subgraph));
+
+  const size_t dims[] = {2, 3};
+  uint32_t input_id = XNN_INVALID_VALUE_ID;
+  ASSERT_EQ(xnn_status_success,
+            xnn_define_tensor_value(subgraph, xnn_datatype_fp32, 2, dims,
+                                    nullptr, 0, XNN_VALUE_FLAG_EXTERNAL_INPUT,
+                                    &input_id));
+  uint32_t output_id = XNN_INVALID_VALUE_ID;
+  ASSERT_EQ(xnn_status_success,
+            xnn_define_tensor_value(subgraph, xnn_datatype_fp32, 2, dims,
+                                    nullptr, 1, XNN_VALUE_FLAG_EXTERNAL_OUTPUT,
+                                    &output_id));
+
+  const size_t splits[] = {2, 3};
+  EXPECT_NE(xnn_status_success,
+            xnn_define_split_dim(subgraph, /*axis=*/SIZE_MAX, /*num_splits=*/2,
+                                 splits, input_id, output_id, /*flags=*/0));
+
+  xnn_delete_subgraph(subgraph);
+}
+
 TEST(FuseAndSplitQS8, test) { FuseAndSplit<quantized<int8_t>>(); }
 TEST(FuseAndSplitQU8, test) { FuseAndSplit<quantized<uint8_t>>(); }
 TEST(FuseAndSplitBF16, test) { FuseAndSplit<xnn_bfloat16>(); }


### PR DESCRIPTION
AddressSanitizer, defining a fuse_dims node with a large axis:

    ERROR: AddressSanitizer: stack-buffer-overflow
    WRITE of size 8 ... in xnn_define_fuse_dims copy.c:575
      'dims' (line 573) <== Memory access overflows this variable

xnn_define_fuse_dims and xnn_define_split_dim bound the dimensions with `axis + axes_count > XNN_MAX_TENSOR_DIMS`. axis comes from the caller as a size_t, so a large value wraps the sum back under the limit and the check passes. fuse_dims then fills the local `size_t dims[XNN_MAX_TENSOR_DIMS]` for axes_count entries and walks off the stack array. The wrapped axis is also stored as the fuse start dimension, where it later slips past the `num_dims < first_dim + num_dims` guard in resize_fuse_dims_output_tensor.

Spotted while fuzzing the define entry points with boundary values. axis = SIZE_MAX with num_dims = 2 is accepted today; pushing the count past the limit walks straight off dims[].

Check each operand against XNN_MAX_TENSOR_DIMS before the addition so it cannot wrap. Added a subgraph regression test for both define functions.