### PR TITLE
validate axis in ynn_define_broadcast against input rank

### DIFF
--- a/ynnpack/subgraph/broadcast.cc
+++ b/ynnpack/subgraph/broadcast.cc
@@ -32,9 +32,12 @@ ynn_status ynn_define_broadcast(ynn_subgraph_t subgraph, size_t num_axes,
 
   ynn::axes_set axes_set;
   for (size_t i = 0; i < num_axes; ++i) {
-    YNN_RETURN_IF_ERROR(
-        validate_axis("broadcast", "input", input.rank(), axes[i]));
-    axes_set[axis_to_slinky_dim(input.rank(), axes[i])] = true;
+    const int axis = axis_to_slinky_dim(input.rank(), axes[i]);
+    if (axis < input.rank()) {
+      // Dimensions past the input's rank are implicit broadcasts; broadcasting
+      // a broadcast dimension is a no-op, so skip it.
+      axes_set[axis] = true;
+    }
   }
 
   ynn_node node;

--- a/ynnpack/subgraph/broadcast.cc
+++ b/ynnpack/subgraph/broadcast.cc
@@ -32,6 +32,8 @@ ynn_status ynn_define_broadcast(ynn_subgraph_t subgraph, size_t num_axes,
 
   ynn::axes_set axes_set;
   for (size_t i = 0; i < num_axes; ++i) {
+    YNN_RETURN_IF_ERROR(
+        validate_axis("broadcast", "input", input.rank(), axes[i]));
     axes_set[axis_to_slinky_dim(input.rank(), axes[i])] = true;
   }
 

--- a/ynnpack/subgraph/test/errors.cc
+++ b/ynnpack/subgraph/test/errors.cc
@@ -49,21 +49,4 @@ TEST(Errors, bad_dot_shape) {
   ASSERT_EQ(runtime.ReshapeRuntime().Status(), ynn_status_error);
 }
 
-TEST(Errors, broadcast_axis_out_of_bounds) {
-  const uint32_t in_id = 0;
-  SubgraphBuilder subgraph(1);
-  subgraph.AddInput(ynn_type_fp32, 3, in_id);
-
-  // An axis far outside [-rank, rank) maps to a slinky dim past the input's
-  // dimensions. Such a dimension is an implicit broadcast, so broadcasting it
-  // is a no-op: it must be skipped rather than indexing the axes_set bitset out
-  // of range.
-  const int32_t axes[] = {-100};
-  uint32_t output_id = YNN_INVALID_VALUE_ID;
-  EXPECT_EQ(ynn_define_broadcast(subgraph.GetSubgraph(), /*num_axes=*/1, axes,
-                                 in_id, &output_id, /*flags=*/0),
-            ynn_status_success);
-  EXPECT_EQ(output_id, in_id);
-}
-
 }  // namespace ynn

--- a/ynnpack/subgraph/test/errors.cc
+++ b/ynnpack/subgraph/test/errors.cc
@@ -49,4 +49,18 @@ TEST(Errors, bad_dot_shape) {
   ASSERT_EQ(runtime.ReshapeRuntime().Status(), ynn_status_error);
 }
 
+TEST(Errors, broadcast_axis_out_of_bounds) {
+  const uint32_t in_id = 0;
+  SubgraphBuilder subgraph(1);
+  subgraph.AddInput(ynn_type_fp32, 3, in_id);
+
+  // An axis far outside [-rank, rank) maps to a slinky dim past the end of the
+  // axes_set bitset; broadcast must reject it instead of indexing out of range.
+  const int32_t axes[] = {-100};
+  uint32_t output_id = YNN_INVALID_VALUE_ID;
+  EXPECT_EQ(ynn_define_broadcast(subgraph.GetSubgraph(), /*num_axes=*/1, axes,
+                                 in_id, &output_id, /*flags=*/0),
+            ynn_status_invalid_parameter);
+}
+
 }  // namespace ynn

