### PR TITLE
free partial operator on alloc failure in create paths

### DIFF
--- a/src/operators/binary-elementwise-nd.c
+++ b/src/operators/binary-elementwise-nd.c
@@ -247,6 +247,7 @@ enum xnn_status xnn_create_binary_elementwise_nd(
     xnn_log_error("failed to allocate %zu bytes for %s operator descriptor",
                   sizeof(struct compute_parameters),
                   xnn_binary_operator_to_string(type));
+    xnn_delete_operator(op);
     return xnn_status_out_of_memory;
   }
   op->num_compute_invocations = 1;

--- a/src/operators/pack-lh.c
+++ b/src/operators/pack-lh.c
@@ -52,6 +52,7 @@ enum xnn_status create_pack_lh(uint32_t flags,
     xnn_log_error("failed to allocate %zu bytes for %s operator descriptor",
                   sizeof(struct compute_parameters),
                   xnn_operator_type_to_string(expected_operator_type));
+    xnn_delete_operator(pack_lh_op);
     return xnn_status_out_of_memory;
   }
   pack_lh_op->num_compute_invocations = 1;

--- a/src/operators/resize-bilinear-nhwc.c
+++ b/src/operators/resize-bilinear-nhwc.c
@@ -90,6 +90,7 @@ enum xnn_status xnn_create_resize_bilinear2d_nhwc(
     xnn_log_error("failed to allocate %zu bytes for %s operator descriptor",
                   sizeof(struct compute_parameters),
                   xnn_operator_type_to_string(xnn_operator_type_resize_bilinear_nhwc));
+    xnn_delete_operator(resize_op);
     return xnn_status_out_of_memory;
   }
   resize_op->num_compute_invocations = num_compute_invocations;
@@ -98,6 +99,7 @@ enum xnn_status xnn_create_resize_bilinear2d_nhwc(
     xnn_log_error("failed to allocate %zu bytes for %s operator descriptor",
                   sizeof(struct xnn_convolution_operator),
                   xnn_operator_type_to_string(xnn_operator_type_resize_bilinear_nhwc));
+    xnn_delete_operator(resize_op);
     return xnn_status_out_of_memory;
   }
 

--- a/src/operators/unary-elementwise-nc.c
+++ b/src/operators/unary-elementwise-nc.c
@@ -348,6 +348,7 @@ enum xnn_status xnn_create_unary_elementwise_nc(
     xnn_log_error("failed to allocate %zu bytes for %s operator descriptor",
                   sizeof(struct compute_parameters),
                   xnn_unary_operator_to_string(op_type));
+    xnn_delete_operator(op);
     return xnn_status_out_of_memory;
   }
   op->num_compute_invocations = num_compute_invocations;
@@ -637,6 +638,7 @@ static enum xnn_status create_unary_elementwise_nc(
     xnn_log_error("failed to allocate %zu bytes for %s operator descriptor",
                   sizeof(struct compute_parameters),
                   xnn_operator_type_to_string(operator_type));
+    xnn_delete_operator(unary_elementwise_op);
     return xnn_status_out_of_memory;
   }
   unary_elementwise_op->num_compute_invocations = num_compute_invocations;


### PR DESCRIPTION
spotted while tracing the create error paths against xnn_delete_operator: in xnn_create_resize_bilinear2d_nhwc, xnn_create_unary_elementwise_nc, create_unary_elementwise_nc, xnn_create_binary_elementwise_nd and create_pack_lh the operator struct is allocated first and then a sub-buffer (compute, and resize_op->convolution_op), but a failed sub-buffer allocation returns out-of-memory directly and leaks the partial operator, whereas the sibling creates (softmax-nc, fully-connected-nc, batch-matrix-multiply-nc, reduce-nd, slice-nd, transpose-nd, the pooling ops) all release it via goto error; this releases it with xnn_delete_operator before the same return.