### PR TITLE
Reuse leading gaps in memory planner

### DIFF
--- a/src/memory-planner.c
+++ b/src/memory-planner.c
@@ -105,10 +105,6 @@ static size_t find_value_alloc_offset(struct memory_block* live_mem_blocks,
     return 0;
   }
 
-  if (num_mem_blocks == 1) {
-    return live_mem_blocks[0].end;
-  }
-
   // Sort memory blocks according to 'start' in increasing order.
   qsort(live_mem_blocks, num_mem_blocks, sizeof(struct memory_block), cmp_memory_block);
 
@@ -130,17 +126,20 @@ static size_t find_value_alloc_offset(struct memory_block* live_mem_blocks,
   }
 
   size_t smallest_gap_size = SIZE_MAX;
-  // The first index to live_mem_blocks that the 'to_alloc_size' should be allocated after.
-  size_t smallest_gap_index = num_coalesced_mem_blocks - 1;
+  size_t alloc_offset = live_mem_blocks[num_coalesced_mem_blocks - 1].end;
+  if (live_mem_blocks[0].start >= to_alloc_size) {
+    smallest_gap_size = live_mem_blocks[0].start;
+    alloc_offset = 0;
+  }
   for (size_t i = 0; i < num_coalesced_mem_blocks - 1; ++i) {
     assert(live_mem_blocks[i + 1].start > live_mem_blocks[i].end);
     const size_t gap = live_mem_blocks[i + 1].start - live_mem_blocks[i].end;
     if (gap >= to_alloc_size && gap < smallest_gap_size) {
-      smallest_gap_index = i;
       smallest_gap_size = gap;
+      alloc_offset = live_mem_blocks[i].end;
     }
   }
