### PR TITLE
resize-bilinear: guard indirection buffer and packed weights size against overflow

### DIFF
--- a/src/operators/resize-bilinear-nchw.c
+++ b/src/operators/resize-bilinear-nchw.c
@@ -192,8 +192,28 @@ XNN_NO_SANITIZE_FUNCTION enum xnn_status xnn_reshape_resize_bilinear2d_nchw(
   const size_t output_height = resize_op->convolution_op->output_height;
   const size_t output_width = resize_op->convolution_op->output_width;
   if (output_height * output_width != resize_op->convolution_op->last_output_height * resize_op->convolution_op->last_output_width) {
-    const size_t indirection_buffer_size = sizeof(void*) * (output_height * output_width * 4);
-    const size_t packed_weights_size = (output_height * output_width * 2) << log2_weight_element_size;
+    size_t num_output_pixels = 0;
+    if (!xnn_safe_mul(output_height, output_width, &num_output_pixels)) {
+      xnn_log_error(
+          "failed to reshape %s operator: output pixel count overflows size_t",
+          xnn_operator_type_to_string(xnn_operator_type_resize_bilinear_nchw));
+      return xnn_status_out_of_memory;
+    }
+    size_t indirection_buffer_size = 0;
+    if (!xnn_safe_mul(num_output_pixels, 4 * sizeof(void*), &indirection_buffer_size)) {
+      xnn_log_error(
+          "failed to reshape %s operator: indirection buffer size overflows size_t",
+          xnn_operator_type_to_string(xnn_operator_type_resize_bilinear_nchw));
+      return xnn_status_out_of_memory;
+    }
+    const size_t packed_weights_element_size = 2u << log2_weight_element_size;
+    size_t packed_weights_size = 0;
+    if (!xnn_safe_mul(num_output_pixels, packed_weights_element_size, &packed_weights_size)) {
+      xnn_log_error(
+          "failed to reshape %s operator: packed weights size overflows size_t",
+          xnn_operator_type_to_string(xnn_operator_type_resize_bilinear_nchw));
+      return xnn_status_out_of_memory;
+    }
 
     const void** indirection_buffer = (const void**) xnn_reallocate_memory(resize_op->convolution_op->indirection_buffer, indirection_buffer_size);
     if (indirection_buffer == NULL) {

--- a/src/operators/resize-bilinear-nhwc.c
+++ b/src/operators/resize-bilinear-nhwc.c
@@ -195,8 +195,28 @@ XNN_NO_SANITIZE_FUNCTION enum xnn_status xnn_reshape_resize_bilinear2d_nhwc(
   const size_t output_width = resize_op->convolution_op->output_width;
   const bool enable_transient_indirection = !!(resize_op->flags & XNN_FLAG_TRANSIENT_INDIRECTION_BUFFER);
   const size_t input_pixel_stride_in_bytes = input_pixel_stride << log2_data_element_size;
-  const size_t indirection_buffer_size = sizeof(void*) * (output_height * output_width * 4);
-  const size_t packed_weights_size = (output_height * output_width * 2) << log2_weight_element_size;
+  size_t num_output_pixels = 0;
+  if (!xnn_safe_mul(output_height, output_width, &num_output_pixels)) {
+    xnn_log_error(
+        "failed to reshape %s operator: output pixel count overflows size_t",
+        xnn_operator_type_to_string_v2(resize_op));
+    return xnn_status_out_of_memory;
+  }
+  size_t indirection_buffer_size = 0;
+  if (!xnn_safe_mul(num_output_pixels, 4 * sizeof(void*), &indirection_buffer_size)) {
+    xnn_log_error(
+        "failed to reshape %s operator: indirection buffer size overflows size_t",
+        xnn_operator_type_to_string_v2(resize_op));
+    return xnn_status_out_of_memory;
+  }
+  const size_t packed_weights_element_size = 2u << log2_weight_element_size;
+  size_t packed_weights_size = 0;
+  if (!xnn_safe_mul(num_output_pixels, packed_weights_element_size, &packed_weights_size)) {
+    xnn_log_error(
+        "failed to reshape %s operator: packed weights size overflows size_t",
+        xnn_operator_type_to_string_v2(resize_op));
+    return xnn_status_out_of_memory;
+  }
 
   const size_t num_threads = pthreadpool_get_threads_count(threadpool);
 
@@ -354,7 +374,8 @@ enum xnn_status xnn_setup_resize_bilinear2d_nhwc(
   const size_t log2_weight_element_size = resize_op->ibilinear_config->log2_weight_element_size;
   const size_t output_height = resize_op->context.resize_nhwc_indirection_init.output_height;
   const size_t output_width = resize_op->context.resize_nhwc_indirection_init.output_width;
-  const size_t packed_weights_size = (output_height * output_width * 2) << log2_weight_element_size;
+  const size_t num_output_pixels = output_height * output_width;
+  const size_t packed_weights_size = num_output_pixels * (2u << log2_weight_element_size);
   if (resize_op->flags & XNN_FLAG_TRANSIENT_INDIRECTION_BUFFER) {
     // indirect_input should start at a multiple of pointer size to avoid ubsan failures
     const size_t indirect_input_offset = (packed_weights_size + sizeof(void*) - 1) & ~(sizeof(void*) - 1);

--- a/src/operators/resize-bilinear-nhwc.c
+++ b/src/operators/resize-bilinear-nhwc.c
@@ -374,8 +374,7 @@ enum xnn_status xnn_setup_resize_bilinear2d_nhwc(
   const size_t log2_weight_element_size = resize_op->ibilinear_config->log2_weight_element_size;
   const size_t output_height = resize_op->context.resize_nhwc_indirection_init.output_height;
   const size_t output_width = resize_op->context.resize_nhwc_indirection_init.output_width;
-  const size_t num_output_pixels = output_height * output_width;
-  const size_t packed_weights_size = num_output_pixels * (2u << log2_weight_element_size);
+  const size_t packed_weights_size = (output_height * output_width * 2) << log2_weight_element_size;
   if (resize_op->flags & XNN_FLAG_TRANSIENT_INDIRECTION_BUFFER) {
     // indirect_input should start at a multiple of pointer size to avoid ubsan failures
     const size_t indirect_input_offset = (packed_weights_size + sizeof(void*) - 1) & ~(sizeof(void*) - 1);


### PR DESCRIPTION
`xnn_reshape_resize_bilinear2d_nhwc_*` and `xnn_reshape_resize_bilinear2d_nchw_*` computed the indirection buffer size and packed-weights size with raw multiplication:

```c
sizeof(void*) * (output_height * output_width * 4)
(output_height * output_width * 2) << log2_weight_element_size
```

On 32-bit targets (WebAssembly, ARM32) where `size_t` is 32 bits, the product overflows when `output_height * output_width >= 2^28` (e.g. 16384 × 16384), wrapping the computed size to zero. `xnn_reallocate_memory` then returns a zero-size allocation, and `xnn_indirection_init_resize_bilinear2d_*` subsequently writes `4 * output_height * output_width` pointer entries into this undersized buffer — a heap out-of-bounds write.

Replace the raw multiplications with chained `xnn_safe_mul` calls that return `xnn_status_out_of_memory` on overflow, matching the pattern used in other reshape paths.