### PR TITLE
Apply XNN_NO_SANITIZE_FUNCTION to remaining type-erased call sites

### DIFF
--- a/src/operator-run.c
+++ b/src/operator-run.c
@@ -103,9 +103,9 @@ XNN_NO_SANITIZE_FUNCTION void xnn_compute_transposec_5d(struct transpose_context
   context->const_size_ukernel(x, y, ld_input, ld_output, tile_l, tile_m);
 }
 
-void xnn_compute_transposec_6d(struct transpose_context* restrict context,
-                               size_t i, size_t j, size_t k, size_t l, size_t m,
-                               size_t n, size_t tile_m, size_t tile_n) {
+XNN_NO_SANITIZE_FUNCTION void xnn_compute_transposec_6d(
+    struct transpose_context* restrict context, size_t i, size_t j, size_t k,
+    size_t l, size_t m, size_t n, size_t tile_m, size_t tile_n) {
   const size_t ld_input = context->input_stride[5];
   const size_t ld_output = context->output_stride[4];
   const void* x =
@@ -124,9 +124,9 @@ void xnn_compute_transposec_6d(struct transpose_context* restrict context,
   context->const_size_ukernel(x, y, ld_input, ld_output, tile_m, tile_n);
 }
 
-void xnn_compute_transposev_2d(struct transpose_context* restrict context,
-                               size_t i, size_t j, size_t tile_i,
-                               size_t tile_j) {
+XNN_NO_SANITIZE_FUNCTION void xnn_compute_transposev_2d(
+    struct transpose_context* restrict context, size_t i, size_t j,
+    size_t tile_i, size_t tile_j) {
   const size_t element_size = context->output_stride[1];
   const size_t ld_input = context->input_stride[1];
   const size_t ld_output = context->output_stride[0];
@@ -141,9 +141,9 @@ void xnn_compute_transposev_2d(struct transpose_context* restrict context,
       context->output_stride[1], element_size, tile_i, tile_j);
 }
 
-void xnn_compute_transposev_3d(struct transpose_context* restrict context,
-                               size_t i, size_t j, size_t k, size_t tile_j,
-                               size_t tile_k) {
+XNN_NO_SANITIZE_FUNCTION void xnn_compute_transposev_3d(
+    struct transpose_context* restrict context, size_t i, size_t j, size_t k,
+    size_t tile_j, size_t tile_k) {
   const size_t element_size = context->output_stride[2];
   const size_t ld_input = context->input_stride[2];
   const size_t ld_output = context->output_stride[1];
@@ -160,9 +160,9 @@ void xnn_compute_transposev_3d(struct transpose_context* restrict context,
       context->output_stride[2], element_size, tile_j, tile_k);
 }
 
-void xnn_compute_transposev_4d(struct transpose_context* restrict context,
-                               size_t i, size_t j, size_t k, size_t l,
-                               size_t tile_k, size_t tile_l) {
+XNN_NO_SANITIZE_FUNCTION void xnn_compute_transposev_4d(
+    struct transpose_context* restrict context, size_t i, size_t j, size_t k,
+    size_t l, size_t tile_k, size_t tile_l) {
   const size_t element_size = context->output_stride[3];
   const size_t ld_input = context->input_stride[3];
   const size_t ld_output = context->output_stride[2];
@@ -181,9 +181,9 @@ void xnn_compute_transposev_4d(struct transpose_context* restrict context,
       context->output_stride[3], element_size, tile_k, tile_l);
 }
 
-void xnn_compute_transposev_5d(struct transpose_context* restrict context,
-                               size_t i, size_t j, size_t k, size_t l, size_t m,
-                               size_t tile_l, size_t tile_m) {
+XNN_NO_SANITIZE_FUNCTION void xnn_compute_transposev_5d(
+    struct transpose_context* restrict context, size_t i, size_t j, size_t k,
+    size_t l, size_t m, size_t tile_l, size_t tile_m) {
   const size_t element_size = context->output_stride[4];
   const size_t ld_input = context->input_stride[4];
   const size_t ld_output = context->output_stride[3];
@@ -203,9 +203,9 @@ void xnn_compute_transposev_5d(struct transpose_context* restrict context,
       context->output_stride[4], element_size, tile_l, tile_m);
 }
 
-void xnn_compute_transposev_6d(struct transpose_context* restrict context,
-                               size_t i, size_t j, size_t k, size_t l, size_t m,
-                               size_t n, size_t tile_m, size_t tile_n) {
+XNN_NO_SANITIZE_FUNCTION void xnn_compute_transposev_6d(
+    struct transpose_context* restrict context, size_t i, size_t j, size_t k,
+    size_t l, size_t m, size_t n, size_t tile_m, size_t tile_n) {
   const size_t element_size = context->output_stride[5];
   const size_t ld_input = context->input_stride[5];
   const size_t ld_output = context->output_stride[4];
@@ -543,7 +543,7 @@ void xnn_compute_grouped_qp8gemm(struct gemm_context* restrict context,
                                   mr_block_size);
 }
 
-XNN_INLINE static void compute_hmp_qp8gemm(
+XNN_INLINE static XNN_NO_SANITIZE_FUNCTION void compute_hmp_qp8gemm(
     struct gemm_context* restrict context, uint32_t uarch_index,
     size_t nr_block_start, size_t mr_block_start, size_t nr_block_size,
     size_t mr_block_size) {
@@ -620,8 +620,9 @@ void xnn_compute_qp8gemm(struct gemm_context* restrict context,
                       mr_block_start, nr_block_size, mr_block_size);
 }
 
-void xnn_compute_spmm(struct spmm_context* restrict context, size_t batch_index,
-                      size_t mr_block_start, size_t mr_block_size) {
+XNN_NO_SANITIZE_FUNCTION void xnn_compute_spmm(
+    struct spmm_context* restrict context, size_t batch_index,
+    size_t mr_block_start, size_t mr_block_size) {
   context->ukernel(
       mr_block_size, context->n,
       (const void*)((uintptr_t)context->input +
@@ -811,11 +812,10 @@ void xnn_compute_inline_packed_igemm(
                                       mr_block_size);
 }
 
-void xnn_compute_hmp_inline_packed_igemm(struct igemm_context* restrict context,
-                                         uint32_t uarch_index, size_t thread_id,
-                                         size_t batch_index, size_t group_index,
-                                         size_t mr_block_start,
-                                         size_t mr_block_size) {
+XNN_NO_SANITIZE_FUNCTION void xnn_compute_hmp_inline_packed_igemm(
+    struct igemm_context* restrict context, uint32_t uarch_index,
+    size_t thread_id, size_t batch_index, size_t group_index,
+    size_t mr_block_start, size_t mr_block_size) {
   const size_t mr = context->mr;
   const size_t mr_packed = context->mr_packed;
   const size_t kc = context->kc;
@@ -956,9 +956,9 @@ XNN_NO_SANITIZE_FUNCTION void xnn_compute_dqsubconv2d(struct subconv_context* re
       &context->quantization_params[batch_index]);
 }
 
-void xnn_compute_conv2d_hwc2chw(struct conv2d_context* restrict context,
-                                size_t batch_index, size_t output_y_start,
-                                size_t output_y_slice) {
+XNN_NO_SANITIZE_FUNCTION void xnn_compute_conv2d_hwc2chw(
+    struct conv2d_context* restrict context, size_t batch_index,
+    size_t output_y_start, size_t output_y_slice) {
   context->hwc2chw_ukernel(
       context->input_height, context->input_width, output_y_start,
       output_y_start + output_y_slice,
@@ -1011,8 +1011,9 @@ XNN_NO_SANITIZE_FUNCTION void xnn_compute_dwconv_unipass(struct dwconv_context* 
                    context->zero, &context->params);
 }
 
-void xnn_compute_dwconv2d_chw(struct dwconv2d_context* restrict context,
-                              size_t batch_index, size_t channel) {
+XNN_NO_SANITIZE_FUNCTION void xnn_compute_dwconv2d_chw(
+    struct dwconv2d_context* restrict context, size_t batch_index,
+    size_t channel) {
   context->chw_ukernel(context->input_height, context->input_width,
                        (const void*)((uintptr_t)context->input +
                                      channel * context->input_channel_stride +
@@ -1145,7 +1146,7 @@ XNN_NO_SANITIZE_FUNCTION void xnn_compute_resize_bilinear(
       output, context->output_pixel_stride - context->scaled_channels);
 }
 
-void xnn_compute_resize_bilinear_chw(
+XNN_NO_SANITIZE_FUNCTION void xnn_compute_resize_bilinear_chw(
     struct resize_bilinear_chw_context* restrict context, size_t batch_index,
     size_t channel_start, size_t channel_range) {
   void* output = (void*)((uintptr_t)context->output +
@@ -1161,8 +1162,9 @@ void xnn_compute_resize_bilinear_chw(
                    context->input_channel_stride);
 }
 
-void xnn_compute_pad_5d(struct pad_context* restrict context, size_t i,
-                        size_t j, size_t k, size_t l, size_t m) {
+XNN_NO_SANITIZE_FUNCTION void xnn_compute_pad_5d(
+    struct pad_context* restrict context, size_t i, size_t j, size_t k,
+    size_t l, size_t m) {
   const void* input =
       (const void*)((uintptr_t)context->input + i * context->input_stride[4] +
                     j * context->input_stride[3] +
@@ -1248,8 +1250,9 @@ XNN_NO_SANITIZE_FUNCTION void xnn_compute_slice_4d(struct slice_context* restric
   context->ukernel(context->contiguous_size, input, output, NULL);
 }
 
-void xnn_compute_slice_5d(struct slice_context* restrict context, size_t i,
-                          size_t j, size_t k, size_t l, size_t m) {
+XNN_NO_SANITIZE_FUNCTION void xnn_compute_slice_5d(
+    struct slice_context* restrict context, size_t i, size_t j, size_t k,
+    size_t l, size_t m) {
   const void* input =
       (const void*)((uintptr_t)context->input + i * context->input_stride[4] +
                     j * context->input_stride[3] +
@@ -1344,7 +1347,7 @@ XNN_NO_SANITIZE_FUNCTION void xnn_compute_elementwise_binary_4d(
   }
 }
 
-void xnn_compute_elementwise_binary_5d(
+XNN_NO_SANITIZE_FUNCTION void xnn_compute_elementwise_binary_5d(
     struct elementwise_binary_context* restrict context, size_t i, size_t j,
     size_t k, size_t l, size_t m) {
   const void* a =
@@ -1361,8 +1364,9 @@ void xnn_compute_elementwise_binary_5d(
   context->ukernel(context->elements, a, b, y, &context->params);
 }
 
-void xnn_compute_lut_strided(struct lut_strided_context* restrict context,
-                             size_t batch_offset, size_t batch_range) {
+XNN_NO_SANITIZE_FUNCTION void xnn_compute_lut_strided(
+    struct lut_strided_context* restrict context, size_t batch_offset,
+    size_t batch_range) {
   for (size_t batch_index = batch_offset;
        batch_index < batch_offset + batch_range; batch_index++) {
     const void* x =
@@ -1373,8 +1377,9 @@ void xnn_compute_lut_strided(struct lut_strided_context* restrict context,
   }
 }
 
-void xnn_compute_lut_contiguous(struct lut_contiguous_context* restrict context,
-                                size_t offset, size_t size) {
+XNN_NO_SANITIZE_FUNCTION void xnn_compute_lut_contiguous(
+    struct lut_contiguous_context* restrict context, size_t offset,
+    size_t size) {
   const void* x = (const void*)((uintptr_t)context->x + offset);
   void* y = (void*)((uintptr_t)context->y + offset);
 
@@ -1748,7 +1753,7 @@ void xnn_compute_f32_qdu8_convert(
   }
 }
 
-void xnn_compute_pack_lh(struct pack_lh_context* restrict context,
+XNN_NO_SANITIZE_FUNCTION void xnn_compute_pack_lh(struct pack_lh_context* restrict context,
                          size_t group_idx, size_t m_idx_start, size_t tile) {
   const void* lhs =
       (const void*)((uintptr_t)context->lhs + group_idx * context->gi_stride +
@@ -1763,7 +1768,7 @@ void xnn_compute_pack_lh(struct pack_lh_context* restrict context,
                            context->lhs_stride, lhs_packed);
 }
 
-void xnn_compute_f32_qp8_convert(
+XNN_NO_SANITIZE_FUNCTION void xnn_compute_f32_qp8_convert(
     struct f32_qp8_convert_context* restrict context, size_t group_idx,
     size_t m_idx_start, size_t m_tile) {
   const size_t m_end = m_idx_start + m_tile;
@@ -1785,8 +1790,8 @@ void xnn_compute_f32_qp8_convert(
   }
 }
 
-void xnn_compute_u8_softmax(struct u8_softmax_context* restrict context,
-                            size_t batch_index) {
+XNN_NO_SANITIZE_FUNCTION void xnn_compute_u8_softmax(
+    struct u8_softmax_context* restrict context, size_t batch_index) {
   const uint8_t* x =
       (const uint8_t*)((uintptr_t)context->x + context->x_stride * batch_index);
   uint8_t* y =
@@ -1830,8 +1835,9 @@ XNN_NO_SANITIZE_FUNCTION void xnn_compute_floating_point_softmax(
   context->vmulc_ukernel(n, y, &y_scale, y, &context->minmax_params);
 }
 
-void xnn_compute_vmulcaddc(struct vmulcaddc_context* restrict context,
-                           size_t batch_start, size_t batch_size) {
+XNN_NO_SANITIZE_FUNCTION void xnn_compute_vmulcaddc(
+    struct vmulcaddc_context* restrict context, size_t batch_start,
+    size_t batch_size) {
   const size_t x_stride = context->x_stride;
   const size_t y_stride = context->y_stride;
 

--- a/src/operators/average-pooling-nhwc.c
+++ b/src/operators/average-pooling-nhwc.c
@@ -121,7 +121,7 @@ enum xnn_status create_average_pooling2d_nhwc(
   return xnn_status_success;
 }
 
-enum xnn_status xnn_create_average_pooling2d_nhwc_f16(
+XNN_NO_SANITIZE_FUNCTION enum xnn_status xnn_create_average_pooling2d_nhwc_f16(
     uint32_t input_padding_top,
     uint32_t input_padding_right,
     uint32_t input_padding_bottom,
@@ -214,7 +214,7 @@ error:
   return status;
 }
 
-enum xnn_status xnn_create_average_pooling2d_nhwc_f32(
+XNN_NO_SANITIZE_FUNCTION enum xnn_status xnn_create_average_pooling2d_nhwc_f32(
     uint32_t input_padding_top,
     uint32_t input_padding_right,
     uint32_t input_padding_bottom,

--- a/src/operators/batch-matrix-multiply-nc.c
+++ b/src/operators/batch-matrix-multiply-nc.c
@@ -208,8 +208,8 @@ static enum xnn_status setup_linear_ukernels(const struct bmm_variant* variant,
   return xnn_status_success;
 }
 
-static enum xnn_status setup_params_f16(const struct bmm_variant* variant,
-                                        struct bmm_context* context) {
+static XNN_NO_SANITIZE_FUNCTION enum xnn_status setup_params_f16(
+    const struct bmm_variant* variant, struct bmm_context* context) {
   if XNN_LIKELY (context->gemm_config->init.f16 != NULL) {
     context->gemm_config->init.f16(&context->params.f16_minmax,
                                    xnn_float16_from_float(-INFINITY),
@@ -219,8 +219,8 @@ static enum xnn_status setup_params_f16(const struct bmm_variant* variant,
   return xnn_status_success;
 }
 
-static enum xnn_status setup_params_f32(const struct bmm_variant* variant,
-                                        struct bmm_context* context) {
+static XNN_NO_SANITIZE_FUNCTION enum xnn_status setup_params_f32(
+    const struct bmm_variant* variant, struct bmm_context* context) {
   if XNN_LIKELY (context->gemm_config->init.f32 != NULL) {
     context->gemm_config->init.f32(&context->params.f32_minmax, -INFINITY,
                                    INFINITY);
@@ -229,8 +229,8 @@ static enum xnn_status setup_params_f32(const struct bmm_variant* variant,
   return xnn_status_success;
 }
 
-static enum xnn_status setup_params_qs8_qc8w(const struct bmm_variant* variant,
-                                             struct bmm_context* context) {
+static XNN_NO_SANITIZE_FUNCTION enum xnn_status setup_params_qs8_qc8w(
+    const struct bmm_variant* variant, struct bmm_context* context) {
   if (context->output_min > context->output_max) {
     xnn_log_error(
         "failed to create %s operator with [%f, %f] output range:"
@@ -825,7 +825,8 @@ enum xnn_status xnn_create_batch_matrix_multiply_nc_qs8_const_weights(
       &qs8_variant, &context);
 }
 
-static enum xnn_status reshape_batch_matrix_multiply_nc(
+static XNN_NO_SANITIZE_FUNCTION enum xnn_status
+reshape_batch_matrix_multiply_nc(
     xnn_operator_t batch_matrix_multiply_op,
     enum xnn_operator_type expected_operator_type, size_t num_batch_dims,
     const size_t* batch_dims_a, const size_t* batch_dims_b, size_t m, size_t k,

--- a/src/operators/convolution-nchw.c
+++ b/src/operators/convolution-nchw.c
@@ -82,7 +82,7 @@ static inline const void* get_bias_for_cache_key(
                                      : context->bias;
 }
 
-static enum xnn_status create_spmm_path(
+static XNN_NO_SANITIZE_FUNCTION enum xnn_status create_spmm_path(
     struct convolution2d_nchw_context* context,
     const uint32_t log2_filter_element_size,
     const xnn_analyze_spmm_w_fn xnn_analyze_spmm,
@@ -198,7 +198,7 @@ error:
   return status;
 }
 
-static enum xnn_status create_conv2d_hwc2chw_path(
+static XNN_NO_SANITIZE_FUNCTION enum xnn_status create_conv2d_hwc2chw_path(
     struct convolution2d_nchw_context* context,
     const size_t output_height_tile,
     const size_t output_channel_tile,
@@ -258,7 +258,7 @@ static enum xnn_status create_conv2d_hwc2chw_path(
   return xnn_status_success;
 }
 
-static enum xnn_status create_dwconv_path(
+static XNN_NO_SANITIZE_FUNCTION enum xnn_status create_dwconv_path(
     const struct convolution2d_nchw_context* context,
     const uint32_t log2_filter_element_size,
     const xnn_pack_chw_dwconv_hwg_w_fn pack_chw_dwconv_hwg_w,
@@ -353,22 +353,20 @@ static float round_float_value_f16(float value) {
   return xnn_float16_to_float(fp16_value);
 }
 
-static void init_spmm_f32(xnn_analyze_spmm_w_fn* xnn_analyze_spmm,
-                          xnn_pack_spmm_w_fn* xnn_pack_spmm,
-                          xnn_operator_t convolution_op, float output_min,
-                          float output_max, int flags,
-                          const struct xnn_spmm_config* spmm_config) {
+static XNN_NO_SANITIZE_FUNCTION void init_spmm_f32(
+    xnn_analyze_spmm_w_fn* xnn_analyze_spmm, xnn_pack_spmm_w_fn* xnn_pack_spmm,
+    xnn_operator_t convolution_op, float output_min, float output_max,
+    int flags, const struct xnn_spmm_config* spmm_config) {
   *xnn_analyze_spmm = (xnn_analyze_spmm_w_fn)xnn_analyze_f32_spmm_w;
   *xnn_pack_spmm = (xnn_pack_spmm_w_fn)xnn_pack_f32_spmm_w;
   spmm_config->init.f32(&convolution_op->params.f32_minmax, output_min,
                         output_max);
 }
 
-static void init_spmm_f16(xnn_analyze_spmm_w_fn* xnn_analyze_spmm,
-                          xnn_pack_spmm_w_fn* xnn_pack_spmm,
-                          xnn_operator_t convolution_op, float output_min,
-                          float output_max, int flags,
-                          const struct xnn_spmm_config* spmm_config) {
+static XNN_NO_SANITIZE_FUNCTION void init_spmm_f16(
+    xnn_analyze_spmm_w_fn* xnn_analyze_spmm, xnn_pack_spmm_w_fn* xnn_pack_spmm,
+    xnn_operator_t convolution_op, float output_min, float output_max,
+    int flags, const struct xnn_spmm_config* spmm_config) {
   if (flags & XNN_FLAG_FP32_STATIC_WEIGHTS) {
     *xnn_analyze_spmm = (xnn_analyze_spmm_w_fn)xnn_analyze_f32_spmm_w;
     *xnn_pack_spmm = (xnn_pack_spmm_w_fn)xnn_pack_f32_to_f16_spmm_w;
@@ -381,7 +379,7 @@ static void init_spmm_f16(xnn_analyze_spmm_w_fn* xnn_analyze_spmm,
                         xnn_float16_from_float(output_max));
 }
 
-static enum xnn_status init_conv_hwc2chw_f32(
+static XNN_NO_SANITIZE_FUNCTION enum xnn_status init_conv_hwc2chw_f32(
     xnn_pack_dconv_oki_w_fn* xnn_pack_dconv_oki_w,
     const struct xnn_conv_hwc2chw_config** conv_hwc2chw_config,
     xnn_operator_t convolution_op, const int flags, const float output_min,
@@ -401,7 +399,7 @@ static enum xnn_status init_conv_hwc2chw_f32(
   return xnn_status_success;
 }
 
-static enum xnn_status init_conv_hwc2chw_f16(
+static XNN_NO_SANITIZE_FUNCTION enum xnn_status init_conv_hwc2chw_f16(
     xnn_pack_dconv_oki_w_fn* xnn_pack_dconv_oki_w,
     const struct xnn_conv_hwc2chw_config** conv_hwc2chw_config,
     xnn_operator_t convolution_op, const int flags, const float output_min,
@@ -428,7 +426,7 @@ static enum xnn_status init_conv_hwc2chw_f16(
   return xnn_status_success;
 }
 
-static void init_dwconv_f32(
+static XNN_NO_SANITIZE_FUNCTION void init_dwconv_f32(
     xnn_pack_chw_dwconv_hwg_w_fn* pack_chw_dwconv_hwg_w,
     xnn_pack_chw_dwconv_ghw_w_fn* pack_chw_dwconv_ghw_w,
     const struct xnn_dwconv2d_chw_parameters* dwconv2d_parameters,
@@ -442,7 +440,7 @@ static void init_dwconv_f32(
                                 output_max);
 }
 
-static void init_dwconv_f16(
+static XNN_NO_SANITIZE_FUNCTION void init_dwconv_f16(
     xnn_pack_chw_dwconv_hwg_w_fn* pack_chw_dwconv_hwg_w,
     xnn_pack_chw_dwconv_ghw_w_fn* pack_chw_dwconv_ghw_w,
     const struct xnn_dwconv2d_chw_parameters* dwconv2d_parameters,

--- a/src/operators/convolution-nhwc.c
+++ b/src/operators/convolution-nhwc.c
@@ -1092,7 +1092,7 @@ static enum xnn_status init_packing_params_fxx_qc8w(
   return xnn_status_success;
 }
 
-static enum xnn_status init_gemm_params_qu8(
+static XNN_NO_SANITIZE_FUNCTION enum xnn_status init_gemm_params_qu8(
     const struct convolution2d_nhwc_variant* variant,
     struct convolution2d_nhwc_context* context) {
   if (context->output_max > UINT8_MAX) {
@@ -1112,7 +1112,7 @@ static enum xnn_status init_gemm_params_qu8(
   return xnn_status_success;
 }
 
-static enum xnn_status init_gemm_params_qs8_qc8w(
+static XNN_NO_SANITIZE_FUNCTION enum xnn_status init_gemm_params_qs8_qc8w(
     const struct convolution2d_nhwc_variant* variant,
     struct convolution2d_nhwc_context* context) {
   if (context->output_max > INT8_MAX) {
@@ -1131,7 +1131,7 @@ static enum xnn_status init_gemm_params_qs8_qc8w(
   return xnn_status_success;
 }
 
-static enum xnn_status init_gemm_params_f16(
+static XNN_NO_SANITIZE_FUNCTION enum xnn_status init_gemm_params_f16(
     const struct convolution2d_nhwc_variant* variant,
     struct convolution2d_nhwc_context* context) {
   if XNN_LIKELY (context->gemm_config->init.f16 != NULL) {
@@ -1144,7 +1144,7 @@ static enum xnn_status init_gemm_params_f16(
   return xnn_status_success;
 }
 
-static enum xnn_status init_gemm_params_f32(
+static XNN_NO_SANITIZE_FUNCTION enum xnn_status init_gemm_params_f32(
     const struct convolution2d_nhwc_variant* variant,
     struct convolution2d_nhwc_context* context) {
   if XNN_LIKELY (context->gemm_config->init.f32 != NULL) {
@@ -1156,7 +1156,7 @@ static enum xnn_status init_gemm_params_f32(
   return xnn_status_success;
 }
 
-static enum xnn_status init_dwconv_params_qu8(
+static XNN_NO_SANITIZE_FUNCTION enum xnn_status init_dwconv_params_qu8(
     const struct convolution2d_nhwc_variant* variant,
     struct convolution2d_nhwc_context* context) {
   const struct xnn_dwconv_config* dwconv_config = xnn_init_qu8_dwconv_config();
@@ -1181,7 +1181,7 @@ static enum xnn_status init_dwconv_params_qu8(
   return xnn_status_success;
 }
 
-static enum xnn_status init_dwconv_params_qs8_qc8w(
+static XNN_NO_SANITIZE_FUNCTION enum xnn_status init_dwconv_params_qs8_qc8w(
     const struct convolution2d_nhwc_variant* variant,
     struct convolution2d_nhwc_context* context) {
   const struct xnn_dwconv_config* dwconv_config =
@@ -1206,7 +1206,7 @@ static enum xnn_status init_dwconv_params_qs8_qc8w(
   return xnn_status_success;
 }
 
-static enum xnn_status init_dwconv_params_f16(
+static XNN_NO_SANITIZE_FUNCTION enum xnn_status init_dwconv_params_f16(
     const struct convolution2d_nhwc_variant* variant,
     struct convolution2d_nhwc_context* context) {
   const struct xnn_dwconv_config* dwconv_config = xnn_init_f16_dwconv_config();
@@ -1229,7 +1229,7 @@ static enum xnn_status init_dwconv_params_f16(
   return xnn_status_success;
 }
 
-static enum xnn_status init_dwconv_params_f32(
+static XNN_NO_SANITIZE_FUNCTION enum xnn_status init_dwconv_params_f32(
     const struct convolution2d_nhwc_variant* variant,
     struct convolution2d_nhwc_context* context) {
   const struct xnn_dwconv_config* dwconv_config = xnn_init_f32_dwconv_config();
@@ -1251,7 +1251,7 @@ static enum xnn_status init_dwconv_params_f32(
   return xnn_status_success;
 }
 
-static enum xnn_status init_vmuladdc_params_f16(
+static XNN_NO_SANITIZE_FUNCTION enum xnn_status init_vmuladdc_params_f16(
     const struct convolution2d_nhwc_variant* variant,
     struct convolution2d_nhwc_context* context) {
   const struct xnn_vmulcaddc_config* vmulcaddc_config =
@@ -1273,7 +1273,7 @@ static enum xnn_status init_vmuladdc_params_f16(
   return xnn_status_success;
 }
 
-static enum xnn_status init_vmuladdc_params_f32(
+static XNN_NO_SANITIZE_FUNCTION enum xnn_status init_vmuladdc_params_f32(
     const struct convolution2d_nhwc_variant* variant,
     struct convolution2d_nhwc_context* context) {
   const struct xnn_vmulcaddc_config* vmulcaddc_config =

--- a/src/operators/deconvolution-nhwc.c
+++ b/src/operators/deconvolution-nhwc.c
@@ -764,7 +764,7 @@ static enum xnn_status setup_linear_gemm_ukernels(
   return xnn_status_success;
 }
 
-static enum xnn_status setup_params_qs8_qc8w(
+static XNN_NO_SANITIZE_FUNCTION enum xnn_status setup_params_qs8_qc8w(
     const struct deconv2d_variant* variant, struct deconv2d_context* context) {
   if XNN_LIKELY (context->gemm_config->init.qs8_qc8w != NULL) {
     context->gemm_config->init.qs8_qc8w(
@@ -776,8 +776,8 @@ static enum xnn_status setup_params_qs8_qc8w(
   return xnn_status_success;
 }
 
-static enum xnn_status setup_params_qu8(const struct deconv2d_variant* variant,
-                                        struct deconv2d_context* context) {
+static XNN_NO_SANITIZE_FUNCTION enum xnn_status setup_params_qu8(
+    const struct deconv2d_variant* variant, struct deconv2d_context* context) {
   if XNN_LIKELY (context->gemm_config->init.qu8 != NULL) {
     context->gemm_config->init.qu8(
         &context->params_.qu8, context->kernel_zero_point,
@@ -789,8 +789,8 @@ static enum xnn_status setup_params_qu8(const struct deconv2d_variant* variant,
   return xnn_status_success;
 }
 
-static enum xnn_status setup_params_f16(const struct deconv2d_variant* variant,
-                                        struct deconv2d_context* context) {
+static XNN_NO_SANITIZE_FUNCTION enum xnn_status setup_params_f16(
+    const struct deconv2d_variant* variant, struct deconv2d_context* context) {
   if XNN_LIKELY (context->gemm_config->init.f16 != NULL) {
     const xnn_float16 output_min_as_half =
         xnn_float16_from_float(context->output_min);
@@ -804,8 +804,8 @@ static enum xnn_status setup_params_f16(const struct deconv2d_variant* variant,
   return xnn_status_success;
 }
 
-static enum xnn_status setup_params_f32(const struct deconv2d_variant* variant,
-                                        struct deconv2d_context* context) {
+static XNN_NO_SANITIZE_FUNCTION enum xnn_status setup_params_f32(
+    const struct deconv2d_variant* variant, struct deconv2d_context* context) {
   if XNN_LIKELY (context->gemm_config->init.f32 != NULL) {
     context->gemm_config->init.f32(&context->params_.f32, context->output_min,
                                    context->output_max);
@@ -1731,7 +1731,7 @@ enum xnn_status xnn_create_deconvolution2d_nhwc_f32_f16(
   return status;
 }
 
-static enum xnn_status reshape_igemm_path(
+static XNN_NO_SANITIZE_FUNCTION enum xnn_status reshape_igemm_path(
     xnn_operator_t deconvolution_op, size_t batch_size,
     uint32_t log2_input_element_size, uint32_t log2_filter_element_size,
     uint32_t extra_weights_element_size, uint32_t log2_output_element_size,

--- a/src/operators/dynamic-fully-connected-nc.c
+++ b/src/operators/dynamic-fully-connected-nc.c
@@ -149,7 +149,7 @@ error:
   return status;
 }
 
-enum xnn_status create_dynamic_fully_connected_nc_f16(
+XNN_NO_SANITIZE_FUNCTION enum xnn_status create_dynamic_fully_connected_nc_f16(
     float output_min, float output_max, uint32_t flags,
     const struct xnn_gemm_config* gemm_config,
     enum xnn_operator_type expected_operator_type,
@@ -232,7 +232,7 @@ enum xnn_status xnn_create_dynamic_fully_connected_nc_pf16(
       dynamic_fully_connected_op_out);
 }
 
-enum xnn_status create_dynamic_fully_connected_nc_f32(
+XNN_NO_SANITIZE_FUNCTION enum xnn_status create_dynamic_fully_connected_nc_f32(
     float output_min, float output_max, uint32_t flags,
     const struct xnn_gemm_config* gemm_config,
     const struct xnn_gemm_config* gemm_nr2_config,
@@ -338,7 +338,8 @@ enum xnn_status xnn_create_dynamic_fully_connected_nc_pf32(
       dynamic_fully_connected_op_out);
 }
 
-static enum xnn_status reshape_dynamic_fully_connected_nc(
+static XNN_NO_SANITIZE_FUNCTION enum xnn_status
+reshape_dynamic_fully_connected_nc(
     xnn_operator_t dynamic_fully_connected_op,
     enum xnn_operator_type expected_operator_type, size_t batch_size,
     size_t input_channels, size_t output_channels, size_t input_stride,

--- a/src/operators/fingerprint_cache.c
+++ b/src/operators/fingerprint_cache.c
@@ -158,7 +158,7 @@ struct fingerprint_context create_fingerprint_context(
   return context;
 }
 
-static void free_fingerprint_cache_provider(
+static XNN_NO_SANITIZE_FUNCTION void free_fingerprint_cache_provider(
     struct xnn_weights_cache_provider* const provider) {
   if (provider) {
     provider->delete_cache(provider->context);

--- a/src/operators/fully-connected-nc.c
+++ b/src/operators/fully-connected-nc.c
@@ -666,8 +666,8 @@ static enum xnn_status setup_gemm_ukernels(const struct fc_variant* variant,
   return xnn_status_success;
 }
 
-static enum xnn_status setup_params_f16(const struct fc_variant* variant,
-                                        struct fc_context* context) {
+static XNN_NO_SANITIZE_FUNCTION enum xnn_status setup_params_f16(
+    const struct fc_variant* variant, struct fc_context* context) {
   const xnn_float16 fp16_output_min =
       xnn_float16_from_float(context->output_min);
   const xnn_float16 fp16_output_max =
@@ -680,8 +680,8 @@ static enum xnn_status setup_params_f16(const struct fc_variant* variant,
   return xnn_status_success;
 }
 
-static enum xnn_status setup_params_f16_qc4w(const struct fc_variant* variant,
-                                             struct fc_context* context) {
+static XNN_NO_SANITIZE_FUNCTION enum xnn_status setup_params_f16_qc4w(
+    const struct fc_variant* variant, struct fc_context* context) {
   const xnn_float16 fp16_output_min =
       xnn_float16_from_float(context->output_min);
   const xnn_float16 fp16_output_max =
@@ -695,8 +695,8 @@ static enum xnn_status setup_params_f16_qc4w(const struct fc_variant* variant,
   return xnn_status_success;
 }
 
-static enum xnn_status setup_params_f16_qb4w(const struct fc_variant* variant,
-                                             struct fc_context* context) {
+static XNN_NO_SANITIZE_FUNCTION enum xnn_status setup_params_f16_qb4w(
+    const struct fc_variant* variant, struct fc_context* context) {
   const xnn_float16 fp16_output_min =
       xnn_float16_from_float(context->output_min);
   const xnn_float16 fp16_output_max =
@@ -710,8 +710,8 @@ static enum xnn_status setup_params_f16_qb4w(const struct fc_variant* variant,
   return xnn_status_success;
 }
 
-static enum xnn_status setup_params_f32(const struct fc_variant* variant,
-                                        struct fc_context* context) {
+static XNN_NO_SANITIZE_FUNCTION enum xnn_status setup_params_f32(
+    const struct fc_variant* variant, struct fc_context* context) {
   if XNN_LIKELY (context->gemm_config->init.f32 != NULL) {
     context->gemm_config->init.f32(&context->params.f32, context->output_min,
                                    context->output_max);
@@ -720,8 +720,8 @@ static enum xnn_status setup_params_f32(const struct fc_variant* variant,
   return xnn_status_success;
 }
 
-static enum xnn_status setup_params_f32_qc4w(const struct fc_variant* variant,
-                                             struct fc_context* context) {
+static XNN_NO_SANITIZE_FUNCTION enum xnn_status setup_params_f32_qc4w(
+    const struct fc_variant* variant, struct fc_context* context) {
   if XNN_LIKELY (context->gemm_config->init.f32_qc4w != NULL) {
     context->gemm_config->init.f32_qc4w(
         &context->params.f32_qc4w, context->output_min, context->output_max,
@@ -731,8 +731,8 @@ static enum xnn_status setup_params_f32_qc4w(const struct fc_variant* variant,
   return xnn_status_success;
 }
 
-static enum xnn_status setup_params_f32_qb4w(const struct fc_variant* variant,
-                                             struct fc_context* context) {
+static XNN_NO_SANITIZE_FUNCTION enum xnn_status setup_params_f32_qb4w(
+    const struct fc_variant* variant, struct fc_context* context) {
   if XNN_LIKELY (context->gemm_config->init.f32_qb4w != NULL) {
     context->gemm_config->init.f32_qb4w(
         &context->params.f32_qb4w, context->output_min, context->output_max,
@@ -742,8 +742,8 @@ static enum xnn_status setup_params_f32_qb4w(const struct fc_variant* variant,
   return xnn_status_success;
 }
 
-static enum xnn_status setup_params_qs8_qc8w(const struct fc_variant* variant,
-                                             struct fc_context* context) {
+static XNN_NO_SANITIZE_FUNCTION enum xnn_status setup_params_qs8_qc8w(
+    const struct fc_variant* variant, struct fc_context* context) {
   context->output_min = clamp(context->output_min, INT8_MIN, INT8_MAX);
   context->output_max = clamp(context->output_max, INT8_MIN, INT8_MAX);
   if XNN_LIKELY (context->gemm_config->init.qs8_qc8w != NULL) {
@@ -755,8 +755,8 @@ static enum xnn_status setup_params_qs8_qc8w(const struct fc_variant* variant,
   return xnn_status_success;
 }
 
-static enum xnn_status setup_params_qu8(const struct fc_variant* variant,
-                                        struct fc_context* context) {
+static XNN_NO_SANITIZE_FUNCTION enum xnn_status setup_params_qu8(
+    const struct fc_variant* variant, struct fc_context* context) {
   const float requantization_scale = context->input_scale *
                                      context->kernel_scale_value /
                                      context->output_scale;
@@ -2719,7 +2719,7 @@ enum xnn_status xnn_create_fully_connected_nc_qu8(
   return create_fully_connected_nc_helper(&context);
 }
 
-static enum xnn_status reshape_fully_connected_nc(
+static XNN_NO_SANITIZE_FUNCTION enum xnn_status reshape_fully_connected_nc(
     xnn_operator_t fully_connected_op,
     enum xnn_operator_type expected_operator_type, size_t batch_size,
     bool dynamic_quantization, uint32_t log2_output_element_size,

--- a/src/operators/max-pooling-nhwc.c
+++ b/src/operators/max-pooling-nhwc.c
@@ -155,7 +155,7 @@ error:
   return status;
 }
 
-enum xnn_status xnn_create_max_pooling2d_nhwc_s8(
+XNN_NO_SANITIZE_FUNCTION enum xnn_status xnn_create_max_pooling2d_nhwc_s8(
     uint32_t input_padding_top,
     uint32_t input_padding_right,
     uint32_t input_padding_bottom,
@@ -194,7 +194,7 @@ enum xnn_status xnn_create_max_pooling2d_nhwc_s8(
     max_pooling_op_out);
 }
 
-enum xnn_status xnn_create_max_pooling2d_nhwc_u8(
+XNN_NO_SANITIZE_FUNCTION enum xnn_status xnn_create_max_pooling2d_nhwc_u8(
     uint32_t input_padding_top,
     uint32_t input_padding_right,
     uint32_t input_padding_bottom,
@@ -233,7 +233,7 @@ enum xnn_status xnn_create_max_pooling2d_nhwc_u8(
     max_pooling_op_out);
 }
 
-enum xnn_status xnn_create_max_pooling2d_nhwc_f32(
+XNN_NO_SANITIZE_FUNCTION enum xnn_status xnn_create_max_pooling2d_nhwc_f32(
     uint32_t input_padding_top,
     uint32_t input_padding_right,
     uint32_t input_padding_bottom,
@@ -291,7 +291,7 @@ enum xnn_status xnn_create_max_pooling2d_nhwc_f32(
     max_pooling_op_out);
 }
 
-enum xnn_status xnn_create_max_pooling2d_nhwc_f16(
+XNN_NO_SANITIZE_FUNCTION enum xnn_status xnn_create_max_pooling2d_nhwc_f16(
     uint32_t input_padding_top,
     uint32_t input_padding_right,
     uint32_t input_padding_bottom,

--- a/src/operators/pack-lh.c
+++ b/src/operators/pack-lh.c
@@ -90,14 +90,12 @@ enum xnn_status xnn_create_pack_lh_x8(uint32_t flags,
                         pack_lh_op_out);
 }
 
-enum xnn_status reshape_pack_lh(xnn_operator_t pack_lh_op, size_t num_groups,
-                                size_t batch_size, size_t channels,
-                                size_t* output_size_bytes,
-                                enum xnn_operator_type expected_operator_type,
-                                size_t element_size,
-                                const struct xnn_gemm_config* gemm_config,
-                                const struct xnn_pack_lh_config* pack_lh_config,
-                                pthreadpool_t threadpool) {
+XNN_NO_SANITIZE_FUNCTION enum xnn_status reshape_pack_lh(
+    xnn_operator_t pack_lh_op, size_t num_groups, size_t batch_size,
+    size_t channels, size_t* output_size_bytes,
+    enum xnn_operator_type expected_operator_type, size_t element_size,
+    const struct xnn_gemm_config* gemm_config,
+    const struct xnn_pack_lh_config* pack_lh_config, pthreadpool_t threadpool) {
   if (pack_lh_op->type != expected_operator_type) {
     xnn_log_error(
         "failed to reshape operator: operator type mismatch (expected %s, got "

--- a/src/operators/reduce-nd.c
+++ b/src/operators/reduce-nd.c
@@ -128,12 +128,11 @@ static uint32_t get_identity_value(xnn_operator_t reduce_op, size_t num_reductio
   return identity_value;
 }
 
-static enum xnn_status reshape_reduce_nd(
+static XNN_NO_SANITIZE_FUNCTION enum xnn_status reshape_reduce_nd(
     xnn_operator_t reduce_op, size_t num_reduction_axes,
     const int64_t* reduction_axes, size_t num_input_dims,
     const size_t* input_shape, size_t* workspace_size,
-    enum xnn_operator_type expected_operator_type,
-    pthreadpool_t threadpool) {
+    enum xnn_operator_type expected_operator_type, pthreadpool_t threadpool) {
   if (reduce_op->type != expected_operator_type) {
     xnn_log_error(
         "failed to reshape operator: operator type mismatch (expected %s, got "
@@ -426,7 +425,7 @@ static enum xnn_status setup_reduce_nd(
   return xnn_status_success;
 }
 
-enum xnn_status xnn_create_reduce_nd(
+XNN_NO_SANITIZE_FUNCTION enum xnn_status xnn_create_reduce_nd(
     const enum xnn_reduce_operator reduce_operator_type,
     const enum xnn_datatype datatype,
     const struct xnn_quantization_params* input_quantization,

--- a/src/operators/resize-bilinear-nchw.c
+++ b/src/operators/resize-bilinear-nchw.c
@@ -117,7 +117,7 @@ error:
   return status;
 }
 
-enum xnn_status xnn_reshape_resize_bilinear2d_nchw(
+XNN_NO_SANITIZE_FUNCTION enum xnn_status xnn_reshape_resize_bilinear2d_nchw(
     xnn_operator_t resize_op,
     size_t batch_size,
     size_t input_height,

--- a/src/operators/unary-elementwise-nc.c
+++ b/src/operators/unary-elementwise-nc.c
@@ -246,7 +246,7 @@ static const struct xnn_unary_elementwise_config* get_config(
   return NULL;
 }
 
-static enum xnn_status init_op(
+static XNN_NO_SANITIZE_FUNCTION enum xnn_status init_op(
     xnn_operator_t op,
     enum xnn_unary_operator op_type,
     enum xnn_datatype input_datatype,


### PR DESCRIPTION
`XNN_NO_SANITIZE_FUNCTION` was introduced to suppress `-fsanitize=function` false positives where XNNPACK calls microkernels/helpers through type-erased function pointers, but it was not applied everywhere it should have been.

This PR fills in the gaps across `src/operator-run.c` and `src/operators/*.c`, annotating the remaining functions that directly invoke such pointers. The macro is a no-op unless built with Clang `-fsanitize=function`, so there is no effect on code generation or runtime behavior.

Chromium issue: https://issues.chromium.org/issues/520663347