### PR TITLE
dynamic-fully-connected-nc: guard workspace size against integer overflow

### DIFF
--- a/src/operators/dynamic-fully-connected-nc.c
+++ b/src/operators/dynamic-fully-connected-nc.c
@@ -463,7 +463,12 @@ reshape_dynamic_fully_connected_nc(
       dynamic_fully_connected_op->dynamic_context.gemm;
 
   // TODO(zhin): fast path to query workspace size when workspace_size != NULL?
-  *workspace_size = n_stride * weights_stride;
+  if (!xnn_safe_mul(n_stride, weights_stride, workspace_size)) {
+    xnn_log_error(
+        "failed to reshape %s operator: workspace size overflows size_t",
+        xnn_operator_type_to_string_v2(dynamic_fully_connected_op));
+    return xnn_status_out_of_memory;
+  }
 
   if (dynamic_fully_connected_op->flags & XNN_FLAG_TRANSPOSE_WEIGHTS) {
     assert(ukernel->packw_gemm_gio || gemm_config->pack_weights_and_biases);


### PR DESCRIPTION
`reshape_dynamic_fully_connected_nc` computes the packed-weights workspace
size as a raw multiplication with no overflow guard:

```c
*workspace_size = n_stride * weights_stride;
```

On 32-bit targets (WebAssembly, ARM32) where `size_t` is 32 bits:

- `n_stride = round_up(output_channels, nr)` — large when output_channels is large
- `weights_stride = k_stride * element_size + bias_element_size` — large when input_channels is large
- The product wraps when `n_stride * weights_stride >= 2^32`. For f32 with
  `output_channels = 65536` and `input_channels = 16384`:
  `n_stride = 65536`, `weights_stride = 65540` → product ~4 GB wraps to ~4 bytes

The runtime allocates workspace of the wrapped size. The packing kernel
(`packw_gemm_goi` / `packw_gemm_gio`) then writes the full `n_stride *
weights_stride` bytes of packed weights into this undersized workspace,
producing a heap out-of-bounds write.

Fix: replace the raw multiplication with `xnn_safe_mul` and return
`xnn_status_out_of_memory` on overflow.