### PR TITLE
Max Pooling: guard indirection buffer size calculation against overflow

### DIFF
--- a/src/operators/max-pooling-nhwc.c
+++ b/src/operators/max-pooling-nhwc.c
@@ -473,19 +473,53 @@ static enum xnn_status reshape_max_pooling2d_nhwc(
 
   const size_t pooling_height = max_pooling_op->convolution_op->kernel_height;
   const size_t pooling_width = max_pooling_op->convolution_op->kernel_width;
-  const size_t pooling_size = pooling_height * pooling_width;
+  size_t pooling_size = 0;
+  if (!xnn_safe_mul(pooling_height, pooling_width, &pooling_size)) {
+    xnn_log_error(
+        "failed to reshape %s operator: indirection buffer size overflows for "
+        "%zux%zu pooling size",
+        xnn_operator_type_to_string_v2(max_pooling_op), pooling_width,
+        pooling_height);
+    return xnn_status_out_of_memory;
+  }
   const size_t output_height = max_pooling_op->convolution_op->output_height;
   const size_t output_width = max_pooling_op->convolution_op->output_width;
 
   const size_t step_width =
     max_pooling_op->convolution_op->dilation_width > 1 ? pooling_width : min(max_pooling_op->convolution_op->stride_width, pooling_width);
-  const size_t step_height = pooling_size + (output_width - 1) * step_width * pooling_height;
+  size_t step_height = 0;
+  size_t step_height_increment = 0;
+  if (!xnn_safe_mul(output_width - 1, step_width, &step_height_increment) ||
+      !xnn_safe_mul(step_height_increment, pooling_height,
+                    &step_height_increment) ||
+      !xnn_safe_add(pooling_size, step_height_increment, &step_height)) {
+    xnn_log_error(
+        "failed to reshape %s operator: indirection buffer size overflows for "
+        "%zux%zu output and %zux%zu pooling size",
+        xnn_operator_type_to_string_v2(max_pooling_op), output_width,
+        output_height, pooling_width, pooling_height);
+    return xnn_status_out_of_memory;
+  }
 
   if (input_height != max_pooling_op->convolution_op->last_input_height ||
       input_width != max_pooling_op->convolution_op->last_input_width ||
       channels != max_pooling_op->convolution_op->last_input_channels)
   {
-    const size_t indirection_buffer_size = sizeof(void*) * ((pooling_size - 1) + output_height * step_height);
+    size_t indirection_buffer_elements = 0;
+    size_t indirection_buffer_size = 0;
+    if (!xnn_safe_mul(output_height, step_height,
+                      &indirection_buffer_elements) ||
+        !xnn_safe_add(pooling_size - 1, indirection_buffer_elements,
+                      &indirection_buffer_elements) ||
+        !xnn_safe_mul(indirection_buffer_elements, sizeof(void*),
+                      &indirection_buffer_size)) {
+      xnn_log_error(
+          "failed to reshape %s operator: indirection buffer size overflows "
+          "for %zux%zu output and %zux%zu pooling size",
+          xnn_operator_type_to_string_v2(max_pooling_op), output_width,
+          output_height, pooling_width, pooling_height);
+      return xnn_status_out_of_memory;
+    }
     const void** indirection_buffer =
       (const void**) xnn_reallocate_memory(max_pooling_op->convolution_op->indirection_buffer, indirection_buffer_size);
     if (indirection_buffer == NULL) {


### PR DESCRIPTION
# Max Pooling: guard indirection buffer size calculation against overflow

## Summary

This updates the NHWC max-pooling reshape path to validate the indirection
buffer size before allocating and initializing it.

`reshape_max_pooling2d_nhwc()` now uses the existing `xnn_safe_mul()` and
`xnn_safe_add()` helpers for the intermediate `step_height`, element-count, and
byte-count calculations. If the computed indirection buffer size cannot be
represented in `size_t`, reshape returns `xnn_status_out_of_memory` before
allocating an undersized buffer.

Valid max-pooling operators continue to use the existing indirection
initialization path unchanged.

## Bug

The max-pooling reshape path previously computed the indirection buffer size
with unchecked `size_t` arithmetic:

```c
const size_t pooling_size = pooling_height * pooling_width;
const size_t step_height =
    pooling_size + (output_width - 1) * step_width * pooling_height;
const size_t indirection_buffer_size =
    sizeof(void*) * ((pooling_size - 1) + output_height * step_height);
```

For very large output dimensions this can wrap around `size_t`. The wrapped
size is passed to `xnn_reallocate_memory()`, but
`xnn_indirection_init_maxpool2d()` still initializes the table using the
original output dimensions and step values.

An ASan repro against the unpatched code confirmed this through the public
`xnn_reshape_max_pooling2d_nhwc_f32()` API:

```text
Debug (XNNPACK): allocated 0 bytes for indirection buffer in Max Pooling (NHWC, F32) operator
ERROR: AddressSanitizer: heap-buffer-overflow
WRITE of size 8
    #0 xnn_indirection_init_maxpool2d src/indirection.c:453
    #1 reshape_max_pooling2d_nhwc src/operators/max-pooling-nhwc.c:506
    #2 xnn_reshape_max_pooling2d_nhwc_f32 src/operators/max-pooling-nhwc.c:635
```

## Fix

- Check `pooling_height * pooling_width`.
- Check the intermediate `step_height` calculation.
- Check the final indirection-buffer element count.
- Check the final byte count before calling `xnn_reallocate_memory()`.
- Return `xnn_status_out_of_memory` with a clear overflow log if any step is
  not representable in `size_t`.

## Test

Built XNNPACK with ASan/UBSan and rebuilt the `XNNPACK` target:

```sh
cmake --build build-xnnpack-asan --target XNNPACK -j2
```

Ran a local public-API ASan reproducer before and after the fix:

- Before: ASan reports a heap-buffer-overflow in
  `xnn_indirection_init_maxpool2d()`.
- After: no ASan finding; reshape returns `xnn_status_out_of_memory` and logs
  an indirection-buffer size overflow.

Patched run result:

```text
Error in XNNPACK: failed to reshape Max Pooling (NHWC, F32) operator: indirection buffer size overflows for 1073741824x2147483648 output and 1x1 pooling size
reshape status: 6, output=2147483648x1073741824
```

## Security Report

Related Google VRP / IssueTracker report: 532600764

