### PR TITLE
unpooling: guard indirection buffer size computation against integer overflow

### DIFF
--- a/src/operators/unpooling-nhwc.c
+++ b/src/operators/unpooling-nhwc.c
@@ -215,9 +215,22 @@ enum xnn_status xnn_reshape_unpooling2d_nhwc_x32(
 
   const size_t pooling_height = unpooling_op->convolution_op->kernel_height;
   const size_t pooling_width = unpooling_op->convolution_op->kernel_width;
-  const size_t pooling_size = pooling_height * pooling_width;
+  size_t pooling_size = 0;
+  if (!xnn_safe_mul(pooling_height, pooling_width, &pooling_size)) {
+    xnn_log_error("failed to reshape %s operator: kernel size overflows size_t",
+      xnn_operator_type_to_string(xnn_operator_type_unpooling_nhwc_x32));
+    return xnn_status_out_of_memory;
+  }
 
-  const size_t indirection_buffer_size = sizeof(void*) * (batch_size * input_height * input_width * pooling_size);
+  size_t indirection_buffer_size = 0;
+  if (!xnn_safe_mul(batch_size, input_height, &indirection_buffer_size) ||
+      !xnn_safe_mul(indirection_buffer_size, input_width, &indirection_buffer_size) ||
+      !xnn_safe_mul(indirection_buffer_size, pooling_size, &indirection_buffer_size) ||
+      !xnn_safe_mul(indirection_buffer_size, sizeof(void*), &indirection_buffer_size)) {
+    xnn_log_error("failed to reshape %s operator: indirection buffer size overflows size_t",
+      xnn_operator_type_to_string(xnn_operator_type_unpooling_nhwc_x32));
+    return xnn_status_out_of_memory;
+  }
   const void** indirection_buffer = (const void**) xnn_reallocate_memory(unpooling_op->convolution_op->indirection_buffer, indirection_buffer_size);
   if (indirection_buffer == NULL) {
     xnn_log_error(


### PR DESCRIPTION
`xnn_reshape_unpooling2d_nhwc_x32` computed the indirection buffer size with a raw five-factor multiplication — `sizeof(void*) * batch_size * input_height * input_width * pooling_size` — with no overflow guard. When caller-supplied dimensions are large, the product silently wraps to a value far smaller than required. `xnn_reallocate_memory` returns a valid pointer to an undersized buffer, and `xnn_indirection_init_unpool2d` then writes the full (attacker-controlled) number of pointer entries out of bounds.

**Concrete overflow (64-bit, 2×2 pool):**
```
batch_size=1<<20, input_height=1<<20, input_width=1<<20, pooling_size=4
8 * (2^20 * 2^20 * 2^20 * 4) = 8 * 2^62 = 2^65 mod 2^64 = 0
```
`xnn_reallocate_memory(ptr, 0)` under glibc returns a non-NULL zero-byte allocation. `xnn_indirection_init_unpool2d` then writes 2^62 pointer-sized entries out of bounds.

**Fix:** replace the raw multiplication with chained `xnn_safe_mul` calls, matching the pattern already used in `argmax-pooling-nhwc.c` and `average-pooling-nhwc.c` after PR #10646.