### PR TITLE
operators: guard dwconv step_height and indirection buffer size against overflow

### DIFF
--- a/src/operators/convolution-nhwc.c
+++ b/src/operators/convolution-nhwc.c
@@ -2954,8 +2954,15 @@ static enum xnn_status reshape_dwconv(
       convolution_op->convolution_op->dilation_width == 1
           ? min(convolution_op->convolution_op->stride_width, kernel_width)
           : kernel_width;
-  const size_t step_height =
-      kernel_size + (output_width - 1) * step_width * kernel_height;
+  size_t step_height_increment = 0;
+  size_t step_height = 0;
+  if (!xnn_safe_mul(output_width - 1, step_width, &step_height_increment) ||
+      !xnn_safe_mul(step_height_increment, kernel_height, &step_height_increment) ||
+      !xnn_safe_add(kernel_size, step_height_increment, &step_height)) {
+    xnn_log_error("failed to reshape %s operator: step_height overflows size_t",
+                  xnn_operator_type_to_string_v2(convolution_op));
+    return xnn_status_out_of_memory;
+  }
   const struct xnn_ukernel_dwconv dwconv_ukernel =
       convolution_op->ukernel.dwconv;
   const size_t primary_tile = dwconv_ukernel.primary_tile;
@@ -2963,10 +2970,19 @@ static enum xnn_status reshape_dwconv(
 
   // Micro-kernel will read (tile_size - kernel_size) elements after the end of
   // indirection buffer.
+  size_t indirection_buffer_elements = 0;
+  size_t indirection_buffer_size_raw = 0;
+  if (!xnn_safe_mul(output_height, step_height, &indirection_buffer_elements) ||
+      !xnn_safe_add(primary_tile - kernel_size, indirection_buffer_elements,
+                    &indirection_buffer_elements) ||
+      !xnn_safe_mul(indirection_buffer_elements, sizeof(void*),
+                    &indirection_buffer_size_raw)) {
+    xnn_log_error("failed to reshape %s operator: indirection buffer size overflows size_t",
+                  xnn_operator_type_to_string_v2(convolution_op));
+    return xnn_status_out_of_memory;
+  }
   const size_t indirection_buffer_size =
-      round_up_po2(sizeof(void*) * (primary_tile - kernel_size +
-                                    output_height * step_height),
-                   XNN_ALLOCATION_ALIGNMENT);
+      round_up_po2(indirection_buffer_size_raw, XNN_ALLOCATION_ALIGNMENT);
 
   size_t dwconv_compute_index;
   const bool is_transient_indirection_buffer =


### PR DESCRIPTION
`reshape_dwconv` - the reshape path for all depthwise convolution operators - computed `step_height` and `indirection_buffer_size` through two consecutive unguarded multiplications:

```c
const size_t step_height =
    kernel_size + (output_width - 1) * step_width * kernel_height;   // overflow 1

const size_t indirection_buffer_size =
    round_up_po2(sizeof(void*) * (primary_tile - kernel_size +
                                  output_height * step_height),      // overflow 2
                 XNN_ALLOCATION_ALIGNMENT);
```

On 32-bit targets (WebAssembly, ARM32) where `size_t` is 32 bits, large values of `output_width`, `kernel_height`, or `output_height` cause both products to silently wrap, yielding an undersized heap allocation. `xnn_indirection_init_dwconv2d` is then called with the true (untruncated) values and writes the full intended extent of pointer entries out of bounds - a heap out-of-bounds write.

This fix replaces both computations with `xnn_safe_mul`/`xnn_safe_add` chains that return `xnn_status_out_of_memory` on overflow, consistent with the pattern used in `average-pooling-nhwc.c` and `argmax-pooling-nhwc.c`.