### PR TITLE
litert/arithmetic: add axis bounds check in Unpack()

### DIFF
--- a/litert/tensor/arithmetic.h
+++ b/litert/tensor/arithmetic.h
@@ -1442,6 +1442,10 @@ std::vector<Tensor<Mixins...>> Unpack(
   std::vector<Tensor<Mixins...>> outputs;
   outputs.reserve(num);
   const graph::TensorInformation& input_info = GetInfo(input.GetRaw()).value();
+  if (axis < 0 || axis >= static_cast<int>(input_info.shape.size())) {
+    return {Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
+        "The Unpack axis is out of range.")))};
+  }
   std::vector<int> output_shape = input_info.shape;
   output_shape.erase(output_shape.begin() + axis);
   for (int i = 0; i < num; ++i) {


### PR DESCRIPTION
`Unpack()` in `litert/tensor/arithmetic.h` passes the `axis` parameter directly to `std::vector::erase()` without validating it is within `[0, input_rank)`. An out-of-bounds iterator passed to `erase()` is undefined behaviour per the C++ standard; in practice on glibc and libc++ it corrupts adjacent heap memory.

The sibling `Pack()` function (fixed in #10464) already has the equivalent guard:

```cpp
if (axis < 0 || axis > static_cast<int>(first_input_info.shape.size())) {
    return Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
        "The Pack axis is out of range.")));
}
```

This PR adds the same check to `Unpack()` using the identical pattern.

**Before:**
```cpp
std::vector<int> output_shape = input_info.shape;
output_shape.erase(output_shape.begin() + axis);  // no bounds check
```

**After:**
```cpp
if (axis < 0 || axis >= static_cast<int>(input_info.shape.size())) {
  return {Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
      "The Unpack axis is out of range.")))};
}
std::vector<int> output_shape = input_info.shape;
output_shape.erase(output_shape.begin() + axis);
```