### PR TITLE
Fix benchmark minmax parameter order

### DIFF
--- a/bench/f16-conv-hwc2chw.cc
+++ b/bench/f16-conv-hwc2chw.cc
@@ -87,7 +87,8 @@ static void f16_conv_hwc2chw(
   xnnpack::Buffer<xnn_float16> output(output_elements * num_buffers);
 
   xnn_f16_minmax_params params;
-  init_params(&params, 0x7C00 /* inf */, 0xFC00 /* -inf */);
+  init_params(&params, static_cast<xnn_float16>(-INFINITY),
+              static_cast<xnn_float16>(INFINITY));
 
   size_t buffer_index = 0;
   for (auto _ : state) {

--- a/bench/f16-f32acc-igemm.cc
+++ b/bench/f16-f32acc-igemm.cc
@@ -119,9 +119,8 @@ static void f16_igemm(benchmark::State& state,
 
   // Prepare minmax parameters.
   xnn_f16_minmax_params params;
-  // TODO: min = INFINITY, max = -INFINITY?!
-  init_params(&params, static_cast<xnn_float16>(INFINITY),
-              static_cast<xnn_float16>(-INFINITY));
+  init_params(&params, static_cast<xnn_float16>(-INFINITY),
+              static_cast<xnn_float16>(INFINITY));
 
   size_t buffer_index = 0;
   for (auto _ : state) {


### PR DESCRIPTION
## Summary
- Fix reversed no-clamp min/max parameters in the f16-f32acc IGEMM benchmark.
- Fix the same reversed half-precision min/max constants in the f16 HWC-to-CHW convolution benchmark.
- Add a lightweight CMake source check for obvious reversed `init_params` min/max argument pairs.

## Testing
- `python3 tools/check-minmax-init-params.py`
- `ctest --test-dir build/minmax-check -R ^minmax-init-params-test$ --output-on-failure`
- `cmake --build build/minmax-check --target f16-f32acc-igemm-bench f16-conv-hwc2chw-bench --parallel 8`