### PR TITLE
security: zero sensitive weight buffers before release in xnn_destroy_operator() and FP16/BF16 conversion functions

### DIFF
--- a/src/operator-utils.c
+++ b/src/operator-utils.c
@@ -3,6 +3,9 @@
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
 
+#if !defined(_GNU_SOURCE)
+#define _GNU_SOURCE
+#endif
 #include "src/xnnpack/operator-utils.h"
 
 #include <assert.h>
@@ -194,6 +197,16 @@ enum xnn_status xnn_destroy_operator(xnn_operator_t op)
     xnn_release_memory(op->convolution_op);
   }
   if (op->weights_cache == NULL) {
+    // CWE-226: Zero packed weight buffer before release so model weights do not
+    // remain recoverable from freed heap memory. The buffer size is
+    // group_output_channels * weights_stride, matching the allocation in
+    // xnn_get_pointer_to_write_weights().
+    if (op->packed_weights.pointer != NULL && op->convolution_op != NULL &&
+        op->weights_stride > 0) {
+      explicit_bzero(op->packed_weights.pointer,
+                     op->convolution_op->group_output_channels *
+                         op->weights_stride);
+    }
     xnn_release_simd_memory(op->packed_weights.pointer);
   }
   xnn_release_simd_memory(op->zero_buffer);

--- a/src/operators/convolution-nchw.c
+++ b/src/operators/convolution-nchw.c
@@ -3,6 +3,9 @@
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
 
+#if !defined(_GNU_SOURCE)
+#define _GNU_SOURCE
+#endif
 #if defined(__GNUC__) && !defined(__clang__)
 // This warning has a ton of false positives, including in GCC's own headers, so
 // we need to disable this warning before including those. Furthermore, it is
@@ -1267,7 +1270,13 @@ enum xnn_status xnn_create_convolution2d_nchw_f32_f16(
   status = create_convolution2d_nchw(&f32_conv, &context, convolution_op_out);
 
   // Release temporary `f32` buffers.
+  // CWE-226: Zero before release so kernel/bias data does not persist on heap.
+  explicit_bzero(fp32_kernel_buffer, num_kernel_entries * sizeof(float));
   xnn_release_memory(fp32_kernel_buffer);
+  if (fp32_bias_buffer != NULL) {
+    explicit_bzero(fp32_bias_buffer,
+                   groups * group_output_channels * sizeof(float));
+  }
   xnn_release_memory(fp32_bias_buffer);
 
   return status;

--- a/src/operators/convolution-nhwc.c
+++ b/src/operators/convolution-nhwc.c
@@ -6,6 +6,9 @@
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
 
+#if !defined(_GNU_SOURCE)
+#define _GNU_SOURCE
+#endif
 #include <assert.h>
 #include <float.h>
 #include <inttypes.h>
@@ -2527,7 +2530,13 @@ enum xnn_status xnn_create_convolution2d_nhwc_f32_f16(
       &f32_variant, &context, convolution_op_out);
 
   // Release temporary `f32` buffers.
+  // CWE-226: Zero before release so kernel/bias data does not persist on heap.
+  explicit_bzero(fp32_kernel_buffer, num_kernel_entries * sizeof(float));
   xnn_release_memory(fp32_kernel_buffer);
+  if (fp32_bias_buffer != NULL) {
+    explicit_bzero(fp32_bias_buffer,
+                   groups * group_output_channels * sizeof(float));
+  }
   xnn_release_memory(fp32_bias_buffer);
 
   return status;
@@ -2607,7 +2616,13 @@ enum xnn_status xnn_create_convolution2d_nhwc_pf32_f16(
       &f32_variant, &context, convolution_op_out);
 
   // Release temporary `f32` buffers.
+  // CWE-226: Zero before release so kernel/bias data does not persist on heap.
+  explicit_bzero(fp32_kernel_buffer, num_kernel_entries * sizeof(float));
   xnn_release_memory(fp32_kernel_buffer);
+  if (fp32_bias_buffer != NULL) {
+    explicit_bzero(fp32_bias_buffer,
+                   groups * group_output_channels * sizeof(float));
+  }
   xnn_release_memory(fp32_bias_buffer);
 
   return status;

--- a/src/operators/deconvolution-nhwc.c
+++ b/src/operators/deconvolution-nhwc.c
@@ -6,6 +6,9 @@
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
 
+#if !defined(_GNU_SOURCE)
+#define _GNU_SOURCE
+#endif
 #include <assert.h>
 #include <float.h>
 #include <inttypes.h>
@@ -1725,7 +1728,13 @@ enum xnn_status xnn_create_deconvolution2d_nhwc_f32_f16(
       flags, weights_cache, deconvolution_op_out);
 
   // Release temporary `f32` buffers.
+  // CWE-226: Zero before release so kernel/bias data does not persist on heap.
+  explicit_bzero(fp32_kernel_buffer, num_kernel_entries * sizeof(float));
   xnn_release_memory(fp32_kernel_buffer);
+  if (fp32_bias_buffer != NULL) {
+    explicit_bzero(fp32_bias_buffer,
+                   groups * group_output_channels * sizeof(float));
+  }
   xnn_release_memory(fp32_bias_buffer);
 
   return status;

--- a/src/operators/fully-connected-nc.c
+++ b/src/operators/fully-connected-nc.c
@@ -6,6 +6,9 @@
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
 
+#if !defined(_GNU_SOURCE)
+#define _GNU_SOURCE
+#endif
 #include <assert.h>
 #include <float.h>
 #include <inttypes.h>
@@ -1917,6 +1920,8 @@ enum xnn_status xnn_create_fully_connected_nc_qd8_f16_qb4w_f16_scales(
       input_channels, output_channels, input_stride, output_stride, block_size,
       kernel_zero_point, (const uint16_t*)bf16_scale_buffer, kernel, bias,
       output_min, output_max, flags, weights_cache, fully_connected_op_out);
+  // CWE-226: Zero scale buffer derived from private kernel data before release.
+  explicit_bzero(bf16_scale_buffer, num_blocks * sizeof(xnn_bfloat16));
   xnn_release_memory(bf16_scale_buffer);
   return status;
 }
