### PR TITLE
fix(build): correct explicit_false alias target in define_build_option

### DIFF
--- a/ynnpack/build_defs.bzl
+++ b/ynnpack/build_defs.bzl
@@ -39,7 +39,7 @@ def define_build_option(name, default_all = [], default_any = []):
         name = name,
         actual = select({
             explicit_true: ":" + explicit_true,
-            explicit_false: ":" + explicit_true,
+            explicit_false: ":" + explicit_false,
             "//conditions:default": ":" + default,
         }),
     )


### PR DESCRIPTION
Fixes #9676

This PR corrects a copy-paste typo in the `define_build_option` function within `build_defs.bzl`. 

Previously, the `explicit_false` key in the `native.alias` select dictionary was incorrectly mapped to `":" + explicit_true`. This update corrects the mapping to point to `":" + explicit_false` as intended.