### PR TITLE
reject input rank mismatch in transpose reshape

### DIFF
--- a/src/subgraph/static-transpose.c
+++ b/src/subgraph/static-transpose.c
@@ -74,7 +74,15 @@ static enum xnn_status reshape_transpose_operator(
   assert(output_id < num_values);
 
   const size_t num_dims = opdata->shape1.num_dims;
-  assert(input->shape.num_dims == num_dims);
+  if (input->shape.num_dims != num_dims) {
+    xnn_log_error(
+      "failed to reshape %s operator with input ID #%" PRIu32
+      ": number of input dimensions (%zu) does not match the number of "
+      "permutation dimensions (%zu)",
+      xnn_node_type_to_string(xnn_node_type_static_transpose), input_id,
+      input->shape.num_dims, num_dims);
+    return xnn_status_invalid_parameter;
+  }
 
   switch (opdata->operator_objects[0]->type) {
     case xnn_operator_type_transpose_nd_x16: {

--- a/test/subgraph/static-transpose.cc
+++ b/test/subgraph/static-transpose.cc
@@ -85,4 +85,26 @@ INSTANTIATE_TEST_SUITE_P(Transpose, TransposeQU8, rank_params);
 INSTANTIATE_TEST_SUITE_P(Transpose, TransposeF16, rank_params);
 INSTANTIATE_TEST_SUITE_P(Transpose, TransposeF32, rank_params);
 
+TEST(Transpose, reshape_rejects_input_rank_mismatch) {
+  ASSERT_EQ(xnn_status_success, xnn_initialize(nullptr /* allocator */));
+
+  // The permutation fixes the operator rank at define time. An external input
+  // may be reshaped to a different rank at runtime; the reshape must reject the
+  // mismatch instead of transposing with a stale dimension count and reading
+  // past the input buffer.
+  const std::vector<size_t> perm = {2, 0, 1};
+  SubgraphTester subgraph(2);
+  subgraph.AddInputTensor(3, xnn_datatype_fp32, 0)
+      .AddOutputTensor(3, xnn_datatype_fp32, 1)
+      .AddTranspose(perm, 0, 1);
+  if (subgraph.CreateRuntime() == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+
+  std::vector<float> data(6, 0.0f);
+  subgraph.ReshapeExternalTensor(std::vector<size_t>({2, 3}), data.data(), 0)
+      .ReshapeRuntime();
+  EXPECT_EQ(subgraph.Status(), xnn_status_invalid_parameter);
+}
+
 }  // namespace xnnpack

--- a/test/subgraph/static-transpose.cc
+++ b/test/subgraph/static-transpose.cc
@@ -85,6 +85,7 @@ INSTANTIATE_TEST_SUITE_P(Transpose, TransposeQU8, rank_params);
 INSTANTIATE_TEST_SUITE_P(Transpose, TransposeF16, rank_params);
 INSTANTIATE_TEST_SUITE_P(Transpose, TransposeF32, rank_params);
 
+#ifndef XNNPACK_USE_YNNPACK
 TEST(Transpose, reshape_rejects_input_rank_mismatch) {
   ASSERT_EQ(xnn_status_success, xnn_initialize(nullptr /* allocator */));
 
@@ -106,5 +107,9 @@ TEST(Transpose, reshape_rejects_input_rank_mismatch) {
       .ReshapeRuntime();
   EXPECT_EQ(subgraph.Status(), xnn_status_invalid_parameter);
 }
+#else
+// In YNNPACK transpose can add or remove dimensions, so a rank mismatch is not
+// an error.
+#endif  // XNNPACK_USE_YNNPACK
 
 }  // namespace xnnpack


### PR DESCRIPTION
Was poking at transpose with mismatched runtime shapes. A rank-3 transpose fed a rank-2 external input slips straight through reshape instead of being rejected:

    Transpose.reshape_rejects_input_rank_mismatch
    Expected equality of these values:
      subgraph.Status()              Which is: 0   (xnn_status_success)
      xnn_status_invalid_parameter   Which is: 2

reshape_transpose_operator takes its working rank from the permutation length, which is fixed at define time, and only ties it to the live input rank with an assert. xnn_reshape_external_value lets an external input be reshaped to any rank at run time, so under NDEBUG the assert is gone and the mismatched input is accepted. The op then transposes with a stale dimension count: it reads input->shape.dim[perm[i]] for slots past the live rank (stale values left over from the larger declared shape) and ends up walking the input buffer past what it actually holds.

The permutation length and the input rank must agree. Swapped the assert for a real check, same shape as the softmax and fully-connected runtime rank guards. The regression test reshapes a rank-3 transpose input down to rank 2 and expects invalid_parameter.