### PR TITLE
operators: clamp TF SAME padding to avoid unsigned underflow

### DIFF
--- a/src/operators/average-pooling-nhwc.c
+++ b/src/operators/average-pooling-nhwc.c
@@ -398,9 +398,9 @@ static XNN_NO_SANITIZE_FUNCTION enum xnn_status reshape_average_pooling2d(
     const uint32_t kernel_height = average_pooling_op->convolution_op->kernel_height;
     const uint32_t kernel_width = average_pooling_op->convolution_op->kernel_width;
     const uint32_t total_padding_height =
-      (average_pooling_op->convolution_op->output_height - 1) * average_pooling_op->convolution_op->stride_height + kernel_height - input_height;
+      doz((average_pooling_op->convolution_op->output_height - 1) * average_pooling_op->convolution_op->stride_height + kernel_height, input_height);
     const uint32_t total_padding_width =
-      (average_pooling_op->convolution_op->output_width - 1) * average_pooling_op->convolution_op->stride_width + kernel_width - input_width;
+      doz((average_pooling_op->convolution_op->output_width - 1) * average_pooling_op->convolution_op->stride_width + kernel_width, input_width);
     average_pooling_op->convolution_op->padding_top = total_padding_height / 2;
     average_pooling_op->convolution_op->padding_left = total_padding_width / 2;
     average_pooling_op->convolution_op->padding_bottom = total_padding_height - average_pooling_op->convolution_op->padding_top;

--- a/src/operators/convolution-nhwc.c
+++ b/src/operators/convolution-nhwc.c
@@ -3230,13 +3230,15 @@ static enum xnn_status reshape_convolution2d_nhwc(
             convolution_op->convolution_op->dilation_width +
         1;
     const size_t total_padding_height =
-        (convolution_op->convolution_op->output_height - 1) *
-            convolution_op->convolution_op->stride_height +
-        effective_kernel_height - input_height;
+        doz((convolution_op->convolution_op->output_height - 1) *
+                    convolution_op->convolution_op->stride_height +
+                effective_kernel_height,
+            input_height);
     const size_t total_padding_width =
-        (convolution_op->convolution_op->output_width - 1) *
-            convolution_op->convolution_op->stride_width +
-        effective_kernel_width - input_width;
+        doz((convolution_op->convolution_op->output_width - 1) *
+                    convolution_op->convolution_op->stride_width +
+                effective_kernel_width,
+            input_width);
     convolution_op->convolution_op->padding_top = total_padding_height / 2;
     convolution_op->convolution_op->padding_left = total_padding_width / 2;
     convolution_op->convolution_op->padding_bottom =


### PR DESCRIPTION
### Problem
`average-pooling-nhwc` and `convolution-nhwc` compute the TensorFlow SAME total padding with a raw subtraction that underflows.

### Root cause
```c
total_padding = (output - 1) * stride + effective_kernel - input;   // unsigned
```
When the effective kernel is smaller than the stride — e.g. a 1×1 convolution or a small pooling window with `stride > 1` — this expression is negative and wraps to a huge `size_t` / `uint32_t`, producing bogus `padding_top/left/bottom/right` (and a huge downstream size). `max-pooling-nhwc` already guards this with `doz()` (difference-or-zero, i.e. TF's `max(0, …)`); avg-pooling and convolution do not.

### Fix
Use `doz(...)` for the total padding in both, matching `max-pooling-nhwc`.

### Verification
Static reasoning + the `max-pooling-nhwc` sibling. Concretely, a stride-2 op with a 1×1 effective kernel and `input = 4` gives `output = 2` and `(2-1)*2 + 1 - 4 = -1` → wraps without the clamp. (No local XNNPACK build set up.)
