### PR TITLE
Introduce XNN_NO_SANITIZE_INTEGER_OVERFLOW macro

### DIFF
--- a/src/qs8-rsum/avx2.c.in
+++ b/src/qs8-rsum/avx2.c.in
@@ -20,6 +20,7 @@ $assert AVX in [2, 10]
 
 $ACC_SUFFIX = "" if ACCUMULATORS == 1 else "_acc%d" % ACCUMULATORS
 $ISA = "avx2" if AVX == 2 else "avx256skx"
+XNN_NO_SANITIZE_INTEGER_OVERFLOW
 void xnn_qs8_rsum_ukernel__${ISA}_u${CHANNEL_TILE}${ACC_SUFFIX}(
     size_t batch,
     const int8_t* input,

--- a/src/qs8-rsum/gen/qs8-rsum-avx2-u128-acc2.c
+++ b/src/qs8-rsum/gen/qs8-rsum-avx2-u128-acc2.c
@@ -18,6 +18,7 @@
 #include "src/xnnpack/microparams.h"
 #include "src/xnnpack/reduce.h"
 
+XNN_NO_SANITIZE_INTEGER_OVERFLOW
 void xnn_qs8_rsum_ukernel__avx2_u128_acc2(
     size_t batch,
     const int8_t* input,

--- a/src/qs8-rsum/gen/qs8-rsum-avx2-u128-acc4.c
+++ b/src/qs8-rsum/gen/qs8-rsum-avx2-u128-acc4.c
@@ -18,6 +18,7 @@
 #include "src/xnnpack/microparams.h"
 #include "src/xnnpack/reduce.h"
 
+XNN_NO_SANITIZE_INTEGER_OVERFLOW
 void xnn_qs8_rsum_ukernel__avx2_u128_acc4(
     size_t batch,
     const int8_t* input,

--- a/src/qs8-rsum/gen/qs8-rsum-avx2-u32.c
+++ b/src/qs8-rsum/gen/qs8-rsum-avx2-u32.c
@@ -18,6 +18,7 @@
 #include "src/xnnpack/microparams.h"
 #include "src/xnnpack/reduce.h"
 
+XNN_NO_SANITIZE_INTEGER_OVERFLOW
 void xnn_qs8_rsum_ukernel__avx2_u32(
     size_t batch,
     const int8_t* input,

--- a/src/qs8-rsum/gen/qs8-rsum-avx2-u64-acc2.c
+++ b/src/qs8-rsum/gen/qs8-rsum-avx2-u64-acc2.c
@@ -18,6 +18,7 @@
 #include "src/xnnpack/microparams.h"
 #include "src/xnnpack/reduce.h"
 
+XNN_NO_SANITIZE_INTEGER_OVERFLOW
 void xnn_qs8_rsum_ukernel__avx2_u64_acc2(
     size_t batch,
     const int8_t* input,

--- a/src/qs8-rsum/gen/qs8-rsum-avx256skx-u128-acc2.c
+++ b/src/qs8-rsum/gen/qs8-rsum-avx256skx-u128-acc2.c
@@ -18,6 +18,7 @@
 #include "src/xnnpack/microparams.h"
 #include "src/xnnpack/reduce.h"
 
+XNN_NO_SANITIZE_INTEGER_OVERFLOW
 void xnn_qs8_rsum_ukernel__avx256skx_u128_acc2(
     size_t batch,
     const int8_t* input,

--- a/src/qs8-rsum/gen/qs8-rsum-avx256skx-u128-acc4.c
+++ b/src/qs8-rsum/gen/qs8-rsum-avx256skx-u128-acc4.c
@@ -18,6 +18,7 @@
 #include "src/xnnpack/microparams.h"
 #include "src/xnnpack/reduce.h"
 
+XNN_NO_SANITIZE_INTEGER_OVERFLOW
 void xnn_qs8_rsum_ukernel__avx256skx_u128_acc4(
     size_t batch,
     const int8_t* input,

--- a/src/qs8-rsum/gen/qs8-rsum-avx256skx-u32.c
+++ b/src/qs8-rsum/gen/qs8-rsum-avx256skx-u32.c
@@ -18,6 +18,7 @@
 #include "src/xnnpack/microparams.h"
 #include "src/xnnpack/reduce.h"
 
+XNN_NO_SANITIZE_INTEGER_OVERFLOW
 void xnn_qs8_rsum_ukernel__avx256skx_u32(
     size_t batch,
     const int8_t* input,

--- a/src/qs8-rsum/gen/qs8-rsum-avx256skx-u64-acc2.c
+++ b/src/qs8-rsum/gen/qs8-rsum-avx256skx-u64-acc2.c
@@ -18,6 +18,7 @@
 #include "src/xnnpack/microparams.h"
 #include "src/xnnpack/reduce.h"
 
+XNN_NO_SANITIZE_INTEGER_OVERFLOW
 void xnn_qs8_rsum_ukernel__avx256skx_u64_acc2(
     size_t batch,
     const int8_t* input,

--- a/src/xnnpack/common.h
+++ b/src/xnnpack/common.h
@@ -339,6 +339,17 @@
 #define XNN_NO_SANITIZE_FUNCTION
 #endif
 
+// Disables UBSan's integer-overflow checks for an annotated function. Only use
+// this where the overflow merely yields a wrong numeric result and poses no
+// safety risk. Expands to nothing on compilers without the attribute.
+#if defined(__clang__) && XNN_COMPILER_HAS_ATTRIBUTE(no_sanitize)
+#define XNN_NO_SANITIZE_INTEGER_OVERFLOW                  \
+  __attribute__((no_sanitize("signed-integer-overflow",      \
+                             "unsigned-integer-overflow")))
+#else
+#define XNN_NO_SANITIZE_INTEGER_OVERFLOW
+#endif
+
 #define XNN_OOB_READS \
   XNN_DISABLE_TSAN XNN_DISABLE_MSAN XNN_DISABLE_HWASAN XNN_DISABLE_ASAN
 


### PR DESCRIPTION
Introduce XNN_NO_SANITIZE_INTEGER_OVERFLOW macro and use it on functions where the chromium fuzzer has already detected the overflow. See chromium issue: https://issues.chromium.org/issues/519841740