@@ -2122,6 +2127,8 @@ enum xnn_status xnn_create_fully_connected_nc_qp8_f32_qb4w_f16_scales(
       input_channels, output_channels, input_stride, output_stride, block_size,
       kernel_zero_point, (const uint16_t*)bf16_scale_buffer, kernel, bias,
       output_min, output_max, flags, weights_cache, fully_connected_op_out);
+  // CWE-226: Zero scale buffer derived from private kernel data before release.
+  explicit_bzero(bf16_scale_buffer, num_blocks * sizeof(xnn_bfloat16));
   xnn_release_memory(bf16_scale_buffer);
   return status;
 }
@@ -2171,6 +2178,8 @@ enum xnn_status xnn_create_fully_connected_nc_qd8_f32_qb4w_f16_scales(
       input_channels, output_channels, input_stride, output_stride, block_size,
       kernel_zero_point, (const uint16_t*)bf16_scale_buffer, kernel, bias, output_min, output_max,
       flags, weights_cache, fully_connected_op_out);
+  // CWE-226: Zero scale buffer derived from private kernel data before release.
+  explicit_bzero(bf16_scale_buffer, num_blocks * sizeof(xnn_bfloat16));
   xnn_release_memory(bf16_scale_buffer);
   return status;
 }
@@ -2220,6 +2229,8 @@ enum xnn_status xnn_create_fully_connected_nc_qdu8_f32_qb4w_f16_scales(
       input_channels, output_channels, input_stride, output_stride, block_size,
       kernel_zero_point, (const uint16_t*)bf16_scale_buffer, kernel, bias, output_min, output_max,
       flags, weights_cache, fully_connected_op_out);
+  // CWE-226: Zero scale buffer derived from private kernel data before release.
+  explicit_bzero(bf16_scale_buffer, num_blocks * sizeof(xnn_bfloat16));
   xnn_release_memory(bf16_scale_buffer);
   return status;
 }
@@ -2363,7 +2374,14 @@ enum xnn_status xnn_create_fully_connected_nc_f32_f16(
       .original_bias = bias,
   };
   enum xnn_status status = create_fully_connected_nc_helper(&context);
