### PR TITLE
reallocate deconv igemm indirection buffer on output-size change

### DIFF
--- a/src/operators/deconvolution-nhwc.c
+++ b/src/operators/deconvolution-nhwc.c
@@ -1775,7 +1775,10 @@ static XNN_NO_SANITIZE_FUNCTION enum xnn_status reshape_igemm_path(
   }
 
   if (input_height != deconvolution_op->convolution_op->last_input_height ||
-      input_width != deconvolution_op->convolution_op->last_input_width) {
+      input_width != deconvolution_op->convolution_op->last_input_width ||
+      output_height != deconvolution_op->convolution_op->last_output_height ||
+      output_width != deconvolution_op->convolution_op->last_output_width ||
+      mr != deconvolution_op->convolution_op->last_mr) {
     const void** indirection_buffer = (const void**)xnn_reallocate_memory(
         deconvolution_op->convolution_op->indirection_buffer,
         indirection_buffer_size);
@@ -1801,6 +1804,9 @@ static XNN_NO_SANITIZE_FUNCTION enum xnn_status reshape_igemm_path(
         deconvolution_op->convolution_op->input;
     deconvolution_op->convolution_op->last_input_height = input_height;
     deconvolution_op->convolution_op->last_input_width = input_width;
+    deconvolution_op->convolution_op->last_output_height = output_height;
+    deconvolution_op->convolution_op->last_output_width = output_width;
+    deconvolution_op->convolution_op->last_mr = mr;
 
     xnn_indirection_init_deconv2d(
         mr, deconvolution_op->convolution_op->indirection_buffer,

--- a/src/operators/deconvolution-nhwc.c
+++ b/src/operators/deconvolution-nhwc.c
@@ -1840,7 +1840,10 @@ static XNN_NO_SANITIZE_FUNCTION enum xnn_status reshape_igemm_path(
   }
 
   if (input_height != deconvolution_op->convolution_op->last_input_height ||
-      input_width != deconvolution_op->convolution_op->last_input_width) {
+      input_width != deconvolution_op->convolution_op->last_input_width ||
+      output_height != deconvolution_op->convolution_op->last_output_height ||
+      output_width != deconvolution_op->convolution_op->last_output_width ||
+      mr != deconvolution_op->convolution_op->last_mr) {
     const void** indirection_buffer = (const void**)xnn_reallocate_memory(
         deconvolution_op->convolution_op->indirection_buffer,
         indirection_buffer_size);
@@ -1866,6 +1869,9 @@ static XNN_NO_SANITIZE_FUNCTION enum xnn_status reshape_igemm_path(
         deconvolution_op->convolution_op->input;
     deconvolution_op->convolution_op->last_input_height = input_height;
     deconvolution_op->convolution_op->last_input_width = input_width;
+    deconvolution_op->convolution_op->last_output_height = output_height;
+    deconvolution_op->convolution_op->last_output_width = output_width;
+    deconvolution_op->convolution_op->last_mr = mr;
 
     xnn_indirection_init_deconv2d(
         mr, deconvolution_op->convolution_op->indirection_buffer,

--- a/test/operators/deconvolution-nhwc.cc
+++ b/test/operators/deconvolution-nhwc.cc
@@ -4,9 +4,13 @@
 // LICENSE file in the root directory of this source tree.
 
 #include <cstddef>
+#include <limits>
+#include <memory>
 #include <vector>
 
 #include <gtest/gtest.h>
+#include "include/xnnpack.h"
+#include "src/xnnpack/buffer.h"
 #include "src/xnnpack/config-types.h"
 #include "src/xnnpack/config.h"
 #include "test/operators/deconvolution-operator-tester.h"
@@ -3385,3 +3389,114 @@ CREATE_DECONVOLUTION_SETUP_TESTS(DECONVOLUTION_NHWC_F16, TestSetupF16)
 CREATE_DECONVOLUTION_TESTS(DECONVOLUTION_NHWC_F32, xnn_init_f32_igemm_config(),
                            TestF32)
 CREATE_DECONVOLUTION_SETUP_TESTS(DECONVOLUTION_NHWC_F32, TestSetupF32)
+
+// Reshaping an operator to a larger output through a bigger `adjustment`, while
+// the input dimensions stay the same, has to resize and refill the IGEMM
+// indirection buffer: its element count follows the output, not the input. A
+// second reshape with an unchanged 4x4 input but adjustment 0 -> 1 grows the
+// output from 7x7 to 8x8, so the buffer that was sized for 49 output pixels is
+// read for 64, past its end. kernel 1x1 with stride 2 selects the IGEMM (not
+// subconv) path and lets the adjustment move the output on its own.
+TEST(DECONVOLUTION_NHWC_F32, reshape_grows_output_via_adjustment) {
+  if (xnn_init_f32_igemm_config() == nullptr) {
+    GTEST_SKIP();
+  }
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  constexpr uint32_t kernel = 1;
+  constexpr uint32_t stride = 2;
+  constexpr size_t groups = 1;
+  constexpr size_t group_input_channels = 4;
+  constexpr size_t group_output_channels = 4;
+  constexpr size_t batch_size = 1;
+  constexpr size_t input_height = 4;
+  constexpr size_t input_width = 4;
+
+  std::vector<float> kernel_data(groups * group_output_channels * kernel *
+                                 kernel * group_input_channels);
+  for (size_t i = 0; i < kernel_data.size(); i++) {
+    kernel_data[i] = static_cast<float>(static_cast<int>(i % 7) - 3) * 0.25f;
+  }
+  std::vector<float> bias(groups * group_output_channels);
+  for (size_t i = 0; i < bias.size(); i++) {
+    bias[i] = static_cast<float>(i) * 0.5f - 1.0f;
+  }
+  xnnpack::Buffer<float> input(
+      batch_size * input_height * input_width * groups * group_input_channels,
+      xnnpack::XnnExtraBytes);
+  for (size_t i = 0; i < input.size(); i++) {
+    input[i] = static_cast<float>(static_cast<int>(i % 11) - 5) * 0.125f;
+  }
+
+  const auto create_op = [&]() -> xnn_operator_t {
+    xnn_operator_t op = nullptr;
+    EXPECT_EQ(xnn_status_success,
+              xnn_create_deconvolution2d_nhwc_f32(
+                  /*output_padding_top=*/0, /*output_padding_right=*/0,
+                  /*output_padding_bottom=*/0, /*output_padding_left=*/0,
+                  kernel, kernel, stride, stride, /*dilation_height=*/1,
+                  /*dilation_width=*/1, groups, group_input_channels,
+                  group_output_channels,
+                  /*input_pixel_stride=*/groups * group_input_channels,
+                  /*output_pixel_stride=*/groups * group_output_channels,
+                  kernel_data.data(), bias.data(),
+                  -std::numeric_limits<float>::infinity(),
+                  std::numeric_limits<float>::infinity(), /*flags=*/0,
+                  /*weights_cache=*/nullptr, &op));
+    return op;
+  };
+
+  // Reference: reshaped straight to the adjustment=1 (8x8) output.
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> reference_op(
+      create_op(), xnn_delete_operator);
+  ASSERT_NE(reference_op, nullptr);
+  size_t reference_height = 0, reference_width = 0;
+  ASSERT_EQ(xnn_status_success,
+            xnn_reshape_deconvolution2d_nhwc_f32(
+                reference_op.get(), batch_size, input_height, input_width,
+                /*adjustment_height=*/1, /*adjustment_width=*/1,
+                &reference_height, &reference_width, /*threadpool=*/nullptr));
+  ASSERT_EQ(reference_height, 8);
+  ASSERT_EQ(reference_width, 8);
+  xnnpack::Buffer<float> reference_output(batch_size * reference_height *
+                                          reference_width * groups *
+                                          group_output_channels);
+  ASSERT_EQ(xnn_status_success,
+            xnn_setup_deconvolution2d_nhwc_f32(
+                reference_op.get(), input.data(), reference_output.data()));
+  ASSERT_EQ(xnn_status_success,
+            xnn_run_operator(reference_op.get(), /*threadpool=*/nullptr));
+
+  // Same operator, reshaped to the smaller adjustment=0 (7x7) output first,
+  // then grown to 8x8 with the input unchanged.
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> op(
+      create_op(), xnn_delete_operator);
+  ASSERT_NE(op, nullptr);
+  size_t small_height = 0, small_width = 0;
+  ASSERT_EQ(xnn_status_success,
+            xnn_reshape_deconvolution2d_nhwc_f32(
+                op.get(), batch_size, input_height, input_width,
+                /*adjustment_height=*/0, /*adjustment_width=*/0, &small_height,
+                &small_width, /*threadpool=*/nullptr));
+  ASSERT_EQ(small_height, 7);
+  ASSERT_EQ(small_width, 7);
+  size_t output_height = 0, output_width = 0;
+  ASSERT_EQ(xnn_status_success,
+            xnn_reshape_deconvolution2d_nhwc_f32(
+                op.get(), batch_size, input_height, input_width,
+                /*adjustment_height=*/1, /*adjustment_width=*/1, &output_height,
+                &output_width, /*threadpool=*/nullptr));
+  ASSERT_EQ(output_height, 8);
+  ASSERT_EQ(output_width, 8);
+  xnnpack::Buffer<float> output(batch_size * output_height * output_width *
+                                groups * group_output_channels);
+  ASSERT_EQ(xnn_status_success,
+            xnn_setup_deconvolution2d_nhwc_f32(op.get(), input.data(),
+                                               output.data()));
+  ASSERT_EQ(xnn_status_success,
+            xnn_run_operator(op.get(), /*threadpool=*/nullptr));
+
+  for (size_t i = 0; i < output.size(); i++) {
+    ASSERT_EQ(output[i], reference_output[i]) << "at index " << i;
+  }
+}

--- a/test/operators/deconvolution-nhwc.cc
+++ b/test/operators/deconvolution-nhwc.cc
@@ -7,9 +7,12 @@
 #include <cstddef>
 #include <cstdint>
 #include <limits>
+#include <memory>
 #include <vector>
 
 #include <gtest/gtest.h>
+#include "include/xnnpack.h"
+#include "src/xnnpack/buffer.h"
 #include "src/xnnpack/config-types.h"
 #include "src/xnnpack/config.h"
 #include "test/operators/deconvolution-operator-tester.h"
@@ -3444,4 +3447,115 @@ TEST(DECONVOLUTION_NHWC, conversion_buffer_size_overflow) {
           std::numeric_limits<float>::infinity(), 0, nullptr,
           &deconvolution_op));
   EXPECT_EQ(nullptr, deconvolution_op);
+}
+
+// Reshaping an operator to a larger output through a bigger `adjustment`, while
+// the input dimensions stay the same, has to resize and refill the IGEMM
+// indirection buffer: its element count follows the output, not the input. A
+// second reshape with an unchanged 4x4 input but adjustment 0 -> 1 grows the
+// output from 7x7 to 8x8, so the buffer that was sized for 49 output pixels is
+// read for 64, past its end. kernel 1x1 with stride 2 selects the IGEMM (not
+// subconv) path and lets the adjustment move the output on its own.
+TEST(DECONVOLUTION_NHWC_F32, reshape_grows_output_via_adjustment) {
+  if (xnn_init_f32_igemm_config() == nullptr) {
+    GTEST_SKIP();
+  }
+  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+
+  constexpr uint32_t kernel = 1;
+  constexpr uint32_t stride = 2;
+  constexpr size_t groups = 1;
+  constexpr size_t group_input_channels = 4;
+  constexpr size_t group_output_channels = 4;
+  constexpr size_t batch_size = 1;
+  constexpr size_t input_height = 4;
+  constexpr size_t input_width = 4;
+
+  std::vector<float> kernel_data(groups * group_output_channels * kernel *
+                                 kernel * group_input_channels);
+  for (size_t i = 0; i < kernel_data.size(); i++) {
+    kernel_data[i] = static_cast<float>(static_cast<int>(i % 7) - 3) * 0.25f;
+  }
+  std::vector<float> bias(groups * group_output_channels);
+  for (size_t i = 0; i < bias.size(); i++) {
+    bias[i] = static_cast<float>(i) * 0.5f - 1.0f;
+  }
+  xnnpack::Buffer<float> input(
+      batch_size * input_height * input_width * groups * group_input_channels,
+      xnnpack::XnnExtraBytes);
+  for (size_t i = 0; i < input.size(); i++) {
+    input[i] = static_cast<float>(static_cast<int>(i % 11) - 5) * 0.125f;
+  }
+
+  const auto create_op = [&]() -> xnn_operator_t {
+    xnn_operator_t op = nullptr;
+    EXPECT_EQ(xnn_status_success,
+              xnn_create_deconvolution2d_nhwc_f32(
+                  /*output_padding_top=*/0, /*output_padding_right=*/0,
+                  /*output_padding_bottom=*/0, /*output_padding_left=*/0,
+                  kernel, kernel, stride, stride, /*dilation_height=*/1,
+                  /*dilation_width=*/1, groups, group_input_channels,
+                  group_output_channels,
+                  /*input_pixel_stride=*/groups * group_input_channels,
+                  /*output_pixel_stride=*/groups * group_output_channels,
+                  kernel_data.data(), bias.data(),
+                  -std::numeric_limits<float>::infinity(),
+                  std::numeric_limits<float>::infinity(), /*flags=*/0,
+                  /*weights_cache=*/nullptr, &op));
+    return op;
+  };
+
+  // Reference: reshaped straight to the adjustment=1 (8x8) output.
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> reference_op(
+      create_op(), xnn_delete_operator);
+  ASSERT_NE(reference_op, nullptr);
+  size_t reference_height = 0, reference_width = 0;
+  ASSERT_EQ(xnn_status_success,
+            xnn_reshape_deconvolution2d_nhwc_f32(
+                reference_op.get(), batch_size, input_height, input_width,
+                /*adjustment_height=*/1, /*adjustment_width=*/1,
+                &reference_height, &reference_width, /*threadpool=*/nullptr));
+  ASSERT_EQ(reference_height, 8);
+  ASSERT_EQ(reference_width, 8);
+  xnnpack::Buffer<float> reference_output(batch_size * reference_height *
+                                          reference_width * groups *
+                                          group_output_channels);
+  ASSERT_EQ(xnn_status_success,
+            xnn_setup_deconvolution2d_nhwc_f32(
+                reference_op.get(), input.data(), reference_output.data()));
+  ASSERT_EQ(xnn_status_success,
+            xnn_run_operator(reference_op.get(), /*threadpool=*/nullptr));
+
+  // Same operator, reshaped to the smaller adjustment=0 (7x7) output first,
+  // then grown to 8x8 with the input unchanged.
+  std::unique_ptr<xnn_operator, decltype(&xnn_delete_operator)> op(
+      create_op(), xnn_delete_operator);
+  ASSERT_NE(op, nullptr);
+  size_t small_height = 0, small_width = 0;
+  ASSERT_EQ(xnn_status_success,
+            xnn_reshape_deconvolution2d_nhwc_f32(
+                op.get(), batch_size, input_height, input_width,
+                /*adjustment_height=*/0, /*adjustment_width=*/0, &small_height,
+                &small_width, /*threadpool=*/nullptr));
+  ASSERT_EQ(small_height, 7);
+  ASSERT_EQ(small_width, 7);
+  size_t output_height = 0, output_width = 0;
+  ASSERT_EQ(xnn_status_success,
+            xnn_reshape_deconvolution2d_nhwc_f32(
+                op.get(), batch_size, input_height, input_width,
+                /*adjustment_height=*/1, /*adjustment_width=*/1, &output_height,
+                &output_width, /*threadpool=*/nullptr));
+  ASSERT_EQ(output_height, 8);
+  ASSERT_EQ(output_width, 8);
+  xnnpack::Buffer<float> output(batch_size * output_height * output_width *
+                                groups * group_output_channels);
+  ASSERT_EQ(xnn_status_success,
+            xnn_setup_deconvolution2d_nhwc_f32(op.get(), input.data(),
+                                               output.data()));
+  ASSERT_EQ(xnn_status_success,
+            xnn_run_operator(op.get(), /*threadpool=*/nullptr));
+
+  for (size_t i = 0; i < output.size(); i++) {
+    ASSERT_EQ(output[i], reference_output[i]) << "at index " << i;
+  }
 }

--- a/test/operators/deconvolution-nhwc.cc
+++ b/test/operators/deconvolution-nhwc.cc
@@ -3460,7 +3460,7 @@ TEST(DECONVOLUTION_NHWC_F32, reshape_grows_output_via_adjustment) {
   if (xnn_init_f32_igemm_config() == nullptr) {
     GTEST_SKIP();
   }
-  ASSERT_EQ(xnn_status_success, xnn_initialize(/*allocator=*/nullptr));
+  ASSERT_EQ(xnn_initialize(/*allocator=*/nullptr), xnn_status_success);
 
   constexpr uint32_t kernel = 1;
   constexpr uint32_t stride = 2;
@@ -3489,8 +3489,7 @@ TEST(DECONVOLUTION_NHWC_F32, reshape_grows_output_via_adjustment) {
 
   const auto create_op = [&]() -> xnn_operator_t {
     xnn_operator_t op = nullptr;
-    EXPECT_EQ(xnn_status_success,
-              xnn_create_deconvolution2d_nhwc_f32(
+    EXPECT_EQ(xnn_create_deconvolution2d_nhwc_f32(
                   /*output_padding_top=*/0, /*output_padding_right=*/0,
                   /*output_padding_bottom=*/0, /*output_padding_left=*/0,
                   kernel, kernel, stride, stride, /*dilation_height=*/1,
@@ -3501,7 +3500,8 @@ TEST(DECONVOLUTION_NHWC_F32, reshape_grows_output_via_adjustment) {
                   kernel_data.data(), bias.data(),
                   -std::numeric_limits<float>::infinity(),
                   std::numeric_limits<float>::infinity(), /*flags=*/0,
-                  /*weights_cache=*/nullptr, &op));
+                  /*weights_cache=*/nullptr, &op),
+              xnn_status_success);
     return op;
   };
 
@@ -3510,21 +3510,21 @@ TEST(DECONVOLUTION_NHWC_F32, reshape_grows_output_via_adjustment) {
       create_op(), xnn_delete_operator);
   ASSERT_NE(reference_op, nullptr);
   size_t reference_height = 0, reference_width = 0;
-  ASSERT_EQ(xnn_status_success,
-            xnn_reshape_deconvolution2d_nhwc_f32(
+  ASSERT_EQ(xnn_reshape_deconvolution2d_nhwc_f32(
                 reference_op.get(), batch_size, input_height, input_width,
                 /*adjustment_height=*/1, /*adjustment_width=*/1,
-                &reference_height, &reference_width, /*threadpool=*/nullptr));
+                &reference_height, &reference_width, /*threadpool=*/nullptr),
+            xnn_status_success);
   ASSERT_EQ(reference_height, 8);
   ASSERT_EQ(reference_width, 8);
   xnnpack::Buffer<float> reference_output(batch_size * reference_height *
                                           reference_width * groups *
                                           group_output_channels);
-  ASSERT_EQ(xnn_status_success,
-            xnn_setup_deconvolution2d_nhwc_f32(
-                reference_op.get(), input.data(), reference_output.data()));
-  ASSERT_EQ(xnn_status_success,
-            xnn_run_operator(reference_op.get(), /*threadpool=*/nullptr));
+  ASSERT_EQ(xnn_setup_deconvolution2d_nhwc_f32(reference_op.get(), input.data(),
+                                               reference_output.data()),
+            xnn_status_success);
+  ASSERT_EQ(xnn_run_operator(reference_op.get(), /*threadpool=*/nullptr),
+            xnn_status_success);
 
   // Same operator, reshaped to the smaller adjustment=0 (7x7) output first,
   // then grown to 8x8 with the input unchanged.
@@ -3532,28 +3532,28 @@ TEST(DECONVOLUTION_NHWC_F32, reshape_grows_output_via_adjustment) {
       create_op(), xnn_delete_operator);
   ASSERT_NE(op, nullptr);
   size_t small_height = 0, small_width = 0;
-  ASSERT_EQ(xnn_status_success,
-            xnn_reshape_deconvolution2d_nhwc_f32(
+  ASSERT_EQ(xnn_reshape_deconvolution2d_nhwc_f32(
                 op.get(), batch_size, input_height, input_width,
                 /*adjustment_height=*/0, /*adjustment_width=*/0, &small_height,
-                &small_width, /*threadpool=*/nullptr));
+                &small_width, /*threadpool=*/nullptr),
+            xnn_status_success);
   ASSERT_EQ(small_height, 7);
   ASSERT_EQ(small_width, 7);
   size_t output_height = 0, output_width = 0;
-  ASSERT_EQ(xnn_status_success,
-            xnn_reshape_deconvolution2d_nhwc_f32(
+  ASSERT_EQ(xnn_reshape_deconvolution2d_nhwc_f32(
                 op.get(), batch_size, input_height, input_width,
                 /*adjustment_height=*/1, /*adjustment_width=*/1, &output_height,
-                &output_width, /*threadpool=*/nullptr));
+                &output_width, /*threadpool=*/nullptr),
+            xnn_status_success);
   ASSERT_EQ(output_height, 8);
   ASSERT_EQ(output_width, 8);
   xnnpack::Buffer<float> output(batch_size * output_height * output_width *
                                 groups * group_output_channels);
-  ASSERT_EQ(xnn_status_success,
-            xnn_setup_deconvolution2d_nhwc_f32(op.get(), input.data(),
-                                               output.data()));
-  ASSERT_EQ(xnn_status_success,
-            xnn_run_operator(op.get(), /*threadpool=*/nullptr));
+  ASSERT_EQ(
+      xnn_setup_deconvolution2d_nhwc_f32(op.get(), input.data(), output.data()),
+      xnn_status_success);
+  ASSERT_EQ(xnn_run_operator(op.get(), /*threadpool=*/nullptr),
+            xnn_status_success);
 
   for (size_t i = 0; i < output.size(); i++) {
     ASSERT_EQ(output[i], reference_output[i]) << "at index " << i;


### PR DESCRIPTION
Reshaping one f32 deconvolution twice, same 4x4 input, adjustment 0 then 1, under ASan:

    ERROR: AddressSanitizer: BUS on unknown address
    The signal is caused by a READ memory access.
    Hint: this fault was caused by a dereference of a high value address (x0 = 0xfffffffffffffff0)
      #0 xnn_f32_igemm_minmax_ukernel_4x2__asm_aarch64_neonfma_cortex_a75_prfm
      #2 xnn_run_operator_with_index operator-run.c:2240

reshape_igemm_path sizes the indirection buffer from the output,
round_up(output_h * output_w, mr) * kernel_size, but only reallocates and
refills it when the input height or width change. adjustment_height and
adjustment_width are reshape arguments and grow the output on their own, so the
same 4x4 input with adjustment 1 gives an 8x8 output while the input check stays
false. The buffer keeps its 49-pixel size and the igemm then walks it for 64
output rows, reading past the end and dereferencing the stale pointers there.

Found while diffing this against reshape_subconv2d_path lower in the file. The
subconv sibling already recognises an output or mr change as a resize; the igemm
gate only looked at the input. Same guard applied here, and the three tracking
fields it needs already exist on the operator.

Added a regression test under DECONVOLUTION_NHWC_F32: it faults on the old code
and passes with the change.
