### PR TITLE
Fix bad-free in rewrite_dequant_bmm_at on fixed-capacity scratch subgraphs

### DIFF
--- a/src/subgraph.c
+++ b/src/subgraph.c
@@ -4242,6 +4242,15 @@ static bool is_qs8_to_f32_dequant(const struct xnn_subgraph* subgraph,
 }
 
 static bool rewrite_dequant_bmm_at(xnn_subgraph_t subgraph, uint32_t node_id) {
+  // Only batch-matrix-multiply nodes are rewritten here. Check the node type
+  // *before* reserving any space: reserving may reallocate the subgraph's node
+  // and value arrays, and some callers optimize a fixed-capacity scratch
+  // subgraph whose `nodes`/`values` storage is not heap-allocated and must not
+  // be reallocated (see `xnn_subgraph_fuse_unary_quantized_into_lut`).
+  if (subgraph->nodes[node_id].type != xnn_node_type_batch_matrix_multiply) {
+    return false;
+  }
+
   // Reserve space upfront (we'll add 1 value + 1 node) so the later
   // `xnn_subgraph_new_internal_value` / `xnn_subgraph_new_node` calls do not
   // each trigger an additional reallocation or invalidate pointers.
@@ -4251,10 +4260,6 @@ static bool rewrite_dequant_bmm_at(xnn_subgraph_t subgraph, uint32_t node_id) {
   }
 
   struct xnn_node* node = &subgraph->nodes[node_id];
-  if (node->type != xnn_node_type_batch_matrix_multiply) {
-    return false;
-  }
-
   const uint32_t input_a_id = node->inputs[0];
   const uint32_t input_b_id = node->inputs[1];
   const uint32_t output_id = node->outputs[0];


### PR DESCRIPTION
`rewrite_dequant_bmm_at()` reserves node/value capacity before checking the node type. The reserve can `realloc()` the subgraph's arrays, which is unsafe for the stack-allocated scratch subgraph built by `xnn_subgraph_fuse_unary_quantized_into_lut()` (`unary_nodes`/`unary_values`, capped at `XNN_MAX_UNARY_FUSION_NODES`). When a fusion chain fills all slots, the reserve calls `realloc()` on a stack pointer → bad-free.

Fix: check for `batch_matrix_multiply` before reserving. A scratch subgraph contains only unary elementwise ops, so it never matches and the stray `realloc()` is avoided. Real heap-backed graphs with a BMM node are unaffected (they still reserve upfront).

See chromium issue: https://issues.chromium.org/issues/539052047