### PR TITLE
subgraph: fix swapped dims in xnn_shape_binary_broadcast

### DIFF
--- a/src/tensor.c
+++ b/src/tensor.c
@@ -757,10 +757,10 @@ enum xnn_status xnn_shape_binary_broadcast(const struct xnn_shape* shape_a,
          idx_c >= 0; idx_a--, idx_b--, idx_c--) {
       if (idx_a >= 0 && idx_b >= 0) {
         if (shape_a->dim[idx_a] == 1) {
-          shape_out->dim[idx_c] = shape_a->dim[idx_a];
+          shape_out->dim[idx_c] = shape_b->dim[idx_b];
         } else if (shape_b->dim[idx_b] == 1 ||
                    shape_a->dim[idx_a] == shape_b->dim[idx_b]) {
-          shape_out->dim[idx_c] = shape_b->dim[idx_b];
+          shape_out->dim[idx_c] = shape_a->dim[idx_a];
         } else {
           return xnn_status_invalid_parameter;
         }


### PR DESCRIPTION
### Problem
`xnn_shape_binary_broadcast` (`src/tensor.c`) computes a wrong output dimension whenever exactly one operand's dimension is 1: the broadcast dimension collapses to 1 instead of taking the partner's extent.

### Root cause
In the compatible-dims branch:
```c
if (shape_a->dim[idx_a] == 1) {
  shape_out->dim[idx_c] = shape_a->dim[idx_a];   // writes 1
} else if (shape_b->dim[idx_b] == 1 ||
           shape_a->dim[idx_a] == shape_b->dim[idx_b]) {
  shape_out->dim[idx_c] = shape_b->dim[idx_b];   // writes 1 in the b==1 case
}
```
Enumerating `(a, b)`: `(1, N)` → writes 1 (want `N`); `(M, 1)` → writes 1 (want `M`); `(M, M)` → `M`; `(1, 1)` → 1. So a genuine broadcast dimension collapses to 1; only equal dimensions survive. The two assignments are swapped relative to NumPy broadcasting.

This helper feeds the static-shape propagation for `xnn_node_type_binary_elementwise` in `optimize_common_subgraphs` (`src/subgraph.c:3749-3755`), so a broadcasting add/mul (e.g. `[N,1,C]` with `[N,H,C]`) is marked `XNN_VALUE_FLAG_SHAPE_IS_STATIC` with a collapsed output shape.

### Fix
Swap the two assignments so each branch emits the partner's extent, matching the `idx_a`-only / `idx_b`-only fallbacks just below (lines 768/770).

### Verification
Standalone reproduction of the per-dim logic:
```
a=1 b=5  want=5  buggy=1 WRONG  fixed=5 OK
a=5 b=1  want=5  buggy=1 WRONG  fixed=5 OK
a=5 b=5  want=5  buggy=5 OK     fixed=5 OK
a=1 b=1  want=1  buggy=1 OK     fixed=1 OK
```
Happy to add a subgraph test exercising a broadcasting binary op with static-shape inputs.
