### PR TITLE
litert/tensor/arithmetic.h: bounds-check multiples length in Tile()

### DIFF
--- a/litert/tensor/arithmetic.h
+++ b/litert/tensor/arithmetic.h
@@ -1715,6 +1715,10 @@ Tensor<Mixins...> Tile(Tensor<Mixins...> input, Tensor<Mixins...> multiples,
     const auto multiples_data =
         multiples_info.buffer->Lock().As<const int32_t>();
     const auto& input_shape = input_info.shape;
+    if (multiples_data.size() != input_shape.size()) {
+      return Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
+          "Tile multiples length must equal input rank.")));
+    }
     output_info.shape.resize(input_shape.size());
     for (size_t i = 0; i < multiples_data.size(); ++i) {
       output_info.shape[i] = input_shape[i] * multiples_data.data()[i];


### PR DESCRIPTION
## Summary

`Tile()` resized `output_info.shape` to `input_shape.size()` (N elements) but iterated `multiples_data.size()` (M) times. When M > N, `output_info.shape[i]` and `input_shape[i]` are both accessed out-of-bounds - a heap OOB write and OOB read on separate `std::vector<int>` allocations.

This adds a length equality check before the loop, matching the pattern already used in `Transpose()` (added in #10702):

```cpp
if (multiples_data.size() != input_shape.size()) {
  return Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
      "Tile multiples length must equal input rank.")));
}
```

## Root cause

`Tile()` was introduced in #10464. `Transpose()` received the equivalent rank-equality guard in #10702 but `Tile()` did not.

## Impact

A crafted LiteRT model with a `Tile` op whose multiples tensor has more elements than the input tensor's rank triggers the OOB accesses during graph construction. The number of out-of-bounds writes is `M - N`, fully attacker-controlled.