### PR TITLE
guard partial-block bias and ksum writes in x64c4 avx256vnni packw

### DIFF
--- a/src/qs8-packw/gen/qs8-packw-x64c4-gemm-goi-avx256vnni-prfm.c
+++ b/src/qs8-packw/gen/qs8-packw-x64c4-gemm-goi-avx256vnni-prfm.c
@@ -1106,13 +1106,27 @@ void xnn_qs8_packw_gemm_goi_ukernel_x64c4__avx256vnni_prfm(
         b += n;
       } else {
         _mm256_storeu_si256((__m256i*) (out + 0), _mm256_setzero_si256());
-        _mm256_storeu_si256((__m256i*) (out + 32), _mm256_setzero_si256());
-        _mm256_storeu_si256((__m256i*) (out + 64), _mm256_setzero_si256());
-        _mm256_storeu_si256((__m256i*) (out + 96), _mm256_setzero_si256());
-        _mm256_storeu_si256((__m256i*) (out + 128), _mm256_setzero_si256());
-        _mm256_storeu_si256((__m256i*) (out + 160), _mm256_setzero_si256());
-        _mm256_storeu_si256((__m256i*) (out + 192), _mm256_setzero_si256());
-        _mm256_storeu_si256((__m256i*) (out + 224), _mm256_setzero_si256());
+        if (n > 8) {
+          _mm256_storeu_si256((__m256i*) (out + 32), _mm256_setzero_si256());
+        }
+        if (n > 16) {
+          _mm256_storeu_si256((__m256i*) (out + 64), _mm256_setzero_si256());
+        }
+        if (n > 24) {
+          _mm256_storeu_si256((__m256i*) (out + 96), _mm256_setzero_si256());
+        }
+        if (n > 32) {
+          _mm256_storeu_si256((__m256i*) (out + 128), _mm256_setzero_si256());
+        }
+        if (n > 40) {
+          _mm256_storeu_si256((__m256i*) (out + 160), _mm256_setzero_si256());
+        }
+        if (n > 48) {
+          _mm256_storeu_si256((__m256i*) (out + 192), _mm256_setzero_si256());
+        }
+        if (n > 56) {
+          _mm256_storeu_si256((__m256i*) (out + 224), _mm256_setzero_si256());
+        }
       }
       out += 64 * sizeof(int32_t);
 