+  // CWE-226: Zero transient FP32 weight buffers before release.
+  explicit_bzero(fp32_kernel_buffer,
+                 input_channels * output_channels * sizeof(float));
   xnn_release_memory(fp32_kernel_buffer);
+  if (fp32_bias_buffer_to_release != NULL) {
+    explicit_bzero(fp32_bias_buffer_to_release,
+                   output_channels * sizeof(float));
+  }
   xnn_release_memory(fp32_bias_buffer_to_release);
   return status;
 }
@@ -2411,7 +2429,14 @@ enum xnn_status xnn_create_fully_connected_nc_pf32_f16(
       .original_bias = bias,
   };
   enum xnn_status status = create_fully_connected_nc_helper(&context);
+  // CWE-226: Zero transient FP32 weight buffers before release.
+  explicit_bzero(fp32_kernel_buffer,
+                 input_channels * output_channels * sizeof(float));
   xnn_release_memory(fp32_kernel_buffer);
+  if (fp32_bias_buffer_to_release != NULL) {
+    explicit_bzero(fp32_bias_buffer_to_release,
+                   output_channels * sizeof(float));
+  }
   xnn_release_memory(fp32_bias_buffer_to_release);
   return status;
 }


### PR DESCRIPTION
## Summary

This patch adds `explicit_bzero()` calls before every `xnn_release_memory()` /
`xnn_release_simd_memory()` call on buffers that hold caller-supplied model
weight data. The goal is to reduce the window during which those values remain
readable in freed heap memory.

## Motivation

Standard allocators (`free()`, `posix_memalign`) do not scrub freed memory.
On Linux, a freed heap page stays mapped in the process address space until the
OS reclaims it. In multi-model inference services or multi-tenant deployments
where several models share a process, weight data from a destroyed operator can
remain accessible in freed memory and be read by a later allocation landing on
the same freed page.

`memset()` is not used here because compilers are permitted to elide dead-store
`memset()` calls under optimization. `explicit_bzero()` is the POSIX primitive
specifically designed to survive optimization for this purpose — the same
approach used by OpenSSL, libsodium, and the Linux kernel for sensitive data.

## Changes

**`src/operator-utils.c` — `xnn_destroy_operator()`**
Zero `op->packed_weights.pointer` (the repacked weight matrix, held for the
full operator lifetime) before `xnn_release_simd_memory()`.

**`src/operators/fully-connected-nc.c`**
- Zero transient `fp32_kernel_buffer` and `fp32_bias_buffer` in
  `xnn_create_fully_connected_nc_f32_f16` and
  `xnn_create_fully_connected_nc_pf32_f16` before `xnn_release_memory()`.
- Zero `bf16_scale_buffer` at 4 callsites before `xnn_release_memory()`.

**`src/operators/convolution-nhwc.c`**
Zero transient `fp32_kernel_buffer` and `fp32_bias_buffer` in
`xnn_create_convolution2d_nhwc_f32_f16` and
`xnn_create_convolution2d_nhwc_pf32_f16` before release.

**`src/operators/convolution-nchw.c`**
Zero transient `fp32_kernel_buffer` and `fp32_bias_buffer` in
`xnn_create_convolution2d_nchw_f32_f16` before release.

**`src/operators/deconvolution-nhwc.c`**
Zero transient `fp32_kernel_buffer` and `fp32_bias_buffer` in
`xnn_create_deconvolution2d_nhwc_f32_f16` before release.

## Compatibility

`explicit_bzero()` is available on:
- glibc 2.25+ (all modern Linux distributions)
- Bionic (Android NDK r23+)
- Apple platforms (macOS 10.12+, iOS 10+)

The `_GNU_SOURCE` guard already present in several XNNPACK source files
(e.g. `src/memory.c` lines 24–25) is added to each patched file to expose
`explicit_bzero` from `<string.h>` on Linux. A follow-up can address
`SecureZeroMemory()` for `XNN_PLATFORM_WINDOWS` paths if desired.

## Impact on correctness and performance

This patch adds no new code paths and changes no return values or API behavior.
The `explicit_bzero()` calls add a one-time linear write over each buffer
immediately before it is freed — this occurs only at operator teardown and
creation, not during inference.

5 files changed, 71 insertions(+)