### PR TITLE
fix off-by-one heap write in zephyr log output path

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -45,7 +45,15 @@
 
 #define XNN_LOG_STDERR STD_ERROR_HANDLE
 #define XNN_LOG_STDOUT STD_OUTPUT_HANDLE
-#elif defined(__hexagon__) || defined(__ZEPHYR__)
+#elif defined(__ZEPHYR__)
+// The Zephyr branch writes a trailing '\n' followed by a '\0' (the buffer is
+// passed to printf, which needs a NUL terminator), i.e. two trailing bytes,
+// so reserve two like the _WIN32 path.
+#define XNN_LOG_NEWLINE_LENGTH 2
+
+#define XNN_LOG_STDERR 0
+#define XNN_LOG_STDOUT 0
+#elif defined(__hexagon__)
 #define XNN_LOG_NEWLINE_LENGTH 1
 
 #define XNN_LOG_STDERR 0


### PR DESCRIPTION
ASan, on the heap path of `xnn_vlog` (a message longer than the 1024-byte stack buffer) in a Zephyr build:

    ==ERROR: AddressSanitizer: heap-buffer-overflow
    WRITE of size 1 at 0x...
        #0 xnn_vlog src/log.c   out_buffer[prefix_length + format_length + 1] = '\0'
    0x... is located 0 bytes after a (prefix_length + format_length + 1)-byte region

Spotted while reading the platform branches in `src/log.c`. Every buffer size in the function is `prefix_length + format_length + XNN_LOG_NEWLINE_LENGTH`, so that constant has to equal the trailing bytes a branch actually writes. `_WIN32` writes two (`\r`, `\n`) and uses 2. The POSIX branch writes one (`\n`) and uses 1. The Zephyr branch writes two, a `\n` and then a `\0` for `printf`, but shared the value 1 with hexagon. So the allocation, and the stack-vs-heap cutoff, come out a byte short and the terminator write at `out_buffer[prefix_length + format_length + 1]` runs one past the end. The heap path overflows on every long line; the stack path at `prefix + format == 1023`.

Checked with a small reproducer of the heap-path arithmetic: newline length 1 trips ASan as above, newline length 2 is clean.

Give Zephyr its own newline length of 2, like `_WIN32` which also writes two trailing bytes. hexagon keeps 1 and never reaches this code, since `XNN_LOG_TO_STDIO` is 0 there.