### PR TITLE
average-pooling-nhwc: guard pixelwise buffer size against integer overflow

### DIFF
--- a/src/operators/average-pooling-nhwc.c
+++ b/src/operators/average-pooling-nhwc.c
@@ -522,7 +522,16 @@ static XNN_NO_SANITIZE_FUNCTION enum xnn_status reshape_average_pooling2d(
     assert(indirection_init_pavgpool2d != NULL);
 
     if (input_size_changed) {
-      const size_t pixelwise_buffer_size = (output_height * output_width) << log2_weight_element_size;
+      size_t num_output_pixels = 0;
+      size_t pixelwise_buffer_size = 0;
+      if (!xnn_safe_mul(output_height, output_width, &num_output_pixels) ||
+          !xnn_safe_mul(num_output_pixels, (size_t)1u << log2_weight_element_size,
+                        &pixelwise_buffer_size)) {
+        xnn_log_error(
+            "failed to reshape %s operator: pixelwise buffer size overflows size_t",
+            xnn_operator_type_to_string_v2(average_pooling_op));
+        return xnn_status_out_of_memory;
+      }
       void* pixelwise_buffer = xnn_reallocate_memory(average_pooling_op->convolution_op->pixelwise_buffer, pixelwise_buffer_size);
       if (pixelwise_buffer == NULL) {
         xnn_log_error(


### PR DESCRIPTION
On 32-bit targets (WebAssembly, ARM32) where `size_t` is 32 bits, the pixelwise buffer size in `reshape_average_pooling2d` is computed as a raw left-shift with no overflow guard:

```c
const size_t pixelwise_buffer_size = (output_height * output_width) << log2_weight_element_size;
```

When `output_height * output_width >= 2^30` (f32, `log2_weight_element_size = 2`) or `>= 2^31` (f16), the product followed by the shift wraps to zero. `xnn_reallocate_memory` is called with size 0, returning a zero-size allocation. `xnn_indirection_init_pavgpool2d_f32` then writes `output_height * output_width` float values into this undersized buffer,
producing a heap out-of-bounds write.

The indirection buffer immediately above this code in the same `if (input_size_changed)` block was already guarded with `xnn_safe_mul` by a prior fix; this commit applies the same pattern to the pixelwise buffer.

Fix: use `xnn_safe_mul` to detect overflow before the allocation and return `xnn_status_out_of_memory`, consistent with guards elsewhere in this file.