@@ -1824,29 +1838,43 @@ void xnn_qs8_packw_gemm_goi_ukernel_x64c4__avx256vnni_prfm(
       __m256i vksum48 = _mm256_mullo_epi32(vacc48, vzeropoint);
       __m256i vksum56 = _mm256_mullo_epi32(vacc56, vzeropoint);
       __m256i vpack0 =  _mm256_loadu_si256((const __m256i*) (packed_b + 0));
-      __m256i vpack8 =  _mm256_loadu_si256((const __m256i*) (packed_b + 8));
-      __m256i vpack16 =  _mm256_loadu_si256((const __m256i*) (packed_b + 16));
-      __m256i vpack24 =  _mm256_loadu_si256((const __m256i*) (packed_b + 24));
-      __m256i vpack32 =  _mm256_loadu_si256((const __m256i*) (packed_b + 32));
-      __m256i vpack40 =  _mm256_loadu_si256((const __m256i*) (packed_b + 40));
-      __m256i vpack48 =  _mm256_loadu_si256((const __m256i*) (packed_b + 48));
-      __m256i vpack56 =  _mm256_loadu_si256((const __m256i*) (packed_b + 56));
       vpack0 = _mm256_sub_epi32(vpack0, vksum0);
-      vpack8 = _mm256_sub_epi32(vpack8, vksum8);
-      vpack16 = _mm256_sub_epi32(vpack16, vksum16);
-      vpack24 = _mm256_sub_epi32(vpack24, vksum24);
-      vpack32 = _mm256_sub_epi32(vpack32, vksum32);
-      vpack40 = _mm256_sub_epi32(vpack40, vksum40);
-      vpack48 = _mm256_sub_epi32(vpack48, vksum48);
-      vpack56 = _mm256_sub_epi32(vpack56, vksum56);
       _mm256_storeu_si256((__m256i *) (packed_b + 0), vpack0);
-      _mm256_storeu_si256((__m256i *) (packed_b + 8), vpack8);
-      _mm256_storeu_si256((__m256i *) (packed_b + 16), vpack16);
-      _mm256_storeu_si256((__m256i *) (packed_b + 24), vpack24);
-      _mm256_storeu_si256((__m256i *) (packed_b + 32), vpack32);
-      _mm256_storeu_si256((__m256i *) (packed_b + 40), vpack40);
-      _mm256_storeu_si256((__m256i *) (packed_b + 48), vpack48);
-      _mm256_storeu_si256((__m256i *) (packed_b + 56), vpack56);
+      if (n > 8) {
+        __m256i vpack8 =  _mm256_loadu_si256((const __m256i*) (packed_b + 8));
+        vpack8 = _mm256_sub_epi32(vpack8, vksum8);
+        _mm256_storeu_si256((__m256i *) (packed_b + 8), vpack8);
+      }
+      if (n > 16) {
+        __m256i vpack16 =  _mm256_loadu_si256((const __m256i*) (packed_b + 16));
+        vpack16 = _mm256_sub_epi32(vpack16, vksum16);
+        _mm256_storeu_si256((__m256i *) (packed_b + 16), vpack16);
+      }
+      if (n > 24) {
+        __m256i vpack24 =  _mm256_loadu_si256((const __m256i*) (packed_b + 24));
+        vpack24 = _mm256_sub_epi32(vpack24, vksum24);
+        _mm256_storeu_si256((__m256i *) (packed_b + 24), vpack24);
+      }
+      if (n > 32) {
+        __m256i vpack32 =  _mm256_loadu_si256((const __m256i*) (packed_b + 32));
+        vpack32 = _mm256_sub_epi32(vpack32, vksum32);
+        _mm256_storeu_si256((__m256i *) (packed_b + 32), vpack32);
+      }
+      if (n > 40) {
+        __m256i vpack40 =  _mm256_loadu_si256((const __m256i*) (packed_b + 40));
+        vpack40 = _mm256_sub_epi32(vpack40, vksum40);
+        _mm256_storeu_si256((__m256i *) (packed_b + 40), vpack40);
+      }
+      if (n > 48) {
+        __m256i vpack48 =  _mm256_loadu_si256((const __m256i*) (packed_b + 48));
+        vpack48 = _mm256_sub_epi32(vpack48, vksum48);
+        _mm256_storeu_si256((__m256i *) (packed_b + 48), vpack48);
+      }
+      if (n > 56) {
+        __m256i vpack56 =  _mm256_loadu_si256((const __m256i*) (packed_b + 56));
+        vpack56 = _mm256_sub_epi32(vpack56, vksum56);
+        _mm256_storeu_si256((__m256i *) (packed_b + 56), vpack56);
+      }
       out = (int8_t*) ((uintptr_t) out + extra_bytes);
     }
 

--- a/src/qs8-packw/gen/qs8-packw-x64c4-gemm-goi-avx256vnni.c
+++ b/src/qs8-packw/gen/qs8-packw-x64c4-gemm-goi-avx256vnni.c
@@ -529,13 +529,27 @@ void xnn_qs8_packw_gemm_goi_ukernel_x64c4__avx256vnni(
         b += n;
       } else {
         _mm256_storeu_si256((__m256i*) (out + 0), _mm256_setzero_si256());
-        _mm256_storeu_si256((__m256i*) (out + 32), _mm256_setzero_si256());
-        _mm256_storeu_si256((__m256i*) (out + 64), _mm256_setzero_si256());
-        _mm256_storeu_si256((__m256i*) (out + 96), _mm256_setzero_si256());
-        _mm256_storeu_si256((__m256i*) (out + 128), _mm256_setzero_si256());
-        _mm256_storeu_si256((__m256i*) (out + 160), _mm256_setzero_si256());
-        _mm256_storeu_si256((__m256i*) (out + 192), _mm256_setzero_si256());
-        _mm256_storeu_si256((__m256i*) (out + 224), _mm256_setzero_si256());
+        if (n > 8) {
+          _mm256_storeu_si256((__m256i*) (out + 32), _mm256_setzero_si256());
+        }
+        if (n > 16) {
+          _mm256_storeu_si256((__m256i*) (out + 64), _mm256_setzero_si256());
+        }
+        if (n > 24) {
+          _mm256_storeu_si256((__m256i*) (out + 96), _mm256_setzero_si256());
+        }
+        if (n > 32) {
+          _mm256_storeu_si256((__m256i*) (out + 128), _mm256_setzero_si256());
+        }
+        if (n > 40) {
+          _mm256_storeu_si256((__m256i*) (out + 160), _mm256_setzero_si256());
+        }
+        if (n > 48) {
+          _mm256_storeu_si256((__m256i*) (out + 192), _mm256_setzero_si256());
+        }
+        if (n > 56) {
+          _mm256_storeu_si256((__m256i*) (out + 224), _mm256_setzero_si256());
+        }
       }
       out += 64 * sizeof(int32_t);
 
