### PR TITLE
Fix integer overflows in NCHW convolution size calculations

### DIFF
--- a/src/operators/convolution-nchw.c
+++ b/src/operators/convolution-nchw.c
@@ -222,10 +222,19 @@ static XNN_NO_SANITIZE_FUNCTION enum xnn_status create_conv2d_hwc2chw_path(
 
   if(convolution_op->packed_weights.offset == XNN_CACHE_NOT_FOUND) {
     const size_t packed_group_output_channels = round_up(context->group_output_channels, output_channel_tile);
-    const size_t packed_weights_size = (context->groups * packed_group_output_channels *
-                                         (context->group_input_channels * context->kernel_height
-                                          * context->kernel_width + 1 /* bias */))
-                                       << log2_filter_element_size;
+
+    // Calculate total packed weights size:
+    //   groups * packed_group_output_channels * (group_input_channels * kernel_height * kernel_width + 1)
+    //   << log2_filter_element_size
+    size_t packed_weights_size;
+    if (!xnn_safe_mul(context->group_input_channels, context->kernel_height, &packed_weights_size) ||
+        !xnn_safe_mul(packed_weights_size, context->kernel_width, &packed_weights_size) ||
+        !xnn_safe_add(packed_weights_size, 1, &packed_weights_size) ||
+        !xnn_safe_mul(packed_weights_size, context->groups, &packed_weights_size) ||
+        !xnn_safe_mul(packed_weights_size, packed_group_output_channels, &packed_weights_size) ||
+        !xnn_safe_mul(packed_weights_size, (size_t)1 << log2_filter_element_size, &packed_weights_size)) {
+      return xnn_status_out_of_memory;
+    }
     const size_t aligned_total_weights_size = round_up_po2(packed_weights_size, XNN_ALLOCATION_ALIGNMENT);
     void* weights_ptr = xnn_get_pointer_to_write_weights(convolution_op, aligned_total_weights_size);
     if (weights_ptr == NULL) {
@@ -283,8 +292,14 @@ static XNN_NO_SANITIZE_FUNCTION enum xnn_status create_dwconv_path(
       XNN_CACHE_NOT_FOUND;
 
   if(convolution_op->packed_weights.offset == XNN_CACHE_NOT_FOUND) {
-    const size_t packed_weights_size =
-        ((size_t) context->groups * ((size_t) context->kernel_height * context->kernel_width + 1 /* bias */)) << log2_filter_element_size;
+    // Calculate total packed weights size: groups * (kernel_height * kernel_width + 1) << log2_filter_element_size
+    size_t packed_weights_size;
+    if (!xnn_safe_mul(context->kernel_height, context->kernel_width, &packed_weights_size) ||
+        !xnn_safe_add(packed_weights_size, 1, &packed_weights_size) ||
+        !xnn_safe_mul(packed_weights_size, context->groups, &packed_weights_size) ||
+        !xnn_safe_mul(packed_weights_size, (size_t)1 << log2_filter_element_size, &packed_weights_size)) {
+      return xnn_status_out_of_memory;
+    }
     const size_t aligned_total_weights_size = round_up_po2(packed_weights_size, XNN_ALLOCATION_ALIGNMENT);
     void* weights_ptr = xnn_get_pointer_to_write_weights(
         convolution_op, aligned_total_weights_size);


### PR DESCRIPTION
## Fix integer overflows in NCHW convolution allocation size calculations

### Problem

`create_conv2d_hwc2chw_path()` performs allocation size calculations using unchecked `size_t` multiplication. Under sufficiently large parameter values, these calculations can overflow, resulting in an undersized allocation.

Subsequent weight-packing code continues operating under the assumption that the original allocation size is valid, leading to invalid memory accesses.

This change replaces the unchecked arithmetic with overflow-checked multiplication, following the existing pattern already used elsewhere in XNNPACK.

### Security Impact

This change addresses a memory-safety issue caused by integer overflow during allocation size computation.

**Confirmed impact:**
- Denial of Service (DoS) through a reproducible process crash.
- Invalid memory access caused by an integer-overflow-induced undersized allocation.

**Potential impact:**
- Heap memory corruption resulting from writes beyond the intended allocation.
- Corruption of adjacent heap objects or allocator metadata, depending on runtime memory layout.
- Undefined behavior arising from memory corruption.
- Additional exploitation opportunities depending on the allocator, compiler optimizations, and deployment environment. Arbitrary code execution has not been demonstrated by this change.

### Solution

- Replace unchecked `size_t` multiplication with `xnn_safe_mul()`.
- Return `xnn_status_out_of_memory` if any intermediate multiplication overflows.
- Align the NCHW implementation with the overflow-safe approach already used in the NHWC convolution implementation.

### Validation

- Verified that overflow inputs are detected before allocation.
- Confirmed that the function returns `xnn_status_out_of_memory` instead of proceeding with an overflowed allocation.
- Verified with AddressSanitizer that the overflow condition no longer reaches the invalid memory access.
- The implementation follows existing XNNPACK overflow-checking conventions.