### PR TITLE
subgraph/reduce: use bitmask test for NCHW output layout flag

### DIFF
--- a/src/subgraph/static-reduce.c
+++ b/src/subgraph/static-reduce.c
@@ -206,7 +206,7 @@ static enum xnn_status reshape_reduce_operator(
       if (input_value->flags & XNN_VALUE_FLAG_LAYOUT_NCHW) {
         mapped_input_idx = INVERSE_NCHW_AXES_MAPPING[input_idx];
       }
-      if (output_value->flags == XNN_VALUE_FLAG_LAYOUT_NCHW) {
+      if (output_value->flags & XNN_VALUE_FLAG_LAYOUT_NCHW) {
         mapped_output_idx = NCHW_AXES_MAPPING[mapped_input_idx];
       }
 


### PR DESCRIPTION
### Problem
In the non-keep-dims branch of `reshape_reduce_operator` (`src/subgraph/static-reduce.c`), the NCHW output-layout check uses exact equality instead of a bitmask test, so the NCHW output-axis remap is skipped in the common case and the reduced output shape is computed wrong.

### Root cause
Line 209:
```c
if (output_value->flags == XNN_VALUE_FLAG_LAYOUT_NCHW) {
```
An NCHW value normally carries additional flag bits (e.g. `XNN_VALUE_FLAG_ONE_CONSUMER`), so `flags == XNN_VALUE_FLAG_LAYOUT_NCHW` (0x800) is false. `mapped_output_idx` is then left unmapped, the reduction axis is matched against the wrong index, and `num_skip_axis` / the packed output dims come out wrong.

The sibling keep-dims branch (line 178) and the input-layout check two lines above in the same loop (line 206) both use `& XNN_VALUE_FLAG_LAYOUT_NCHW`, as does every other NCHW-layout check in the codebase.

### Fix
Use the bitmask test, matching the sibling checks.

### Verification
Static; consistency with the sibling `&` checks in the same function (no bazel build available on my machine). Happy to add/point at a test for an NCHW `keep_dims=false` reduce.