@@ -1119,29 +1133,43 @@ void xnn_qs8_packw_gemm_goi_ukernel_x64c4__avx256vnni(
       __m256i vksum48 = _mm256_mullo_epi32(vacc48, vzeropoint);
       __m256i vksum56 = _mm256_mullo_epi32(vacc56, vzeropoint);
       __m256i vpack0 =  _mm256_loadu_si256((const __m256i*) (packed_b + 0));
-      __m256i vpack8 =  _mm256_loadu_si256((const __m256i*) (packed_b + 8));
-      __m256i vpack16 =  _mm256_loadu_si256((const __m256i*) (packed_b + 16));
-      __m256i vpack24 =  _mm256_loadu_si256((const __m256i*) (packed_b + 24));
-      __m256i vpack32 =  _mm256_loadu_si256((const __m256i*) (packed_b + 32));
-      __m256i vpack40 =  _mm256_loadu_si256((const __m256i*) (packed_b + 40));
-      __m256i vpack48 =  _mm256_loadu_si256((const __m256i*) (packed_b + 48));
-      __m256i vpack56 =  _mm256_loadu_si256((const __m256i*) (packed_b + 56));
       vpack0 = _mm256_sub_epi32(vpack0, vksum0);
-      vpack8 = _mm256_sub_epi32(vpack8, vksum8);
-      vpack16 = _mm256_sub_epi32(vpack16, vksum16);
-      vpack24 = _mm256_sub_epi32(vpack24, vksum24);
-      vpack32 = _mm256_sub_epi32(vpack32, vksum32);
-      vpack40 = _mm256_sub_epi32(vpack40, vksum40);
-      vpack48 = _mm256_sub_epi32(vpack48, vksum48);
-      vpack56 = _mm256_sub_epi32(vpack56, vksum56);
       _mm256_storeu_si256((__m256i *) (packed_b + 0), vpack0);
-      _mm256_storeu_si256((__m256i *) (packed_b + 8), vpack8);
-      _mm256_storeu_si256((__m256i *) (packed_b + 16), vpack16);
-      _mm256_storeu_si256((__m256i *) (packed_b + 24), vpack24);
-      _mm256_storeu_si256((__m256i *) (packed_b + 32), vpack32);
-      _mm256_storeu_si256((__m256i *) (packed_b + 40), vpack40);
-      _mm256_storeu_si256((__m256i *) (packed_b + 48), vpack48);
-      _mm256_storeu_si256((__m256i *) (packed_b + 56), vpack56);
+      if (n > 8) {
+        __m256i vpack8 =  _mm256_loadu_si256((const __m256i*) (packed_b + 8));
+        vpack8 = _mm256_sub_epi32(vpack8, vksum8);
+        _mm256_storeu_si256((__m256i *) (packed_b + 8), vpack8);
+      }
+      if (n > 16) {
+        __m256i vpack16 =  _mm256_loadu_si256((const __m256i*) (packed_b + 16));
+        vpack16 = _mm256_sub_epi32(vpack16, vksum16);
+        _mm256_storeu_si256((__m256i *) (packed_b + 16), vpack16);
+      }
+      if (n > 24) {
+        __m256i vpack24 =  _mm256_loadu_si256((const __m256i*) (packed_b + 24));
+        vpack24 = _mm256_sub_epi32(vpack24, vksum24);
+        _mm256_storeu_si256((__m256i *) (packed_b + 24), vpack24);
+      }
+      if (n > 32) {
+        __m256i vpack32 =  _mm256_loadu_si256((const __m256i*) (packed_b + 32));
+        vpack32 = _mm256_sub_epi32(vpack32, vksum32);
+        _mm256_storeu_si256((__m256i *) (packed_b + 32), vpack32);
+      }
+      if (n > 40) {
+        __m256i vpack40 =  _mm256_loadu_si256((const __m256i*) (packed_b + 40));
+        vpack40 = _mm256_sub_epi32(vpack40, vksum40);
+        _mm256_storeu_si256((__m256i *) (packed_b + 40), vpack40);
+      }
+      if (n > 48) {
+        __m256i vpack48 =  _mm256_loadu_si256((const __m256i*) (packed_b + 48));
+        vpack48 = _mm256_sub_epi32(vpack48, vksum48);
+        _mm256_storeu_si256((__m256i *) (packed_b + 48), vpack48);
+      }
+      if (n > 56) {
+        __m256i vpack56 =  _mm256_loadu_si256((const __m256i*) (packed_b + 56));
+        vpack56 = _mm256_sub_epi32(vpack56, vksum56);
+        _mm256_storeu_si256((__m256i *) (packed_b + 56), vpack56);
+      }
       out = (int8_t*) ((uintptr_t) out + extra_bytes);
     }
 

