### PR TITLE
litert/tensor/arithmetic.h: bounds-check axis and index values before vector subscript

### DIFF
--- a/litert/tensor/arithmetic.h
+++ b/litert/tensor/arithmetic.h
@@ -589,6 +589,10 @@ Tensor<Mixins...> Pad(Tensor<Mixins...> a, Tensor<Mixins...> b,
   if (b_info.buffer) {
     const LockedBufferSpan<const int32_t> b_lock =
         b_info.buffer->Lock().As<const int32_t>();
+    if (b_lock.size() < 2 * o_info.shape.size()) {
+      return Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
+          "Padding buffer size must be at least 2 * input rank.")));
+    }
     const int32_t* b_data = b_lock.data();
     for (int i = 0; i < o_info.shape.size(); ++i) {
       o_info.shape[i] += b_data[i * 2] + b_data[i * 2 + 1];
@@ -617,6 +621,10 @@ Tensor<Mixins...> PadV2(Tensor<Mixins...> a, Tensor<Mixins...> b,
   if (b_info.buffer) {
     const LockedBufferSpan<const int32_t> b_lock =
         b_info.buffer->Lock().As<const int32_t>();
+    if (b_lock.size() < 2 * o_info.shape.size()) {
+      return Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
+          "Padding buffer size must be at least 2 * input rank.")));
+    }
     const int32_t* b_data = b_lock.data();
     for (int i = 0; i < o_info.shape.size(); ++i) {
       o_info.shape[i] += b_data[i * 2] + b_data[i * 2 + 1];
@@ -800,9 +808,19 @@ Tensor<Mixins...> Sum(Tensor<Mixins...> a, Tensor<Mixins...> b, bool keep_dims,
   if (op->keep_dims) {
     o_info.shape = a_info.shape;
     if (b_info.shape.empty()) {
+      if (b_data[0] < 0 ||
+          static_cast<size_t>(b_data[0]) >= o_info.shape.size()) {
+        return Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
+            "The reduction axis is out of range.")));
+      }
       o_info.shape.push_back(o_info.shape[b_data[0]]);
     } else {
       for (int i = 0; i < b_info.shape[0]; ++i) {
+        if (b_data[i] < 0 ||
+            static_cast<size_t>(b_data[i]) >= o_info.shape.size()) {
+          return Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
+              "The reduction axis is out of range.")));
+        }
         o_info.shape[b_data[i]] = 1;
       }
     }
@@ -860,9 +878,19 @@ Tensor<Mixins...> ReduceMax(Tensor<Mixins...> a, Tensor<Mixins...> b,
   if (op->keep_dims) {
     o_info.shape = a_info.shape;
     if (b_info.shape.empty()) {
+      if (b_data[0] < 0 ||
+          static_cast<size_t>(b_data[0]) >= o_info.shape.size()) {
+        return Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
+            "The reduction axis is out of range.")));
+      }
       o_info.shape.push_back(o_info.shape[b_data[0]]);
     } else {
       for (int i = 0; i < b_info.shape[0]; ++i) {
+        if (b_data[i] < 0 ||
+            static_cast<size_t>(b_data[i]) >= o_info.shape.size()) {
+          return Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
+              "The reduction axis is out of range.")));
+        }
         o_info.shape[b_data[i]] = 1;
       }
     }
@@ -919,9 +947,19 @@ Tensor<Mixins...> Mean(Tensor<Mixins...> a, Tensor<Mixins...> b, bool keep_dims,
   if (op->keep_dims) {
     o_info.shape = a_info.shape;
     if (b_info.shape.empty()) {
+      if (b_data[0] < 0 ||
+          static_cast<size_t>(b_data[0]) >= o_info.shape.size()) {
+        return Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
+            "The reduction axis is out of range.")));
+      }
       o_info.shape.push_back(o_info.shape[b_data[0]]);
     } else {
       for (int i = 0; i < b_info.shape[0]; ++i) {
+        if (b_data[i] < 0 ||
+            static_cast<size_t>(b_data[i]) >= o_info.shape.size()) {
+          return Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
+              "The reduction axis is out of range.")));
+        }
         o_info.shape[b_data[i]] = 1;
       }
     }
