### PR TITLE
batch-matrix-multiply-nc: guard workspace size against integer overflow

### DIFF
--- a/src/operators/batch-matrix-multiply-nc.c
+++ b/src/operators/batch-matrix-multiply-nc.c
@@ -974,14 +974,25 @@ reshape_batch_matrix_multiply_nc(
                   extra_weights_bytes)
             : (k_stride << log2_input_b_element_size) + bias_element_size +
                 extra_weights_bytes;
-    const size_t input_b_batch_stride = n_stride * weights_stride;
+    size_t input_b_batch_stride = 0;
+    if (!xnn_safe_mul(n_stride, weights_stride, &input_b_batch_stride)) {
+      xnn_log_error(
+          "failed to reshape %s operator: batch stride overflows size_t",
+          xnn_operator_type_to_string_v2(batch_matrix_multiply_op));
+      return xnn_status_out_of_memory;
+    }
 
     // Store the computed weights stride in the op for later use.
     batch_matrix_multiply_op->weights_stride = weights_stride;
 
     // Compute the required workspace size.
     if (workspace_size != NULL) {
-      *workspace_size = batch_size_b * input_b_batch_stride;
+      if (!xnn_safe_mul(batch_size_b, input_b_batch_stride, workspace_size)) {
+        xnn_log_error(
+            "failed to reshape %s operator: workspace size overflows size_t",
+            xnn_operator_type_to_string_v2(batch_matrix_multiply_op));
+        return xnn_status_out_of_memory;
+      }
     }
     xnn_log_debug("Requesting workspace of size %zu for packed weights.",
                   *workspace_size);


### PR DESCRIPTION
In `reshape_batch_matrix_multiply_nc`, when `const_weights` is false (dynamic weight packing into workspace), the workspace size is computed by two chained multiplications with no overflow guard:

```c
const size_t input_b_batch_stride = n_stride * weights_stride;
// ...
*workspace_size = batch_size_b * input_b_batch_stride;
```

On 32-bit targets (WebAssembly, ARM32) where `size_t` is 32 bits, either product can wrap. For example with `n = 32768`, `k = 16384`, f32:

- `n_stride = 32768`, `weights_stride = 16384 * 4 + 4 = 65540`
- `input_b_batch_stride = 32768 * 65540 = ~2.1 GB → wraps to a small value`
- `*workspace_size` is then a few bytes or zero

The runtime allocates workspace of the wrapped size. The packing kernel (`packw_gemm_goi` / `packw_gemm_gio`) iterates over all `batch_size_b` batches with `gc_stride = input_b_batch_stride`, writing each batch at true byte offset `b * input_b_batch_stride` into the undersized workspace. 
This produces a heap out-of-bounds write covering the full intended workspace extent.

Fix: guard both multiplications with `xnn_safe_mul` and return `xnn_status_out_of_memory` on overflow.

Note: the related overflow in `create_batch_matrix_multiply_nc_const_weights` (line 406) is addressed separately in PR #9860.