-  return live_mem_blocks[smallest_gap_index].end;
+  return alloc_offset;
 }
 
 void xnn_init_value_allocation_tracker(

--- a/test/subgraph/memory-planner.cc
+++ b/test/subgraph/memory-planner.cc
@@ -100,6 +100,130 @@ TEST(MemoryPlanner, MemoryBlocksCoalescing) {
   xnn_release_value_allocation_tracker(&tracker);
 }
 
+TEST(MemoryPlanner, ReusesLeadingGap) {
+  EXPECT_EQ(xnn_status_success, xnn_initialize(nullptr /* allocator */));
+  struct xnn_runtime runtime;
+  runtime.num_ops = 0;
+  runtime.num_values = 3;
+  struct xnn_value_allocation_tracker tracker;
+  xnn_init_value_allocation_tracker(&tracker, &runtime);
+
+  tracker.usage[0].first_node = 0;
+  tracker.usage[0].last_node = 1;
+  xnn_add_value_allocation_tracker(&tracker, 0, 100);
+
+  tracker.usage[1].first_node = 1;
+  tracker.usage[1].last_node = 2;
+  xnn_add_value_allocation_tracker(&tracker, 1, 80);
+
+  tracker.usage[2].first_node = 2;
+  tracker.usage[2].last_node = 3;
+  xnn_add_value_allocation_tracker(&tracker, 2, 60);
+
+  for (size_t i = 0; i < runtime.num_values; i++) {
+    tracker.usage[i].reuse_value_id = XNN_INVALID_VALUE_ID;
+  }
+  xnn_plan_value_allocation_tracker(&tracker);
+
+  EXPECT_EQ(0, tracker.usage[0].alloc_offset);
+  EXPECT_EQ(100, tracker.usage[1].alloc_offset);
+  EXPECT_EQ(0, tracker.usage[2].alloc_offset);
+  EXPECT_EQ(180, tracker.mem_arena_size);
+
+  xnn_release_value_allocation_tracker(&tracker);
+}
+
+TEST(MemoryPlanner, PrefersSmallerInternalGapOverLeadingGap) {
+  EXPECT_EQ(xnn_status_success, xnn_initialize(nullptr /* allocator */));
+  struct xnn_runtime runtime;
+  runtime.num_ops = 0;
+  runtime.num_values = 5;
+  struct xnn_value_allocation_tracker tracker;
+  xnn_init_value_allocation_tracker(&tracker, &runtime);
+
+  tracker.usage[0].first_node = 0;
+  tracker.usage[0].last_node = 0;
+  xnn_add_value_allocation_tracker(&tracker, 0, 100);
+
+  tracker.usage[1].first_node = 0;
+  tracker.usage[1].last_node = 2;
+  xnn_add_value_allocation_tracker(&tracker, 1, 90);
+
+  tracker.usage[2].first_node = 0;
+  tracker.usage[2].last_node = 0;
+  xnn_add_value_allocation_tracker(&tracker, 2, 80);
+
+  tracker.usage[3].first_node = 0;
+  tracker.usage[3].last_node = 2;
+  xnn_add_value_allocation_tracker(&tracker, 3, 70);
+
+  tracker.usage[4].first_node = 2;
+  tracker.usage[4].last_node = 3;
+  xnn_add_value_allocation_tracker(&tracker, 4, 60);
+
+  for (size_t i = 0; i < runtime.num_values; i++) {
+    tracker.usage[i].reuse_value_id = XNN_INVALID_VALUE_ID;
+  }
+  xnn_plan_value_allocation_tracker(&tracker);
+
+  EXPECT_EQ(0, tracker.usage[0].alloc_offset);
+  EXPECT_EQ(100, tracker.usage[1].alloc_offset);
+  EXPECT_EQ(190, tracker.usage[2].alloc_offset);
+  EXPECT_EQ(270, tracker.usage[3].alloc_offset);
+  EXPECT_EQ(190, tracker.usage[4].alloc_offset);
+  EXPECT_EQ(340, tracker.mem_arena_size);
+
+  xnn_release_value_allocation_tracker(&tracker);
+}
+
+TEST(MemoryPlanner, PrefersLeadingGapOnEqualFit) {
+  EXPECT_EQ(xnn_status_success, xnn_initialize(nullptr /* allocator */));
+  struct xnn_runtime runtime;
+  runtime.num_ops = 0;
+  runtime.num_values = 6;
+  struct xnn_value_allocation_tracker tracker;
+  xnn_init_value_allocation_tracker(&tracker, &runtime);
+
+  tracker.usage[0].first_node = 0;
+  tracker.usage[0].last_node = 0;
+  xnn_add_value_allocation_tracker(&tracker, 0, 110);
+
+  tracker.usage[1].first_node = 0;
+  tracker.usage[1].last_node = 2;
+  xnn_add_value_allocation_tracker(&tracker, 1, 100);
+
+  tracker.usage[2].first_node = 0;
+  tracker.usage[2].last_node = 0;
+  xnn_add_value_allocation_tracker(&tracker, 2, 60);
+
+  tracker.usage[3].first_node = 0;
+  tracker.usage[3].last_node = 0;
+  xnn_add_value_allocation_tracker(&tracker, 3, 50);
+
+  tracker.usage[4].first_node = 0;
+  tracker.usage[4].last_node = 2;
+  xnn_add_value_allocation_tracker(&tracker, 4, 45);
+
+  tracker.usage[5].first_node = 2;
+  tracker.usage[5].last_node = 3;
+  xnn_add_value_allocation_tracker(&tracker, 5, 40);
+
+  for (size_t i = 0; i < runtime.num_values; i++) {
+    tracker.usage[i].reuse_value_id = XNN_INVALID_VALUE_ID;
+  }
+  xnn_plan_value_allocation_tracker(&tracker);
+
+  EXPECT_EQ(0, tracker.usage[0].alloc_offset);
+  EXPECT_EQ(110, tracker.usage[1].alloc_offset);
+  EXPECT_EQ(210, tracker.usage[2].alloc_offset);
+  EXPECT_EQ(270, tracker.usage[3].alloc_offset);
+  EXPECT_EQ(320, tracker.usage[4].alloc_offset);
+  EXPECT_EQ(0, tracker.usage[5].alloc_offset);
+  EXPECT_EQ(365, tracker.mem_arena_size);
+
+  xnn_release_value_allocation_tracker(&tracker);
+}
+
 TEST(MemoryPlanner, GeneralPlanning) {
   EXPECT_EQ(xnn_status_success, xnn_initialize(nullptr /* allocator */));
   struct xnn_runtime runtime;


### PR DESCRIPTION
## Summary

- consider the free prefix before the first live memory block as a best-fit candidate
- preserve the existing append fallback and preference for a strictly smaller internal gap
- cover single-block reuse, smaller internal gaps, and deterministic equal-gap selection

## Root cause

`find_value_alloc_offset` searched gaps between coalesced live blocks and then
appended after the final block, but never considered
`[0, first_live_block.start)`. Its single-live-block fast path always appended.
This could grow the arena even when the leading interval was large enough and
free for the value's complete lifetime.

## Impact

Local subgraph benchmarks on an Intel Core i7-14700HX reported:

- FP32 MobileNet V1: 23.862980 to 22.331730 MiB peak allocation (6.42% lower)
- FP16 MobileNet V1: 21.255882 to 19.916039 MiB (6.30% lower)
- the other seven MobileNet cases were unchanged

A public-API resize/reduce witness reduced runtime workspace from 144 MiB + 32 B
to 112 MiB + 32 B with identical output hashes. This change does not alter the
planner's asymptotic complexity, and no invocation-speed change is claimed.

## Validation

- `memory-planner-test`: 23/23 passed
- relevant planner/subgraph CTest group: 4/4 passed
- 30 randomized baseline/candidate MobileNet pairs reproduced the exact memory deltas
- public runtime create, reshape, setup, and two invokes passed with matching outputs

Fixes #10800