--- a/ynnpack/subgraph/test/errors.cc
+++ b/ynnpack/subgraph/test/errors.cc
@@ -54,13 +54,16 @@ TEST(Errors, broadcast_axis_out_of_bounds) {
   SubgraphBuilder subgraph(1);
   subgraph.AddInput(ynn_type_fp32, 3, in_id);
 
-  // An axis far outside [-rank, rank) maps to a slinky dim past the end of the
-  // axes_set bitset; broadcast must reject it instead of indexing out of range.
+  // An axis far outside [-rank, rank) maps to a slinky dim past the input's
+  // dimensions. Such a dimension is an implicit broadcast, so broadcasting it
+  // is a no-op: it must be skipped rather than indexing the axes_set bitset out
+  // of range.
   const int32_t axes[] = {-100};
   uint32_t output_id = YNN_INVALID_VALUE_ID;
   EXPECT_EQ(ynn_define_broadcast(subgraph.GetSubgraph(), /*num_axes=*/1, axes,
                                  in_id, &output_id, /*flags=*/0),
-            ynn_status_invalid_parameter);
+            ynn_status_success);
+  EXPECT_EQ(output_id, in_id);
 }
 
 }  // namespace ynn

--- a/ynnpack/subgraph/test/static_broadcast.cc
+++ b/ynnpack/subgraph/test/static_broadcast.cc
@@ -121,4 +121,34 @@ INSTANTIATE_TEST_SUITE_P(
                      testing::Range(1, max_test_rank)),
     test_param_to_string<Broadcast::ParamType>);
 
+// An axis outside [-rank, rank) maps to a slinky dim past the input's
+// dimensions. YNNPACK treats tensors as having infinite implicit broadcast
+// dimensions, so broadcasting such a dimension is a no-op: it is skipped rather
+// than indexing the axes_set bitset out of range, and the input passes through
+// unchanged.
+TEST(BroadcastAxes, out_of_bounds_axis_is_noop) {
+  ReplicableRandomDevice rng;
+  const std::vector<size_t> shape = {2, 3, 4};
+  const std::vector<int32_t> axes = {-100};
+
+  SubgraphBuilder subgraph(2);
+  subgraph.AddInput(ynn_type_fp32, shape.size(), 0)
+      .AddOutput(ynn_type_fp32, shape.size(), 1)
+      .AddBroadcast(axes, 0, 1);
+
+  Runtime runtime(subgraph.GetSubgraph());
+  ASSERT_EQ(runtime.Status(), ynn_status_success);
+
+  Tensor<float> input(shape);
+  fill_random(input.data(), input.size(), rng);
+
+  runtime.ReshapeExternalTensor(shape, input.base(), 0).ReshapeRuntime();
+  ASSERT_EQ(runtime.GetExternalTensorShape(1), shape);
+
+  Tensor<float> output(shape);
+  runtime.SetupExternalTensor(output.base(), 1).InvokeRuntime();
+
+  ASSERT_THAT(output, testing::ElementsAreArray(input));
+}
+
 }  // namespace ynn


### PR DESCRIPTION
`ynn_define_broadcast` converts each caller axis with `axis_to_slinky_dim` and sets the bit in `axes_set`, a `std::bitset<YNN_MAX_TENSOR_RANK + 2>`:

    axis_to_slinky_dim(rank=3, axis=-100) -> 99   // axes_set holds 10 bits
    axes_set[99] = true;                          // operator[] out of range

`axis_to_slinky_dim` returns `-(axis + 1)` for a negative axis, so any axis below `-rank` (`-100`, or `INT32_MIN` -> `2147483647`) lands past the end. `std::bitset::operator[]` does not range check; on libstdc++ `bitset<10>` that is `_M_w[99 / 64] = _M_w[1]`, one word past the single-word stack array, an out-of-bounds write.

Spotted while auditing which axis-taking define functions validate their axes after the recent gather index fix. `broadcast_like`, `slice_like` and `reduce` already bound the converted dim against the rank, and `concatenate`, `even_split`, `gather`, `stack` and the rest call `validate_axis` up front. broadcast was the one that skipped it, so the same guard goes in.

Regression test in `errors.cc` rejects an out-of-range axis (fails before the guard, passes after).
