### PR TITLE
Fix LUT fusion treating an already-fused LUT node as a plain unary op

### DIFF
--- a/src/subgraph.c
+++ b/src/subgraph.c
@@ -1790,7 +1790,6 @@ static uint32_t is_pure_unary_elementwise(xnn_subgraph_t subgraph,
                                           uint32_t num_unary_values) {
   switch (node->type) {
     case xnn_node_type_unary_elementwise:
-      assert(node->num_inputs >= 1);
       // A pure unary elementwise function takes exactly one tensor input and
       // must have a valid operator. A node already fused into a LUT by this
       // same pass (see `xnn_define_unary_elementwise_lut_in_place`) has 2
@@ -1800,6 +1799,7 @@ static uint32_t is_pure_unary_elementwise(xnn_subgraph_t subgraph,
       if (node->num_inputs != 1 || node->unary_operator == xnn_unary_invalid) {
         return XNN_INVALID_VALUE_ID;
       }
+      assert(node->num_inputs >= 1);
       return node->inputs[0];
     case xnn_node_type_binary_elementwise: {
       const uint32_t input_0_id = node->inputs[0];

--- a/src/subgraph.c
+++ b/src/subgraph.c
@@ -1791,6 +1791,15 @@ static uint32_t is_pure_unary_elementwise(xnn_subgraph_t subgraph,
   switch (node->type) {
     case xnn_node_type_unary_elementwise:
       assert(node->num_inputs >= 1);
+      // A pure unary elementwise function takes exactly one tensor input and
+      // must have a valid operator. A node already fused into a LUT by this
+      // same pass (see `xnn_define_unary_elementwise_lut_in_place`) has 2
+      // inputs (the tensor and the LUT table) and
+      // `unary_operator == xnn_unary_invalid`; it isn't safe to treat that as
+      // a plain unary function and fuse it into another LUT.
+      if (node->num_inputs != 1 || node->unary_operator == xnn_unary_invalid) {
+        return XNN_INVALID_VALUE_ID;
+      }
       return node->inputs[0];
     case xnn_node_type_binary_elementwise: {
       const uint32_t input_0_id = node->inputs[0];


### PR DESCRIPTION
`is_pure_unary_elementwise` treated any `xnn_node_type_unary_elementwise`
node as a plain single-input op, reading `inputs[0]` unconditionally.
But a node already fused into a LUT (via
`xnn_define_unary_elementwise_lut_in_place`) has `num_inputs == 2`
(tensor + LUT table) and `unary_operator == xnn_unary_invalid`. If the
fusion pass reaches that node again — the outer loop in
`xnn_subgraph_fuse_unary_quantized_into_lut` can revisit the same slot
within a single pass, and `xnn_subgraph_optimize` can also be called
more than once on the same subgraph — it would misinterpret the LUT
node as an ordinary unary op and try to fuse it again.
