### PR TITLE
  Fix integer overflow in reshape_subconv2d_path() indirection buffer size computation

### DIFF
--- a/src/operators/deconvolution-nhwc.c
+++ b/src/operators/deconvolution-nhwc.c
@@ -2081,9 +2081,18 @@ static enum xnn_status reshape_subconv2d_path(
   }
 
   if (any_size_change) {
-    const size_t indirection_buffer_size =
-        sizeof(void*) * kernel_size * output_height * stride_width *
-        round_up(divide_round_up(output_width, stride_width), mr);
+    const size_t rounded_output_width =
+      round_up(divide_round_up(output_width, stride_width), mr);
+  size_t indirection_buffer_size = 0;
+  if (!xnn_safe_mul(kernel_size, output_height, &indirection_buffer_size) ||
+      !xnn_safe_mul(indirection_buffer_size, stride_width, &indirection_buffer_size) ||
+      !xnn_safe_mul(indirection_buffer_size, rounded_output_width, &indirection_buffer_size) ||
+      !xnn_safe_mul(indirection_buffer_size, sizeof(void*), &indirection_buffer_size)) {
+    xnn_log_error(
+        "failed to reshape %s operator: indirection buffer size overflows",
+        xnn_operator_type_to_string_v2(deconvolution_op));
+    return xnn_status_out_of_memory;
+  }
 
     const void** indirection_buffer = (const void**)xnn_reallocate_memory(
         deconvolution_op->convolution_op->indirection_buffer,


### PR DESCRIPTION
reshape_subconv2d_path() computes indirection_buffer_size using a raw size_t multiplication chain with no overflow check:
      sizeof(void*) * kernel_size * output_height * stride_width * round_up(divide_round_up(output_width, stride_width), mr)
      
  When kernel dimensions and output dimensions are large, this product silently wraps, producing an allocation far smaller than required. xnn_indirection_init_subconv2d() then writes into the undersized buffer using the real (non-overflowed) dimensions, causing a heap out-of-bounds write.
  
  The sibling reshape_igemm_path() already guards the equivalent computation with xnn_safe_mul at lines 1765–1774. This change applies the same pattern to the subconv2d path: each factor is multiplied through xnn_safe_mul, and the function returns xnn_status_out_of_memory immediately if any step overflows.
