### PR TITLE
fix operator leak on alloc failure in create_deconvolution2d_nhwc

### DIFF
--- a/src/operators/deconvolution-nhwc.c
+++ b/src/operators/deconvolution-nhwc.c
@@ -269,7 +269,7 @@ static XNN_NO_SANITIZE_FUNCTION enum xnn_status create_deconvolution2d_nhwc(
     xnn_log_error("failed to allocate %zu bytes for %s operator descriptor",
                   sizeof(struct xnn_convolution_operator),
                   xnn_operator_type_to_string(operator_type));
-    return xnn_status_out_of_memory;
+    goto error;
   }
 
   deconvolution_op->weights_cache = weights_cache;


### PR DESCRIPTION
Walked the create_* allocation-failure paths in src/operators with LSAN in mind. create_deconvolution2d_nhwc sets up the cleanup label and routes its allocation-failure paths through it, except one.

    deconvolution-nhwc.c:266
      deconvolution_op->convolution_op = xnn_allocate_zero_memory(...);
      if (deconvolution_op->convolution_op == NULL) {
        ...
        return xnn_status_out_of_memory;   // walks past the error: label
      }

By this point deconvolution_op, deconvolution_op->compute and deconvolution_op->ukernel.igemm are already allocated. The bare return skips xnn_delete_operator at the error: label, so all three leak when convolution_op cannot be allocated. Every other check in the same function (compute, igemm, subconvolution_buffer, weights) reaches the label via goto error.

status is already xnn_status_out_of_memory at that line, so goto error returns the same code and releases the partial operator.