### PR TITLE
clamp source coordinate in resize-bilinear indirection init

### DIFF
--- a/src/indirection.c
+++ b/src/indirection.c
@@ -496,7 +496,7 @@ void xnn_indirection_init_resize_bilinear2d_hwc_f16(
   const uint32_t input_x_max = (uint32_t) input_width - 1;
   if (tensorflow_legacy || align_corners) {
     for (size_t output_y = output_y_start; output_y < output_y_end; output_y++) {
-      const float input_y = (float) (int32_t) output_y * height_scale;
+      const float input_y = math_min_f32((float) (int32_t) output_y * height_scale, (float) input_y_max);
       assert(input_y >= 0.0f);
       assert(input_y < (float) input_height);
 
@@ -504,7 +504,7 @@ void xnn_indirection_init_resize_bilinear2d_hwc_f16(
       const uint32_t input_y_bottom = math_min_u32(input_y_top + 1, input_y_max);
       const float alpha_y = input_y - (float) input_y_top;
       for (size_t output_x = 0; output_x < output_width; output_x++) {
-        const float input_x = (float) (int32_t) output_x * width_scale;
+        const float input_x = math_min_f32((float) (int32_t) output_x * width_scale, (float) input_x_max);
         assert(input_x >= 0.0f);
         assert(input_x < (float) input_width);
 
@@ -597,7 +597,7 @@ void xnn_indirection_init_resize_bilinear2d_hwc_f32(
 
   if (tensorflow_legacy || align_corners) {
     for (size_t output_y = output_y_start; output_y < output_y_end; output_y++) {
-      const float input_y = (float) (int32_t) output_y * height_scale;
+      const float input_y = math_min_f32((float) (int32_t) output_y * height_scale, (float) input_y_max);
       assert(input_y >= 0.0f);
       assert(input_y < (float) input_height);
 
@@ -605,7 +605,7 @@ void xnn_indirection_init_resize_bilinear2d_hwc_f32(
       const uint32_t input_y_bottom = math_min_u32(input_y_top + 1, input_y_max);
       const float alpha_y = input_y - (float) input_y_top;
       for (size_t output_x = 0; output_x < output_width; output_x++) {
-        const float input_x = (float) (int32_t) output_x * width_scale;
+        const float input_x = math_min_f32((float) (int32_t) output_x * width_scale, (float) input_x_max);
         assert(input_x >= 0.0f);
         assert(input_x < (float) input_width);
 
@@ -698,7 +698,7 @@ void xnn_indirection_init_resize_bilinear2d_hwc_q11(
 
   if (tensorflow_legacy || align_corners) {
     for (size_t output_y = output_y_start; output_y < output_y_end; output_y++) {
-      const float input_y = (float) (int32_t) output_y * height_scale;
+      const float input_y = math_min_f32((float) (int32_t) output_y * height_scale, (float) input_y_max);
       assert(input_y >= 0.0f);
       assert(input_y < (float) input_height);
 
@@ -706,7 +706,7 @@ void xnn_indirection_init_resize_bilinear2d_hwc_q11(
       const uint32_t input_y_bottom = math_min_u32(input_y_top + 1, input_y_max);
       const float alpha_y = input_y - (float) input_y_top;
       for (size_t output_x = 0; output_x < output_width; output_x++) {
-        const float input_x = (float) (int32_t) output_x * width_scale;
+        const float input_x = math_min_f32((float) (int32_t) output_x * width_scale, (float) input_x_max);
         assert(input_x >= 0.0f);
         assert(input_x < (float) input_width);
 
@@ -794,7 +794,7 @@ void xnn_indirection_init_resize_bilinear2d_chw_f16(
   const uint32_t input_x_max = (uint32_t) input_width - 1;
   if (tensorflow_legacy || align_corners) {
     for (size_t output_y = 0; output_y < output_height; output_y++) {
-      const float input_y = (float) (int32_t) output_y * height_scale;
+      const float input_y = math_min_f32((float) (int32_t) output_y * height_scale, (float) input_y_max);
       assert(input_y >= 0.0f);
       assert(input_y < (float) input_height);
 
@@ -802,7 +802,7 @@ void xnn_indirection_init_resize_bilinear2d_chw_f16(
       const uint32_t input_y_bottom = math_min_u32(input_y_top + 1, input_y_max);
       const float alpha_y = input_y - (float) input_y_top;
       for (size_t output_x = 0; output_x < output_width; output_x++) {
-        const float input_x = (float) (int32_t) output_x * width_scale;
+        const float input_x = math_min_f32((float) (int32_t) output_x * width_scale, (float) input_x_max);
         assert(input_x >= 0.0f);
         assert(input_x < (float) input_width);
 
@@ -894,7 +894,7 @@ void xnn_indirection_init_resize_bilinear2d_chw_f32(
   const uint32_t input_x_max = (uint32_t) input_width - 1;
   if (tensorflow_legacy || align_corners) {
     for (size_t output_y = 0; output_y < output_height; output_y++) {
-      const float input_y = (float) (int32_t) output_y * height_scale;
+      const float input_y = math_min_f32((float) (int32_t) output_y * height_scale, (float) input_y_max);
       assert(input_y >= 0.0f);
       assert(input_y < (float) input_height);
 
@@ -902,7 +902,7 @@ void xnn_indirection_init_resize_bilinear2d_chw_f32(
       const uint32_t input_y_bottom = math_min_u32(input_y_top + 1, input_y_max);
       const float alpha_y = input_y - (float) input_y_top;
       for (size_t output_x = 0; output_x < output_width; output_x++) {
-        const float input_x = (float) (int32_t) output_x * width_scale;
+        const float input_x = math_min_f32((float) (int32_t) output_x * width_scale, (float) input_x_max);
         assert(input_x >= 0.0f);
         assert(input_x < (float) input_width);
 

--- a/test/indirection.cc
+++ b/test/indirection.cc
@@ -540,5 +540,59 @@ TEST(INDIRECTION_COMPRESSED, input2x2_kernel2x2_padding2x2_subsampling2) {
       })
       .TestCompressed();
 }
+
+// Under align-corners (or the TensorFlow legacy mode) the resize-bilinear
+// indirection init floors output_coord * scale to a source pixel index. For
+// some accepted large input extents the float product rounds up to exactly
+// input_height/input_width, one past the last valid pixel, so the indirection
+// pointer addresses memory past the end of the input tensor. The init routine
+// only computes pointers, so a null base lets us check the flat pixel index
+// without allocating the (multi-MiB) input.
+TEST(RESIZE_BILINEAR_INDIRECTION, hwc_f32_align_corners_no_oob) {
+  const size_t input_height = 10485768;
+  const size_t input_width = 3;
+  const size_t output_height = 6;
+  const size_t output_width = 3;
+  const size_t input_pixels = input_height * input_width;
+
+  std::vector<const void*> indirection(4 * output_height * output_width,
+                                       nullptr);
+  std::vector<float> packed_weights(2 * output_height * output_width, 0.0f);
+
+  xnn_indirection_init_resize_bilinear2d_hwc_f32(
+      /*output_y_start=*/0, /*output_y_end=*/output_height,
+      /*input_pixel_stride=*/1, input_height, input_width, output_height,
+      output_width, /*input=*/nullptr, indirection.data(),
+      packed_weights.data(), /*align_corners=*/true,
+      /*tensorflow_legacy=*/false);
+
+  for (size_t i = 0; i < indirection.size(); i++) {
+    EXPECT_LT(reinterpret_cast<uintptr_t>(indirection[i]), input_pixels)
+        << "indirection[" << i << "] points past the input buffer";
+  }
+}
+
+TEST(RESIZE_BILINEAR_INDIRECTION, chw_f32_align_corners_no_oob) {
+  const size_t input_height = 10485768;
+  const size_t input_width = 3;
+  const size_t output_height = 6;
+  const size_t output_width = 3;
+  const size_t input_pixels = input_height * input_width;
+
+  std::vector<const void*> indirection(2 * output_height * output_width,
+                                       nullptr);
+  std::vector<float> packed_weights(2 * output_height * output_width, 0.0f);
+
+  xnn_indirection_init_resize_bilinear2d_chw_f32(
+      /*input_pixel_stride=*/1, input_height, input_width, output_height,
+      output_width, /*input=*/nullptr, indirection.data(),
+      packed_weights.data(), /*align_corners=*/true,
+      /*tensorflow_legacy=*/false);
+
+  for (size_t i = 0; i < indirection.size(); i++) {
+    EXPECT_LT(reinterpret_cast<uintptr_t>(indirection[i]), input_pixels)
+        << "indirection[" << i << "] points past the input buffer";
+  }
+}
 }  // namespace
 }  // namespace xnnpack


### PR DESCRIPTION
the align-corners/legacy branch of the resize-bilinear indirection init floors output*scale to a source pixel index without clamping, so for large but accepted input extents (around 2**24) the float product rounds up to input_width/input_height and the indirection pointer lands one pixel past the input buffer, which the ibilinear ukernel then reads; clamp the coordinate to input_*_max in that branch as the half-pixel branch already does, across the hwc f16/f32/q11 and chw f16/f32 variants.