### PR TITLE
subgraph: initialize status to avoid returning an uninitialized value

### DIFF
--- a/src/subgraph/concatenate.c
+++ b/src/subgraph/concatenate.c
@@ -46,7 +46,7 @@ static enum xnn_status create_concatenate_operator(
   xnn_weights_cache_t weights_cache)
 {
   size_t num_inputs = opdata->num_inputs;
-  enum xnn_status status;
+  enum xnn_status status = xnn_status_success;
   const int32_t axis = node->params.concatenate.axis;
   opdata->axis = axis;
   const uint32_t input1_id = opdata->inputs[0];

--- a/src/subgraph/even-split.c
+++ b/src/subgraph/even-split.c
@@ -63,7 +63,7 @@ static enum xnn_status create_even_split_operator(
   int operator_index = 0;
   const int32_t axis = node->params.even_split.axis;
   opdata->axis = axis;
-  enum xnn_status status;
+  enum xnn_status status = xnn_status_success;
   for (size_t i = 0; i < num_splits; ++i) {
     if (values[opdata->outputs[i]].type == xnn_value_type_invalid) continue;
     assert(operator_index < XNN_MAX_OPERATOR_OBJECTS);


### PR DESCRIPTION
### Problem
`create_concatenate_operator` and `create_even_split_operator` can return an **uninitialized** `enum xnn_status`.

### Root cause
Both declare `enum xnn_status status;` and assign it only inside a loop that can execute zero times, then `return status;` unconditionally:
- `concatenate.c` — the loop runs `for (i = 0; i < num_inputs; ++i)`; a 0-input concatenate node (definable via the public `xnn_define_concatenate` with `num_inputs == 0`, which `reshape_concatenate_operator` already treats as a valid no-op) skips the loop.
- `even-split.c` — the loop `continue`s past every output whose `type == xnn_value_type_invalid`; if all outputs are invalid, nothing is assigned.

The uninitialized value is then tested in `runtime.c` against `xnn_status_success` and can be treated as a spurious creation failure (undefined behavior regardless).

### Fix
Initialize both to `xnn_status_success`, matching the reshape/setup helpers in the same files (e.g. `reshape_even_split_operator`).

### Verification
Static reasoning; the zero-iteration paths are reachable as described. (No local XNNPACK build set up.)