--- a/src/x8-packw/c4-avxvnni.c.in
+++ b/src/x8-packw/c4-avxvnni.c.in
@@ -265,7 +265,12 @@ void xnn_${DATATYPE_SPEC}_packw_gemm_goi_ukernel_x${NR}c${KR}__${ISA}${"_prfm" i
         b += n;
       } else {
         $for N in range(0, NR, 8):
-          _mm256_storeu_si256((__m256i*) (out + ${N*4}), _mm256_setzero_si256());
+          $if N == 0:
+            _mm256_storeu_si256((__m256i*) (out + ${N*4}), _mm256_setzero_si256());
+          $else:
+            if (n > ${N}) {
+              _mm256_storeu_si256((__m256i*) (out + ${N*4}), _mm256_setzero_si256());
+            }
       }
       out += ${NR} * sizeof(${BTYPE});
 
@@ -355,11 +360,16 @@ void xnn_${DATATYPE_SPEC}_packw_gemm_goi_ukernel_x${NR}c${KR}__${ISA}${"_prfm" i
         $for N in range(0, NR, 8):
           __m256i vksum${N} = _mm256_mullo_epi32(vacc${N}, vzeropoint);
         $for N in range(0, NR, 8):
-          __m256i vpack${N} =  _mm256_loadu_si256((const __m256i*) (packed_b + ${N}));
-        $for N in range(0, NR, 8):
-          vpack${N} = _mm256_sub_epi32(vpack${N}, vksum${N});
-        $for N in range(0, NR, 8):
-          _mm256_storeu_si256((__m256i *) (packed_b + ${N}), vpack${N});
+          $if N == 0:
+            __m256i vpack${N} =  _mm256_loadu_si256((const __m256i*) (packed_b + ${N}));
+            vpack${N} = _mm256_sub_epi32(vpack${N}, vksum${N});
+            _mm256_storeu_si256((__m256i *) (packed_b + ${N}), vpack${N});
+          $else:
+            if (n > ${N}) {
+              __m256i vpack${N} =  _mm256_loadu_si256((const __m256i*) (packed_b + ${N}));
+              vpack${N} = _mm256_sub_epi32(vpack${N}, vksum${N});
+              _mm256_storeu_si256((__m256i *) (packed_b + ${N}), vpack${N});
+            }
       out = (${TYPE}*) ((uintptr_t) out + extra_bytes);
     }
 


### PR DESCRIPTION
In the NC remainder (1..63) of the x64c4 avx256vnni packw kernels:

    src/qs8-packw/gen/qs8-packw-x64c4-gemm-goi-avx256vnni.c
      } else {
        _mm256_storeu_si256((__m256i*) (out + 0),   _mm256_setzero_si256());
        _mm256_storeu_si256((__m256i*) (out + 32),  _mm256_setzero_si256());   // n may be < 16
        ...                                                                    // through out + 224
      }

The bias zeros (b == NULL) and, later, the ksum-adjusted biases at packed_b+0..+56 are written a full NR=64 lanes wide regardless of the remainder count n.

75d2c7d fixed exactly this construct in the c8 AVX packw kernels (kr-avxvnni.c.in) by guarding every store past the first with `if (n > N)`, and the NEON c4 kernel already guards the equivalent ksum write with `if (N < n)`. The c4-avxvnni.c.in template was missed, so its x64c4 kernels are the only AVX packw kernels still writing the remainder block unguarded. x64c4 avx256vnni is wired into the qd8/qs8 qc8w gemm configs, so it is on a live path.

Applied the same `if (n > N)` guard to the bias and ksum remainder stores in the template and regenerated the two files. Valid-channel output is byte-identical across n=1..40, k=1..20; only the [n, 64) padding lanes are left untouched now, matching the reference packer in src/reference/packing.cc.