### PR TITLE
Fully Connected: guard packed weights size calculation against overflow

### DIFF
--- a/src/operators/fully-connected-nc.c
+++ b/src/operators/fully-connected-nc.c
@@ -259,7 +259,14 @@ static XNN_NO_SANITIZE_FUNCTION enum xnn_status create_fully_connected_nc(
                 extra_weights_bytes)
           : (k_stride << log2_filter_element_size) + bias_element_size +
                 extra_weights_bytes + block_scale_bytes;
-  const size_t packed_weights_size = n_stride * weights_stride;
+  size_t packed_weights_size = 0;
+  if (!xnn_safe_mul(n_stride, weights_stride, &packed_weights_size)) {
+    xnn_log_error(
+        "failed to create %s operator: packed weights size overflows size_t "
+        "(n_stride=%zu, weights_stride=%zu)",
+        xnn_operator_type_to_string(operator_type), n_stride, weights_stride);
+    goto error;
+  }
   fully_connected_op->weights_stride = weights_stride;
   size_t aligned_total_weights_size =
       round_up_po2(packed_weights_size, XNN_ALLOCATION_ALIGNMENT);


### PR DESCRIPTION
# Fully Connected: guard packed weights size calculation against overflow

## Summary

This updates the fully-connected operator creation path to validate the packed
weights allocation size before allocating and packing weights.

`create_fully_connected_nc()` now uses the existing `xnn_safe_mul()` helper for
`n_stride * weights_stride`. If the product cannot be represented in `size_t`,
operator creation reports an error through the existing cleanup path instead of
allocating a wrapped, undersized packed-weights buffer.

Valid fully-connected operators continue to use the existing packing path
unchanged.

## Bug

The fully-connected operator previously computed the packed weights allocation
size with an unchecked multiplication:

```c
const size_t packed_weights_size = n_stride * weights_stride;
```

Both factors are derived from the operator dimensions and packing configuration.
For very large dimensions, this multiplication can wrap around `size_t`. The
wrapped value is then rounded and passed to `xnn_get_pointer_to_write_weights()`,
but the subsequent packer is still called with the original `input_channels` and
`output_channels`.

That creates an undersized heap allocation followed by writes in the configured
weight-packing routine.

An ASan repro against the unpatched code confirmed this path through the public
`xnn_create_fully_connected_nc_f32()` API:

```text
Debug (XNNPACK): allocated 0 bytes for packed weights in Fully Connected (NC, F32) operator
ERROR: AddressSanitizer: heap-buffer-overflow
WRITE of size 32
    #0 xnn_x32_packw_gemm_goi_ukernel_x16__avx_u4
    #1 create_fully_connected_nc src/operators/fully-connected-nc.c:330
    #2 xnn_create_fully_connected_nc_f32 src/operators/fully-connected-nc.c:2463
```

## Fix

- Replace the unchecked multiplication with `xnn_safe_mul()`.
- Log a clear packed-weights size overflow error when the product is not
  representable.
- Return through the existing error path before any packed-weights allocation or
  packing routine runs.

The check is local to the allocation-size calculation and does not alter normal
packing behavior for representable sizes.

## Test

Built XNNPACK with ASan/UBSan and rebuilt the `XNNPACK` target:

```sh
cmake -S xnnpack-full-asan -B build-xnnpack-asan \
  -DCMAKE_BUILD_TYPE=Debug \
  -DXNNPACK_BUILD_TESTS=OFF \
  -DXNNPACK_BUILD_BENCHMARKS=OFF \
  -DXNNPACK_LIBRARY_TYPE=static \
  -DCMAKE_C_FLAGS='-fsanitize=address,undefined -fno-omit-frame-pointer -g' \
  -DCMAKE_CXX_FLAGS='-fsanitize=address,undefined -fno-omit-frame-pointer -g' \
  -DCMAKE_EXE_LINKER_FLAGS='-fsanitize=address,undefined'

cmake --build build-xnnpack-asan --target XNNPACK -j2
```

Ran a local public-API ASan reproducer before and after the fix:

- Before: ASan reports a heap-buffer-overflow in the f32 packed-weights packer.
- After: no ASan finding; creation returns `xnn_status_out_of_memory` and logs
  `packed weights size overflow`.

Patched run result:

```text
Error in XNNPACK: failed to create Fully Connected (NC, F32) operator with 4611686018427387904 output channels and 1 input channels: packed weights size overflow
create status: 6, op=(nil)
```

## Security Report

Related Google VRP / IssueTracker report: 532600764
