### PR TITLE
Add Qd8 bf16 qb4w subgraph for fully connected

### DIFF
--- a/src/subgraph/fully-connected.c
+++ b/src/subgraph/fully-connected.c
@@ -33,6 +33,7 @@ enum fully_connected_op_type {
   fc_type_qdu8_f16_qc2w,
   fc_type_qd8_f16_qc4w,
   fc_type_qd8_f16_qb4w,
+  fc_type_qd8_bf16_qb4w,
   fc_type_qd8_f16_qc8w,
   fc_type_f32_f32_f32,
   fc_type_f32_f32_f32_dynamic,
@@ -137,6 +138,20 @@ enum fully_connected_op_type get_fully_connected_op_type(
               return fc_type_qd8_f16_qc8w;
             case xnn_datatype_qduint8:
               return fc_type_qdu8_f16_qc8w;
+            default:
+              XNN_UNREACHABLE;
+          }
+          break;
+        default:
+          XNN_UNREACHABLE;
+      }
+      break;
+    case xnn_datatype_bf16:
+      switch (filter_datatype) {
+        case xnn_datatype_qbint4:
+          switch (input_datatype) {
+            case xnn_datatype_qdint8:
+              return fc_type_qd8_bf16_qb4w;
             default:
               XNN_UNREACHABLE;
           }
@@ -436,6 +451,25 @@ static enum xnn_status create_fully_connected_operator(
               /*kernel_zero_point=*/filter_value->quantization.zero_point,
               (const uint16_t*)
                   filter_value->quantization.blockwise_scale.fp16_scale,
+              kernel_data, bias_data, node->activation.output_min,
+              node->activation.output_max, node->flags, weights_cache,
+              fully_connected_op_ptr);
+          break;
+        default:
+          XNN_UNREACHABLE;
+      }
+      break;
+    case fc_type_qd8_bf16_qb4w:
+      switch (filter_value->quantization.scale_type) {
+        case xnn_datatype_bf16:
+          status = xnn_create_fully_connected_nc_qd8_bf16_qb4w(
+              input_channels, output_channels,
+              /*input_stride=*/input_channels,
+              /*output_stride=*/output_channels,
+              /*block_size=*/filter_value->quantization.block_size,
+              /*kernel_zero_point=*/filter_value->quantization.zero_point,
+              (const uint16_t*)
+                  filter_value->quantization.blockwise_scale.bf16_scale,
               kernel_data, bias_data, node->activation.output_min,
               node->activation.output_max, node->flags, weights_cache,
               fully_connected_op_ptr);
@@ -1073,6 +1107,10 @@ static enum xnn_status reshape_fully_connected_operator(
       status = xnn_reshape_fully_connected_nc_qd8_f16_qb4w(
           fully_connected_op, batch_size, &opdata->workspace_size, threadpool);
       break;
+    case xnn_operator_type_fully_connected_nc_qd8_bf16_qb4w:
+      status = xnn_reshape_fully_connected_nc_qd8_bf16_qb4w(
+          fully_connected_op, batch_size, &opdata->workspace_size, threadpool);
+      break;
     case xnn_operator_type_fully_connected_nc_qd8_f32_qb4w:
       status = xnn_reshape_fully_connected_nc_qd8_f32_qb4w(
           fully_connected_op, batch_size, &opdata->workspace_size, threadpool);
@@ -1376,6 +1414,17 @@ static enum xnn_status setup_fully_connected_operator(
           fully_connected_op, input_data, output_data, workspace,
           quantization_params);
     }
+    case xnn_operator_type_fully_connected_nc_qd8_bf16_qb4w: {
+      const void* quantization_params =
+          input_value->quantization.dynamic_params;
+      void* workspace = opdata->workspace;
+      assert(kernel_data == NULL);
+      assert(bias_data == NULL);
+      assert(quantization_params != NULL || workspace != NULL);
+      return xnn_setup_fully_connected_nc_qd8_bf16_qb4w(
+          fully_connected_op, input_data, output_data, workspace,
+          quantization_params);
+    }
     case xnn_operator_type_fully_connected_nc_qd8_f16_qc8w: {
       const void* quantization_params =
           input_value->quantization.dynamic_params;
@@ -1566,6 +1615,10 @@ static inline bool validate_datatypes_with_bias(
                  bias_datatype == xnn_datatype_fp32 &&
                  output_datatype == xnn_datatype_fp16) {
         return true;
+      } else if (input_datatype == xnn_datatype_qdint8 &&
+                 bias_datatype == xnn_datatype_fp32 &&
+                 output_datatype == xnn_datatype_bf16) {
+        return true;
       } else if (input_datatype == xnn_datatype_qpint8 &&
                  bias_datatype == xnn_datatype_fp32 &&
                  output_datatype == xnn_datatype_fp32) {
@@ -1682,6 +1735,9 @@ static inline bool validate_datatypes_without_bias(
         return true;
       } else if (input_datatype == xnn_datatype_qdint8 &&
                  output_datatype == xnn_datatype_fp16) {
+        return true;
+      } else if (input_datatype == xnn_datatype_qdint8 &&
+                 output_datatype == xnn_datatype_bf16) {
         return true;
       } else if (input_datatype == xnn_datatype_qpint8 &&
                  output_datatype == xnn_datatype_fp32) {
@@ -1990,6 +2046,7 @@ enum xnn_status xnn_define_fully_connected(xnn_subgraph_t subgraph,
   }
 
   switch (output_value->datatype) {
+    case xnn_datatype_bf16:
     case xnn_datatype_fp16:
     case xnn_datatype_fp32:
     case xnn_datatype_qint8:

--- a/test/subgraph/fully-connected.cc
+++ b/test/subgraph/fully-connected.cc
@@ -404,6 +404,10 @@ void TestStaticB(xnn_datatype convert_to = xnn_datatype_invalid,
       GTEST_SKIP();
       return;
     }
+    // CreateRuntime may also fail with unsupported_parameter for configs that
+    // have no available microkernel. Assert success so we never proceed to
+    // reshape a null runtime, which segfaults
+    ASSERT_EQ(xnn_status_success, status);
 
     // Run the subgraph twice, with a different input/output shape each time
     // (except for the input/output channels, which are determined by the filter
@@ -676,6 +680,10 @@ void TestDynamicB(xnn_datatype convert_to = xnn_datatype_invalid,
       GTEST_SKIP();
       return;
     }
+    // CreateRuntime may also fail with unsupported_parameter for configs that
+    // have no available microkernel. Assert success so we never proceed to
+    // reshape a null runtime, which segfaults
+    ASSERT_EQ(xnn_status_success, status);
 
     // Run the subgraph twice, with a different input/output shape each time.
     for (int reshape = 0; reshape < 2; ++reshape) {

--- a/test/subgraph/fully-connected.cc
+++ b/test/subgraph/fully-connected.cc
@@ -601,6 +601,12 @@ TEST(FullyConnectedQD8F32QB4W_F16, static_b) {
   TestStaticB<float, qcint4, float, float, xnn_float16>(
       /*convert_to=*/xnn_datatype_qdint8, /*block_size=*/32);
 }
+// bf16 output only supports bf16-typed blockwise scales (there is no
+// qd8_bf16_qb4w_f16_scales create variant), so no _F16 counterpart here.
+TEST(FullyConnectedQD8BF16QB4W_BF16, static_b) {
+  TestStaticB<float, qcint4, float, xnn_bfloat16, xnn_bfloat16>(
+      /*convert_to=*/xnn_datatype_qdint8, /*block_size=*/32);
+}
 #endif  // XNNPACK_USE_YNNPACK
 
 template <typename Input, typename Filter, typename Bias,


### PR DESCRIPTION
# Summary
Previous PR added support for some microkernels and a f32->bf16 rewrite, but did not add the subgraph, this PR completes an initial FC bring up

# Test Plan
```
cmake -B build-test -DCMAKE_BUILD_TYPE=Release \
        -DXNNPACK_BUILD_TESTS=ON -DXNNPACK_BUILD_BENCHMARKS=OFF
cmake --build build-test --target fully-connected-test -j"$(nproc)"
./build-test/test/subgraph/fully-connected-test --gtest_filter='*QD8BF16QB4W*'
  Expected:
  [ RUN      ] FullyConnectedQD8BF16QB4W_BF16.static_b
  [       OK ] FullyConnectedQD8BF16QB4W_BF16.static_b (501 ms)
  [  PASSED  ] 1 test.
```