### PR TITLE
reject input channel mismatch in fully-connected reshape

### DIFF
--- a/src/subgraph/fully-connected-sparse.c
+++ b/src/subgraph/fully-connected-sparse.c
@@ -166,15 +166,21 @@ static enum xnn_status reshape_fully_connected_operator(
     return xnn_status_invalid_parameter;
   }
 
-  const size_t num_input_elements = xnn_shape_multiply_all_dims(&values[input_id].shape);
-  if (num_input_elements % input_channels != 0) {
+  const struct xnn_shape* input_shape = &values[input_id].shape;
+  if (input_shape->num_dims == 0 ||
+      input_shape->dim[input_shape->num_dims - 1] != input_channels) {
     xnn_log_error("failed to reshape %s operator with input ID #%" PRIu32
-                  ": number of input elements %zu is not divisible by "
+                  ": innermost input dimension %zu does not match the number of "
                   "input channels %zu",
                   xnn_node_type_to_string(xnn_node_type_fully_connected_sparse),
-                  input_id, num_input_elements, input_channels);
+                  input_id,
+                  input_shape->num_dims == 0
+                      ? 0
+                      : input_shape->dim[input_shape->num_dims - 1],
+                  input_channels);
     return xnn_status_invalid_parameter;
   }
+  const size_t num_input_elements = xnn_shape_multiply_all_dims(input_shape);
   const size_t batch_size = num_input_elements / input_channels;
   const size_t old_workspace_size = opdata->workspace_size;
   enum xnn_status status = xnn_status_invalid_state;

--- a/src/subgraph/fully-connected.c
+++ b/src/subgraph/fully-connected.c
@@ -973,12 +973,14 @@ static enum xnn_status reshape_fully_connected_operator(
     return xnn_status_invalid_parameter;
   }
 
-  if (num_input_elements % input_channels != 0) {
+  const size_t input_inner_dim =
+      input_value->shape.dim[input_value->shape.num_dims - 1];
+  if (input_inner_dim != input_channels) {
     xnn_log_error("failed to reshape %s operator with input ID #%" PRIu32
-                  ": number of input elements %zu is not divisible by "
+                  ": innermost input dimension %zu does not match the number of "
                   "input channels %zu",
                   xnn_node_type_to_string(xnn_node_type_fully_connected),
-                  input_id, num_input_elements, input_channels);
+                  input_id, input_inner_dim, input_channels);
     return xnn_status_invalid_parameter;
   }
   const size_t batch_size = num_input_elements / input_channels;

--- a/test/subgraph/fully-connected.cc
+++ b/test/subgraph/fully-connected.cc
@@ -863,4 +863,50 @@ TEST(FullyConnectedF32, zero_dim_input_rejected) {
   xnn_delete_subgraph(subgraph);
 }
 
+// Regression test: fully-connected reshape must reject an input whose innermost
+// dimension does not match the filter input channels. The batch size is derived
+// as num_input_elements / input_channels, so a mismatched innermost dimension
+// decouples it from the input batch dimensions. The dynamically-quantized
+// parameter buffer is sized from the input batch dimensions, so the larger
+// batch size over-indexes it at invoke time, reading out of bounds.
+TEST(FullyConnectedQD8F32QC8W, reshape_rejects_input_channel_mismatch) {
+  ASSERT_EQ(xnn_status_success, xnn_initialize(nullptr));
+  const size_t output_channels = 4;
+  const size_t input_channels = 2;
+  SubgraphTester subgraph(3);
+  const uint32_t input_id = 0, filter_id = 1, output_id = 2;
+  subgraph.AddInputTensor(2, xnn_datatype_fp32, input_id);
+  uint32_t fc_input_id = input_id;
+  subgraph.AddInternalDynamicallyQuantizedTensor(
+      2, xnn_datatype_qdint8, /*num_nonbatch_dims=*/1, &fc_input_id);
+  subgraph.AddConvert(input_id, fc_input_id);
+
+  Tensor<int8_t> filter({output_channels, input_channels}, XnnExtraBytes);
+  filter.fill(0);
+  Tensor<float> filter_scale({output_channels});
+  filter_scale.fill(1.0f);
+  subgraph.AddStaticChannelwiseQuantizedTensor(
+      {output_channels, input_channels}, /*channel_dim=*/0,
+      xnn_datatype_qcint8, filter_scale.base(), filter_id, /*flags=*/0,
+      filter.base());
+
+  subgraph.AddOutputTensor(2, xnn_datatype_fp32, output_id)
+      .AddFullyConnected(-std::numeric_limits<float>::infinity(),
+                         std::numeric_limits<float>::infinity(), fc_input_id,
+                         filter_id, XNN_INVALID_VALUE_ID, output_id);
+  const xnn_status create_status = subgraph.CreateRuntime();
+  if (create_status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+  ASSERT_EQ(xnn_status_success, create_status);
+
+  // Innermost input dimension (8) is a multiple of input_channels (2) but does
+  // not equal it, so the old divisibility check passed this shape through.
+  Tensor<float> input({1, 8}, XnnExtraBytes);
+  input.fill(0.0f);
+  subgraph.ReshapeExternalTensor({1, 8}, input.base(), input_id)
+      .ReshapeRuntime();
+  ASSERT_NE(xnn_status_success, subgraph.Status());
+}
+
 }  // namespace xnnpack


### PR DESCRIPTION
Reshaping an external qd8 input to `[1, 1000000]` against a filter with `input_channels` 1, then invoking:

    reshaping operator 0 (Fully Connected (NC, QP8, F32, QC8W))
    Tile size for GEMM with num_groups=1, m=1000000, n=4 and mr=16, nr=4
    Inlining LHS packing for Fully Connected with m=1000000, n=4, and k=1
    Requesting workspace of size 1 x 640 bytes for LHS packing
    reshape status=0   batch_size=1000000
    running operator 0:0 (Fully Connected (NC, QP8, F32, QC8W) GEMM)
    AddressSanitizer:DEADLYSIGNAL

`reshape_fully_connected_operator` derives the batch size as `num_input_elements / input_channels` and only checks that the two divide. `xnn_reshape_external_value` lets a caller reshape an external input to any shape at run time, so an input whose innermost dimension differs from `input_channels`, but whose element count stays divisible, is accepted. The batch size then decouples from the input's real batch dimensions: `resize_fully_connected_output_tensor` sizes the output from the input's leading dimensions while the operator runs `num_input_elements / input_channels` rows, and for a dynamically quantised input the per-batch quantisation parameters are sized from the input batch dimensions. Above, `[1, 1000000]` with `input_channels` 1 yields `batch_size` 1000000 against a single-row workspace, and the GEMM walks off both buffers (out-of-bounds read of the quantisation params and out-of-bounds write of the output).

The fix requires the innermost input dimension to equal `input_channels`, which every valid call already satisfies: a flattened `[.., IC]` input and a conv-style `[B, H, W, IC]` input both end in `IC`. The sparse fully-connected reshape shares `resize_fully_connected_output_tensor` and drives the nchw convolution output write off the same batch size, so it takes the same guard. Added a subgraph regression test that reshapes a mismatched innermost dimension and expects `xnn_status_invalid_parameter`.