@@ -1374,6 +1412,10 @@ Tensor<Mixins...> Concatenation(
   graph::TensorInformation& output_info = *GetInfo(output.GetRaw());
   output_info.type = first_input_info.type;
   output_info.shape = first_input_info.shape;
+  if (axis < 0 || axis >= static_cast<int>(first_input_info.shape.size())) {
+    return Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
+        "The Concatenation axis is out of range.")));
+  }
   for (size_t i = 1; i < inputs.size(); ++i) {
     const graph::TensorInformation& input_info = *GetInfo(inputs[i].GetRaw());
     output_info.shape[axis] += input_info.shape[axis];
@@ -1587,8 +1629,17 @@ Tensor<Mixins...> Transpose(Tensor<Mixins...> input, Tensor<Mixins...> perm,
   if (perm_info.buffer) {
     const auto perm_data = perm_info.buffer->Lock().As<const int32_t>();
     const auto& input_shape = input_info.shape;
+    if (perm_data.size() != input_shape.size()) {
+      return Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
+          "Transpose permutation length must equal input rank.")));
+    }
     output_info.shape.resize(input_shape.size());
     for (size_t i = 0; i < perm_data.size(); ++i) {
+      if (perm_data.data()[i] < 0 ||
+          static_cast<size_t>(perm_data.data()[i]) >= input_shape.size()) {
+        return Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
+            "Transpose permutation value is out of range.")));
+      }
       output_info.shape[i] = input_shape[perm_data.data()[i]];
     }
   } else {


### PR DESCRIPTION
Addresses VRP report https://issuetracker.google.com/issues/533344097

Several graph-building functions in `litert/tensor/arithmetic.h` use axis values or buffer-derived indices as direct subscripts into heap-allocated `std::vector` shape vectors without validating that the values are within bounds. `std::vector::operator[]` is unchecked in release builds.

**Concatenation** — `axis` is passed directly by the caller and used as a subscript into the output and input shape vectors with no prior validation. A negative value implicitly casts to a SIZE_MAX-class `size_t`, directing the read and write gigabytes past the heap allocation.

**ReduceMax, Mean, Sum** — Each function reads axes from a tensor buffer as `int32_t` values and uses them directly as subscripts into the output shape vector (`o_info.shape[b_data[0]]`, `o_info.shape[b_data[i]]`). A value of -1 in the buffer becomes SIZE_MAX after the implicit cast to `size_t`.

**Transpose** — The permutation buffer is read as `int32_t` values and used to index into `input_shape` inside a loop. A negative permutation value produces a SIZE_MAX-class index. Additionally, if the permutation buffer contains more entries than the input rank, the loop writes to `output_info.shape[i]` beyond the resized vector length.

**Pad and PadV2** — The loop reads `b_data[i * 2]` and `b_data[i * 2 + 1]` for every dimension, but the buffer length is not checked against `2 * input_rank` before the loop. A buffer shorter than `2 * input_rank` elements causes reads past the buffer's allocation.

## Fix

Validate axis/index values against `[0, shape.size())` before any subscript, and return an `ErrorTensor` on failure. For Pad and PadV2, confirm the locked buffer holds at least `2 * o_info.shape.size()` elements before entering the loop.

This follows the same pattern introduced in #10464 for `ExpandDims`, `Pack`, and `OneHot`.

## Affected functions

| Function | Issue | Fixed |
|---|---|---|
| `Concatenation` | `axis` unchecked before `shape[axis]` | ✓ |
| `ReduceMax` | `b_data[0]` / `b_data[i]` unchecked before `shape[b_data[*]]` | ✓ |
| `Mean` | same as ReduceMax | ✓ |
| `Sum` | same as ReduceMax | ✓ |
| `Transpose` | `perm_data[i]` unchecked; perm length vs input rank unchecked | ✓ |
| `Pad` | buffer length not checked against `2 * input_rank` before loop | ✓ |
| `PadV2` | same as Pad | ✓ |

## Precedent

PR #10464 ("Bounds-check data-derived axes and quantization params in tensor builder", merged 2026-07-02) fixed the same bug class in `ExpandDims`, `Pack`, and `OneHot` in the same file. The fix here applies the identical pattern to the remaining unchecked functions.