### PR TITLE
Guard packed weights size against integer overflow in batch matrix multiply

### DIFF
--- a/src/operators/batch-matrix-multiply-nc.c
+++ b/src/operators/batch-matrix-multiply-nc.c
@@ -439,7 +439,14 @@ XNN_NO_SANITIZE_FUNCTION enum xnn_status create_batch_matrix_multiply_nc_const_w
     const uint32_t nr =
         batch_matrix_multiply_op->ukernel.gemm_ukernels->gemm.nr;
     const size_t n_stride = round_up(n, nr);
-    const size_t packed_size = batch_size_b * n_stride * weights_stride;
+    size_t packed_size;
+    if (!xnn_safe_mul(batch_size_b, n_stride, &packed_size) ||
+        !xnn_safe_mul(packed_size, weights_stride, &packed_size)) {
+      xnn_log_error(
+          "failed to create %s operator: packed weights size overflows size_t",
+          xnn_operator_type_to_string_v2(batch_matrix_multiply_op));
+      return xnn_status_out_of_memory;
+    }
     const size_t aligned_size =
         round_up_po2(packed_size, XNN_ALLOCATION_ALIGNMENT);
 


### PR DESCRIPTION
create_batch_matrix_multiply_nc_const_weights computes the packed weights buffer size as:

    packed_size = batch_size_b * n_stride * weights_stride

with no overflow protection, unlike reshape_batch_matrix_multiply_nc in the same file which already uses xnn_safe_mul for its own workspace size computation.

This uses xnn_safe_mul for the same computation here, consistent with that existing pattern.