### PR TITLE
[RVV]: Add RVV x32-unpool microkernel and benchmark

### DIFF
--- a/bench/BUILD.bazel
+++ b/bench/BUILD.bazel
@@ -559,3 +559,11 @@ xnnpack_benchmark(
         ":packw_benchmark",
     ],
 )
+
+xnnpack_benchmark(
+    name = "x32_unpool_bench",
+    srcs = [
+        "x32-unpool.cc",
+    ],
+    deps = MICROKERNEL_BENCHMARK_DEPS
+)

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -100,6 +100,7 @@ SET(MICROKERNEL_BENCHMARKS
     spmm
     x16-packw
     x32-packw
+    x32-unpool
     x8-lut
     x8-packq
     x8-packw

--- a/bench/x32-unpool.cc
+++ b/bench/x32-unpool.cc
@@ -1,0 +1,166 @@
+// Copyright 2026 Léandre Le Duc
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <benchmark/benchmark.h>
+#include <src/xnnpack/hardware-config.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <random>
+
+#include "bench/utils.h"
+#include "src/xnnpack/buffer.h"
+#include "src/xnnpack/common.h"
+#include "src/xnnpack/indirection.h"
+#include "src/xnnpack/microfnptr.h"
+#include "src/xnnpack/unpool.h"
+#include "test/replicable_random_device.h"
+
+static void x32_unpool(benchmark::State& state,
+                       xnn_x32_unpool_ukernel_fn unpool,
+                       uint64_t arch_flags = 0) {
+  if (!benchmark::utils::CheckArchFlags(state, arch_flags)) {
+    return;
+  }
+
+  const size_t input_width = state.range(0);
+  const size_t input_height = state.range(1);
+  const size_t channels = state.range(2);
+  const size_t pooling_width = state.range(3);
+  const size_t pooling_height = state.range(4);
+
+  const size_t pooling_size = pooling_height * pooling_width;
+
+  // Unpadded unpooling expands each input pixel into a whole pooling window.
+  const size_t output_height = input_height * pooling_height;
+  const size_t output_width = input_width * pooling_width;
+
+  const size_t input_pixels = input_height * input_width;
+  const size_t output_pixels = output_height * output_width;
+
+  const size_t input_elements = channels * input_pixels;
+  const size_t output_elements = channels * output_pixels;
+  // One argmax index per input element, and one output pointer per pooling
+  // window position.
+  const size_t index_elements = input_elements;
+  const size_t indirection_elements = input_pixels * pooling_size;
+
+  xnnpack::ReplicableRandomDevice rng;
+
+  const size_t num_buffers =
+      1 + benchmark::utils::DivideRoundUp<size_t>(
+              benchmark::utils::GetMaxCacheSize(),
+              sizeof(uint32_t) *
+                      (input_elements + output_elements + index_elements) +
+                  sizeof(void*) * indirection_elements);
+
+  xnnpack::Buffer<uint32_t, XNN_ALLOCATION_ALIGNMENT> input(input_elements *
+                                                            num_buffers);
+  xnnpack::Buffer<uint32_t, XNN_ALLOCATION_ALIGNMENT> output(output_elements *
+                                                             num_buffers);
+  xnnpack::Buffer<uint32_t> index(index_elements * num_buffers);
+  xnnpack::Buffer<uint32_t*> indirection(indirection_elements * num_buffers);
+
+  xnnpack::fill_uniform_random_bits(input.data(), input.size(), rng);
+
+  // The indices are the argmax positions produced by the forward max-pooling
+  // pass, so each one selects a position inside its own pooling window.
+  std::uniform_int_distribution<uint32_t> index_dist(
+      0, static_cast<uint32_t>(pooling_size - 1));
+  for (size_t n = 0; n < index.size(); n++) {
+    index[n] = index_dist(rng);
+  }
+
+  // Build the output pointers with the operator's own code: the ordering it
+  // produces is what the kernel actually walks.
+  for (size_t n = 0; n < num_buffers; n++) {
+    xnn_indirection_init_unpool2d(
+        reinterpret_cast<const void**>(
+            (uintptr_t*)(indirection.data() + n * indirection_elements)),
+        output.data() + n * output_elements,
+        /*output_pixel_stride=*/channels * sizeof(uint32_t),
+        /*batch_size=*/1, input_height, input_width, output_height,
+        output_width, pooling_height, pooling_width, /*output_padding_top=*/0,
+        /*output_padding_left=*/0, /*batch_start=*/0);
+  }
+
+  size_t buffer_index = 0;
+  for (auto _ : state) {
+    buffer_index = (buffer_index + 1) % num_buffers;
+
+    const uint32_t* i = input.data() + buffer_index * input_elements;
+    const uint32_t* idx = index.data() + buffer_index * index_elements;
+    uint32_t** o = indirection.data() + buffer_index * indirection_elements;
+
+    // The microkernel handles a single input pixel per call.
+    for (size_t p = input_pixels; p != 0; p--) {
+      unpool(pooling_size, channels, /*fill=*/0, i, idx, o);
+      i += channels;
+      idx += channels;
+      o += pooling_size;
+    }
+  }
+
+  const uint64_t cpu_frequency = benchmark::utils::GetCurrentCpuFrequency();
+  if (cpu_frequency != 0) {
+    state.counters["cpufreq"] = cpu_frequency;
+  }
+
+  state.counters["elements"] =
+      benchmark::Counter(static_cast<double>(state.iterations()) *
+                             static_cast<double>(output_elements),
+                         benchmark::Counter::kIsRate);
+
+  // output is written once, input, indices and
+  // output pointers are each streamed once.
+  state.counters["bytes"] = benchmark::Counter(
+      static_cast<double>(state.iterations()) *
+          static_cast<double>(
+              (input_elements + index_elements + output_elements) *
+                  sizeof(uint32_t) +
+              indirection_elements * sizeof(void*)),
+      benchmark::Counter::kIsRate);
+}
+
+// {InW, InH, C, PoolW, PoolH}.
+static void UnpoolArguments(benchmark::Benchmark* b) {
+  b->ArgNames({"InW", "InH", "C", "PoolW", "PoolH"});
+  // SegNet-style decoder stages, 2x2 max-unpooling.
+  b->Args({7, 7, 512, 2, 2});
+  b->Args({14, 14, 512, 2, 2});
+  b->Args({28, 28, 256, 2, 2});
+  b->Args({56, 56, 128, 2, 2});
+  b->Args({112, 112, 64, 2, 2});
+  // Wider window, to shift the fill/scatter ratio.
+  b->Args({28, 28, 256, 3, 3});
+}
+
+#define BENCHMARK_UNPOOL(name, arch_flags)                            \
+  BENCHMARK_CAPTURE(x32_unpool, name, xnn_x32_unpool_ukernel__##name, \
+                    arch_flags)                                       \
+      ->Apply(UnpoolArguments)                                        \
+      ->UseRealTime();
+
+BENCHMARK_UNPOOL(scalar, 0);
+
+#if XNN_ARCH_WASMRELAXEDSIMD || XNN_ARCH_WASMSIMD
+BENCHMARK_UNPOOL(wasmsimd, 0);
+#endif
+
+#if XNN_ARCH_ARM || XNN_ARCH_ARM64
+BENCHMARK_UNPOOL(neon, xnn_arch_arm_neon);
+#endif
+
+#if (XNN_ARCH_X86 || XNN_ARCH_X86_64) && XNN_ENABLE_SSE
+BENCHMARK_UNPOOL(sse2, xnn_arch_x86_sse2);
+#endif
+
+#if XNN_ARCH_RISCV && XNN_ENABLE_RISCV_VECTOR
+BENCHMARK_UNPOOL(rvv, xnn_arch_riscv_vector);
+#endif
+
+#ifndef XNNPACK_BENCHMARK_NO_MAIN
+XNN_BENCHMARK_MAIN();
+#endif

--- a/cmake/gen/rvv_microkernels.cmake
+++ b/cmake/gen/rvv_microkernels.cmake
@@ -146,7 +146,8 @@ SET(PROD_RVV_MICROKERNEL_SRCS
   src/x32-transposec/gen/x32-transposec-4x4-rvv.c
   src/x32-transposec/gen/x32-transposec-8x8-rvv.c
   src/x32-transposec/gen/x32-transposec-16x8-rvv.c
-  src/x32-transposec/gen/x32-transposec-32x8-rvv.c)
+  src/x32-transposec/gen/x32-transposec-32x8-rvv.c
+  src/x32-unpool/x32-unpool-rvv.c)
 
 SET(NON_PROD_RVV_MICROKERNEL_SRCS
   src/f32-conv-hwc2chw/f32-conv-hwc2chw-3x3s2p1c3x2v-rvv-1x1.c

--- a/gen/rvv_microkernels.bzl
+++ b/gen/rvv_microkernels.bzl
@@ -143,6 +143,7 @@ PROD_RVV_MICROKERNEL_SRCS = [
     "src/x32-transposec/gen/x32-transposec-8x8-rvv.c",
     "src/x32-transposec/gen/x32-transposec-16x8-rvv.c",
     "src/x32-transposec/gen/x32-transposec-32x8-rvv.c",
+    "src/x32-unpool/x32-unpool-rvv.c",
 ]
 
 NON_PROD_RVV_MICROKERNEL_SRCS = [

--- a/src/configs/unpool-config.c
+++ b/src/configs/unpool-config.c
@@ -49,6 +49,8 @@ static void init_x32_unpool_config(void) {
     }
   #elif XNN_ARCH_WASMSIMD || XNN_ARCH_WASMRELAXEDSIMD
     x32_unpool_config.unpool = XNN_INIT_UNPOOL_UKERNEL(xnn_x32_unpool_ukernel__wasmsimd);
+  #elif XNN_ENABLE_RISCV_VECTOR && XNN_ARCH_RISCV
+    x32_unpool_config.unpool = XNN_INIT_UNPOOL_UKERNEL(xnn_x32_unpool_ukernel__rvv);
   #else
     x32_unpool_config.unpool = XNN_INIT_UNPOOL_UKERNEL(xnn_x32_unpool_ukernel__scalar);
   #endif

--- a/src/x32-unpool/x32-unpool-rvv.c
+++ b/src/x32-unpool/x32-unpool-rvv.c
@@ -1,0 +1,41 @@
+// Copyright 2026 Léandre Le Duc
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+#include <riscv_vector.h>
+
+#include "src/xnnpack/unpool.h"
+
+void xnn_x32_unpool_ukernel__rvv(size_t kernel_elements, size_t channels,
+                                 uint32_t fill, const uint32_t* input,
+                                 const uint32_t* index, uint32_t** output) {
+  uint32_t** os = output;
+
+  do {
+    --kernel_elements;
+
+    uint32_t* o = os[kernel_elements];
+    const uint32_t* in = input;
+    const uint32_t* idx = index;
+    size_t c = channels;
+
+    for (size_t vl; c > 0; c -= vl, in += vl, idx += vl, o += vl) {
+      vl = __riscv_vsetvl_e32m1(c);
+      vuint32m1_t vval = __riscv_vle32_v_u32m1(in, vl);
+      vuint32m1_t vidx = __riscv_vle32_v_u32m1(idx, vl);
+
+      vuint32m1_t vfill = __riscv_vmv_v_x_u32m1(fill, vl);
+
+      // Construct the a fill mask based on the vl equality
+      vbool32_t m = __riscv_vmseq_vx_u32m1_b32(vidx, kernel_elements, vl);
+
+      // Final value by mask filling
+      vuint32m1_t vfinal = __riscv_vmerge_vvm_u32m1(vfill, vval, m, vl);
+
+      // Store the final value
+      __riscv_vse32_v_u32m1(o, vfinal, vl);
+    }
+  } while (kernel_elements > 0);
+}

--- a/src/xnnpack/unpool.h
+++ b/src/xnnpack/unpool.h
@@ -22,6 +22,7 @@ extern "C" {
 
 DECLARE_X32_UNPOOL_UKERNEL_FUNCTION(xnn_x32_unpool_ukernel__neon)
 DECLARE_X32_UNPOOL_UKERNEL_FUNCTION(xnn_x32_unpool_ukernel__scalar)
+DECLARE_X32_UNPOOL_UKERNEL_FUNCTION(xnn_x32_unpool_ukernel__rvv)
 DECLARE_X32_UNPOOL_UKERNEL_FUNCTION(xnn_x32_unpool_ukernel__sse2)
 DECLARE_X32_UNPOOL_UKERNEL_FUNCTION(xnn_x32_unpool_ukernel__wasmsimd)
 

--- a/test/x32-unpool.cc
+++ b/test/x32-unpool.cc
@@ -166,6 +166,62 @@ TEST(X32_UNPOOL__WASMSIMD, y_stride) {
 }
 #endif  // XNN_ARCH_WASMSIMD
 
+#if XNN_ENABLE_RISCV_VECTOR && XNN_ARCH_RISCV
+TEST(X32_UNPOOL__RISCV, c_eq_4) {
+  TEST_REQUIRES_ARCH_FLAGS(xnn_arch_riscv_vector);
+  UnpoolMicrokernelTester().p(10).c(4).Test(xnn_x32_unpool_ukernel__rvv);
+}
+
+TEST(X32_UNPOOL__RISCV, c_div_4) {
+  TEST_REQUIRES_ARCH_FLAGS(xnn_arch_riscv_vector);
+  for (size_t c = 8; c < 32; c += 4) {
+    UnpoolMicrokernelTester().p(10).c(c).Test(xnn_x32_unpool_ukernel__rvv);
+  }
+}
+
+TEST(X32_UNPOOL__RISCV, c_lt_4) {
+  TEST_REQUIRES_ARCH_FLAGS(xnn_arch_riscv_vector);
+  for (size_t c = 1; c < 4; c++) {
+    UnpoolMicrokernelTester().p(10).c(c).Test(xnn_x32_unpool_ukernel__rvv);
+  }
+}
+
+TEST(X32_UNPOOL__RISCV, c_gt_4) {
+  TEST_REQUIRES_ARCH_FLAGS(xnn_arch_riscv_vector);
+  for (size_t c = 5; c < 8; c++) {
+    UnpoolMicrokernelTester().p(10).c(4).Test(xnn_x32_unpool_ukernel__rvv);
+  }
+}
+
+TEST(X32_UNPOOL__RISCV, varying_p) {
+  TEST_REQUIRES_ARCH_FLAGS(xnn_arch_riscv_vector);
+  for (size_t p = 1; p < 20; p += 3) {
+    for (size_t c = 1; c < 32; c += 5) {
+      UnpoolMicrokernelTester().p(p).c(c).Test(xnn_x32_unpool_ukernel__rvv);
+    }
+  }
+}
+
+TEST(X32_UNPOOL__RISCV, varying_f) {
+  TEST_REQUIRES_ARCH_FLAGS(xnn_arch_riscv_vector);
+  for (size_t c = 1; c < 32; c += 5) {
+    UnpoolMicrokernelTester()
+        .p(10)
+        .c(c)
+        .f(0xDEADBEAF)
+        .Test(xnn_x32_unpool_ukernel__rvv);
+  }
+}
+
+TEST(X32_UNPOOL__RISCV, y_stride) {
+  TEST_REQUIRES_ARCH_FLAGS(xnn_arch_riscv_vector);
+  for (size_t c = 1; c < 32; c += 5) {
+    UnpoolMicrokernelTester().p(10).c(c).y_stride(c * 2 + 7).Test(
+        xnn_x32_unpool_ukernel__rvv);
+  }
+}
+#endif  // XNN_ARCH_RISCV
+
 TEST(X32_UNPOOL__SCALAR, c_eq_1) {
   UnpoolMicrokernelTester().p(10).c(1).Test(xnn_x32_unpool_ukernel__scalar);
 }

--- a/test/x32-unpool.cc
+++ b/test/x32-unpool.cc
@@ -3,9 +3,10 @@
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
 
+#include <gtest/gtest.h>
+
 #include <cstddef>
 
-#include <gtest/gtest.h>
 #include "src/xnnpack/common.h"
 #include "src/xnnpack/isa-checks.h"
 #include "src/xnnpack/unpool.h"
@@ -34,7 +35,7 @@ TEST(X32_UNPOOL__NEON, c_lt_4) {
 TEST(X32_UNPOOL__NEON, c_gt_4) {
   TEST_REQUIRES_ARCH_FLAGS(xnn_arch_arm_neon);
   for (size_t c = 5; c < 8; c++) {
-    UnpoolMicrokernelTester().p(10).c(4).Test(xnn_x32_unpool_ukernel__neon);
+    UnpoolMicrokernelTester().p(10).c(c).Test(xnn_x32_unpool_ukernel__neon);
   }
 }
 
@@ -86,7 +87,7 @@ TEST(X32_UNPOOL__SSE2, c_lt_4) {
 
 TEST(X32_UNPOOL__SSE2, c_gt_4) {
   for (size_t c = 5; c < 8; c++) {
-    UnpoolMicrokernelTester().p(10).c(4).Test(xnn_x32_unpool_ukernel__sse2);
+    UnpoolMicrokernelTester().p(10).c(c).Test(xnn_x32_unpool_ukernel__sse2);
   }
 }
 
@@ -135,7 +136,7 @@ TEST(X32_UNPOOL__WASMSIMD, c_lt_4) {
 
 TEST(X32_UNPOOL__WASMSIMD, c_gt_4) {
   for (size_t c = 5; c < 8; c++) {
-    UnpoolMicrokernelTester().p(10).c(4).Test(xnn_x32_unpool_ukernel__wasmsimd);
+    UnpoolMicrokernelTester().p(10).c(c).Test(xnn_x32_unpool_ukernel__wasmsimd);
   }
 }
 
@@ -189,7 +190,7 @@ TEST(X32_UNPOOL__RISCV, c_lt_4) {
 TEST(X32_UNPOOL__RISCV, c_gt_4) {
   TEST_REQUIRES_ARCH_FLAGS(xnn_arch_riscv_vector);
   for (size_t c = 5; c < 8; c++) {
-    UnpoolMicrokernelTester().p(10).c(4).Test(xnn_x32_unpool_ukernel__rvv);
+    UnpoolMicrokernelTester().p(10).c(c).Test(xnn_x32_unpool_ukernel__rvv);
   }
 }
 


### PR DESCRIPTION
Adds an RVV implementation of the `x32-unpool` microkernel, plus a benchmark for it.

The kernel does one pass per output pointer and selects fill-or-input per lane
with a mask compare, instead of the scalar kernel's fill-then-scatter. Indices
that match no pass stay filled, matching scalar semantics. Wired into
`unpool-config.c` and covered by the existing `x32-unpool` tests.

`bench/x32-unpool.cc` is new: it was needed to measure this, and there was no
unpool benchmark before.

Measured on a K230 (C908, VLEN=128), `--benchmark_repetitions=3`, mean throughput:

| InW×InH / C / Pool | scalar | rvv | speedup |
|---|---|---|---|
| 7×7 / 512 / 2×2     | 0.67 GB/s | 3.01 GB/s | 4.47× |
| 14×14 / 512 / 2×2   | 0.67 GB/s | 2.97 GB/s | 4.43× |
| 28×28 / 256 / 2×2   | 0.70 GB/s | 2.93 GB/s | 4.19× |
| 56×56 / 128 / 2×2   | 0.76 GB/s | 3.12 GB/s | 4.08× |
| 112×112 / 64 / 2×2  | 0.89 GB/s | 3.82 GB/s | 4.28× |
| 28×28 / 256 / 3×3   | 0.75 GB/s | 3.06 GB/s | 4.10× |

All runs had cv ≤ 2.8%.
