### PR TITLE
guard indirection buffer size overflow in average and argmax pooling

### DIFF
--- a/src/operators/argmax-pooling-nhwc.c
+++ b/src/operators/argmax-pooling-nhwc.c
@@ -241,13 +241,35 @@ enum xnn_status xnn_reshape_argmax_pooling2d_nhwc_f32(
   if (output_width_out != NULL) {
     *output_width_out = output_width;
   }
-  const size_t pooling_size = pooling_height * pooling_width;
+  size_t pooling_size = 0;
+  if (!xnn_safe_mul(pooling_height, pooling_width, &pooling_size)) {
+    xnn_log_error(
+      "failed to reshape %s operator: indirection buffer size overflows for %zux%zu pooling size",
+      xnn_operator_type_to_string(xnn_operator_type_argmax_pooling_nhwc_f32), pooling_width, pooling_height);
+    return xnn_status_out_of_memory;
+  }
   const struct xnn_argmaxpool_config* argmaxpool_config = argmax_pooling_op->argmaxpool_config;
 
   const size_t step_width = pooling_width;
-  const size_t step_height = pooling_size + (output_width - 1) * step_width * pooling_height;
+  size_t step_height = 0;
+  size_t step_height_increment = 0;
+  if (!xnn_safe_mul(output_width - 1, step_width, &step_height_increment) ||
+      !xnn_safe_mul(step_height_increment, pooling_height, &step_height_increment) ||
+      !xnn_safe_add(pooling_size, step_height_increment, &step_height)) {
+    xnn_log_error(
+      "failed to reshape %s operator: indirection buffer size overflows for %zux%zu output and %zux%zu pooling size",
+      xnn_operator_type_to_string(xnn_operator_type_argmax_pooling_nhwc_f32), output_width, output_height, pooling_width, pooling_height);
+    return xnn_status_out_of_memory;
+  }
 
-  const size_t indirection_buffer_size = sizeof(void*) * (output_height * step_height);
+  size_t indirection_buffer_size = 0;
+  if (!xnn_safe_mul(output_height, step_height, &indirection_buffer_size) ||
+      !xnn_safe_mul(indirection_buffer_size, sizeof(void*), &indirection_buffer_size)) {
+    xnn_log_error(
+      "failed to reshape %s operator: indirection buffer size overflows for %zux%zu output and %zux%zu pooling size",
+      xnn_operator_type_to_string(xnn_operator_type_argmax_pooling_nhwc_f32), output_width, output_height, pooling_width, pooling_height);
+    return xnn_status_out_of_memory;
+  }
 
   // Allocate indirection buffer as size is known here. We initialize the buffer in setup, when input pointer is known.
   const void** indirection_buffer =

--- a/src/operators/average-pooling-nhwc.c
+++ b/src/operators/average-pooling-nhwc.c
@@ -429,17 +429,51 @@ static XNN_NO_SANITIZE_FUNCTION enum xnn_status reshape_average_pooling2d(
   const size_t output_width = average_pooling_op->convolution_op->output_width;
   const size_t pooling_height = average_pooling_op->convolution_op->kernel_height;
   const size_t pooling_width = average_pooling_op->convolution_op->kernel_width;
-  const size_t pooling_size = pooling_height * pooling_width;
+  size_t pooling_size = 0;
+  if (!xnn_safe_mul(pooling_height, pooling_width, &pooling_size)) {
+    xnn_log_error(
+        "failed to reshape %s operator: indirection buffer size overflows for "
+        "%zux%zu pooling size",
+        xnn_operator_type_to_string_v2(average_pooling_op), pooling_width,
+        pooling_height);
+    return xnn_status_out_of_memory;
+  }
 
   const size_t step_width = min(average_pooling_op->convolution_op->stride_width, pooling_width);
-  const size_t step_height = pooling_size + (output_width - 1) * step_width * pooling_height;
+  size_t step_height = 0;
+  size_t step_height_increment = 0;
+  if (!xnn_safe_mul(output_width - 1, step_width, &step_height_increment) ||
+      !xnn_safe_mul(step_height_increment, pooling_height,
+                    &step_height_increment) ||
+      !xnn_safe_add(pooling_size, step_height_increment, &step_height)) {
+    xnn_log_error(
+        "failed to reshape %s operator: indirection buffer size overflows for "
+        "%zux%zu output and %zux%zu pooling size",
+        xnn_operator_type_to_string_v2(average_pooling_op), output_width,
+        output_height, pooling_width, pooling_height);
+    return xnn_status_out_of_memory;
+  }
 
   const size_t indirect_top_height = divide_round_up(average_pooling_op->convolution_op->padding_top, average_pooling_op->convolution_op->stride_height);
   const size_t indirect_bot_height = divide_round_up(average_pooling_op->convolution_op->padding_bottom, average_pooling_op->convolution_op->stride_height);
 
   if (input_size_changed) {
     const size_t indirection_buffer_output_height = (indirect_top_height + indirect_bot_height + 1);
-    const size_t indirection_buffer_size = sizeof(void*) * ((pooling_size - 1) + indirection_buffer_output_height * step_height);
+    size_t indirection_buffer_elements = 0;
+    size_t indirection_buffer_size = 0;
+    if (!xnn_safe_mul(indirection_buffer_output_height, step_height,
+                      &indirection_buffer_elements) ||
+        !xnn_safe_add(pooling_size - 1, indirection_buffer_elements,
+                      &indirection_buffer_elements) ||
+        !xnn_safe_mul(indirection_buffer_elements, sizeof(void*),
+                      &indirection_buffer_size)) {
+      xnn_log_error(
+          "failed to reshape %s operator: indirection buffer size overflows "
+          "for %zux%zu output and %zux%zu pooling size",
+          xnn_operator_type_to_string_v2(average_pooling_op), output_width,
+          output_height, pooling_width, pooling_height);
+      return xnn_status_out_of_memory;
+    }
 
     const void** indirection_buffer =
       (const void**) xnn_reallocate_memory(average_pooling_op->convolution_op->indirection_buffer, indirection_buffer_size);


### PR DESCRIPTION
Following #10616, which guarded reshape_max_pooling2d_nhwc, I grepped for the same indirection sizing and found the identical arithmetic unguarded in two siblings:

    src/operators/average-pooling-nhwc.c:442
    src/operators/argmax-pooling-nhwc.c:250

Both compute the same quantities with plain size_t maths:

    step_height = pooling_size + (output_width - 1) * step_width * pooling_height
    indirection_buffer_size = sizeof(void*) * (... * step_height)

pooling_height/pooling_width are unbounded uint32 create params and output_width derives from the reshape input_width. Large shapes wrap the product, xnn_reallocate_memory hands back an undersized buffer, and xnn_indirection_init_* then writes output_height*step_height pointers past the end of it.

Routed pooling_size, step_height and the buffer size through xnn_safe_mul/xnn_safe_add and return xnn_status_out_of_memory on overflow, matching max pooling. The average-pooling pixelwise buffer uses a different formula and is left alone.