### PR TITLE
use size_t for reduced input dims in reduce compute kernels

### DIFF
--- a/src/operator-run.c
+++ b/src/operator-run.c
@@ -1432,8 +1432,8 @@ XNN_NO_SANITIZE_FUNCTION void xnn_compute_contiguous_reduce(struct reduce_contex
       (output_stride[0] * output_idx0 + output_stride[1] * output_idx1 +
        output_stride[2] * output_idx2) *
       context->accumulation_element_size;
-  int input_shape1 = context->input_shape[1];
-  int input_shape3 = context->input_shape[3];
+  size_t input_shape1 = context->input_shape[1];
+  size_t input_shape3 = context->input_shape[3];
 
   void* output_ptr = NULL;
   if (context->workspace) {
@@ -1512,8 +1512,8 @@ XNN_NO_SANITIZE_FUNCTION void xnn_compute_discontiguous_reduce(struct reduce_con
       (output_stride[0] * output_idx0 + output_stride[1] * output_idx1 +
        output_stride[2] * output_idx2) *
       context->accumulation_element_size;
-  int input_shape0 = context->input_shape[0];
-  int input_shape2 = context->input_shape[2];
+  size_t input_shape0 = context->input_shape[0];
+  size_t input_shape2 = context->input_shape[2];
 
   void* output_ptr = NULL;
   if (context->workspace) {


### PR DESCRIPTION
Building with -Wshorten-64-to-32:

    src/operator-run.c:1435:22: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'int' [-Wshorten-64-to-32]
     1435 |   int input_shape1 = context->input_shape[1];

xnn_compute_contiguous_reduce and xnn_compute_discontiguous_reduce copy the reduced dimensions out of context->input_shape (a size_t array) into int locals, then use them as loop bounds. A reduced dimension of 2^31 or more truncates to a negative int. In `for (size_t i = 0; i < input_shape1; ++i)` that negative value converts back to a near-2^64 bound, so the loop walks the input and output pointers well past their buffers. The discontiguous path also hands the truncated values straight to the size_t k2/k3 parameters of discontiguous_reduce2.

Every other extent, stride and index in both functions is already size_t. These four locals were the only ones left as int. Changed them to match.