### PR TITLE
litert/tensor/arithmetic.h: bounds-check axis in Split/Unpack and rank in Tile

### DIFF
--- a/litert/tensor/arithmetic.h
+++ b/litert/tensor/arithmetic.h
@@ -1429,6 +1429,10 @@ std::vector<Tensor<Mixins...>> Unpack(
   std::vector<Tensor<Mixins...>> outputs;
   outputs.reserve(num);
   const graph::TensorInformation& input_info = GetInfo(input.GetRaw()).value();
+  if (axis < 0 || axis >= static_cast<int>(input_info.shape.size())) {
+    return {Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
+        "The Unpack axis is out of range.")))};
+  }
   std::vector<int> output_shape = input_info.shape;
   output_shape.erase(output_shape.begin() + axis);
   for (int i = 0; i < num; ++i) {
@@ -1469,6 +1473,11 @@ std::vector<Tensor<Mixins...>> Split(
 
   if (axis_val < 0) {
     axis_val += input_info.shape.size();
+  }
+
+  if (axis_val < 0 || static_cast<size_t>(axis_val) >= input_info.shape.size()) {
+    return {Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
+        "The Split axis is out of range.")))};
   }
 
   if (input_info.shape[axis_val] % num_splits != 0) {
@@ -1646,6 +1655,10 @@ Tensor<Mixins...> Tile(Tensor<Mixins...> input, Tensor<Mixins...> multiples,
         multiples_info.buffer->Lock().As<const int32_t>();
     const auto& input_shape = input_info.shape;
     output_info.shape.resize(input_shape.size());
+    if (multiples_data.size() != input_shape.size()) {
+      return Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
+          "Tile multiples length must equal input rank.")));
+    }
     for (size_t i = 0; i < multiples_data.size(); ++i) {
       output_info.shape[i] = input_shape[i] * multiples_data.data()[i];
     }


### PR DESCRIPTION
Three shape-inference functions in `litert/tensor/arithmetic.h` use attacker-controlled values as unchecked subscripts into heap-allocated shape vectors.

**Split** — after negative-axis normalization, `axis_val` is used as `input_info.shape[axis_val]` (OOB read) and `output_shape[axis_val] /= num_splits` (OOB write) without checking `axis_val < input_info.shape.size()`.

**Unpack** — `axis` is passed directly to `output_shape.erase(output_shape.begin() + axis)` with no range check. An out-of-range iterator to `erase()` is UB that corrupts the heap. The sibling `Pack()` already validates its axis (PR #10464); this aligns `Unpack` to the same pattern.

**Tile** — `output_info.shape` is resized to `input_shape.size()` (N elements) but the fill loop iterates `multiples_data.size()` (M) times. When M > N the loop writes `output_info.shape[i]` and reads `input_shape[i]` for `i >= N`, both past the end of their heap-allocated vectors.

Fixes follow the same error-return pattern used in PR #10464 and PR #10702.