### PR TITLE
memory-planner: add NULL checks after xnn_allocate_zero_memory

### DIFF
--- a/src/memory-planner.c
+++ b/src/memory-planner.c
@@ -10,6 +10,7 @@
 
 #include "include/xnnpack.h"
 #include "src/xnnpack/allocator.h"
+#include "src/xnnpack/log.h"
 #include "src/xnnpack/memory-planner.h"
 #include "src/xnnpack/subgraph.h"
 
@@ -143,15 +144,21 @@ static size_t find_value_alloc_offset(struct memory_block* live_mem_blocks,
   return live_mem_blocks[smallest_gap_index].end;
 }
 
-void xnn_init_value_allocation_tracker(
+enum xnn_status xnn_init_value_allocation_tracker(
   struct xnn_value_allocation_tracker* tracker,
   const struct xnn_runtime* runtime)
 {
   tracker->mem_arena_size = 0;
   tracker->usage = xnn_allocate_zero_memory(sizeof(struct xnn_usage_record) * (runtime->num_values + runtime->num_ops));
+  if (tracker->usage == NULL) {
+    xnn_log_error("failed to allocate %zu bytes for memory planning usage tracker",
+                  sizeof(struct xnn_usage_record) * (runtime->num_values + runtime->num_ops));
+    return xnn_status_out_of_memory;
+  }
   populate_value_lifecycle(runtime, tracker->usage);
   tracker->min_value_id = XNN_INVALID_VALUE_ID;
   tracker->max_value_id = XNN_INVALID_VALUE_ID;
+  return xnn_status_success;
 }
 
 void xnn_mark_tensor_as_reuse(struct xnn_value_allocation_tracker* tracker,
@@ -200,14 +207,19 @@ void xnn_add_operator_workspace_allocation_tracker(
   tracker->usage[operator_workspace_value_id].opdata_id = opdata_id;
 }
 
-void xnn_plan_value_allocation_tracker(struct xnn_value_allocation_tracker* tracker) {
+enum xnn_status xnn_plan_value_allocation_tracker(struct xnn_value_allocation_tracker* tracker) {
   if (tracker->min_value_id == XNN_INVALID_VALUE_ID) {
     assert(tracker->max_value_id == XNN_INVALID_VALUE_ID);
-    return;
+    return xnn_status_success;
   }
 
   const uint32_t num_values = tracker->max_value_id - tracker->min_value_id + 1;
   struct xnn_usage_record** sorted_usage = xnn_allocate_zero_memory(sizeof(struct xnn_usage_record*) * num_values);
+  if (sorted_usage == NULL) {
+    xnn_log_error("failed to allocate %zu bytes for memory planning sorted usage array",
+                  sizeof(struct xnn_usage_record*) * num_values);
+    return xnn_status_out_of_memory;
+  }
   size_t num_values_to_alloc = 0;
   for (size_t i = tracker->min_value_id; i <= tracker->max_value_id; ++i) {
     struct xnn_usage_record* info = tracker->usage + i;
@@ -220,6 +232,12 @@ void xnn_plan_value_allocation_tracker(struct xnn_value_allocation_tracker* trac
   // Start the allocation planning process.
   struct memory_block* current_live_mem_blocks = xnn_allocate_zero_memory(
       sizeof(struct memory_block) * num_values_to_alloc);
+  if (current_live_mem_blocks == NULL && num_values_to_alloc != 0) {
+    xnn_log_error("failed to allocate %zu bytes for memory planning live blocks array",
+                  sizeof(struct memory_block) * num_values_to_alloc);
+    xnn_release_memory(sorted_usage);
+    return xnn_status_out_of_memory;
+  }
   size_t mem_arena_size = 0;
   for (size_t i = 0; i < num_values_to_alloc; ++i) {
     size_t num_live_mem_blocks = 0;
@@ -253,4 +271,5 @@ void xnn_plan_value_allocation_tracker(struct xnn_value_allocation_tracker* trac
   tracker->mem_arena_size = mem_arena_size;
   xnn_release_memory(sorted_usage);
   xnn_release_memory(current_live_mem_blocks);
+  return xnn_status_success;
 }

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -824,7 +824,10 @@ enum xnn_status xnn_plan_memory(
     xnn_runtime_t runtime) {
   enum xnn_status status = xnn_status_invalid_state;
   struct xnn_value_allocation_tracker mem_alloc_tracker;
-  xnn_init_value_allocation_tracker(&mem_alloc_tracker, runtime);
+  status = xnn_init_value_allocation_tracker(&mem_alloc_tracker, runtime);
+  if (status != xnn_status_success) {
+    return status;
+  }
 
   for (uint32_t i = 0; i < runtime->num_values; i++) {
     const struct xnn_runtime_value* value = &runtime->values[i];
@@ -851,7 +854,10 @@ enum xnn_status xnn_plan_memory(
   }
 
   optimize_tensor_allocation_for_in_place_operations(&mem_alloc_tracker, runtime);
-  xnn_plan_value_allocation_tracker(&mem_alloc_tracker);
+  status = xnn_plan_value_allocation_tracker(&mem_alloc_tracker);
+  if (status != xnn_status_success) {
+    goto error;
+  }
 
   status = initialize_workspace_values(runtime, &mem_alloc_tracker);
   if (status != xnn_status_success) {

--- a/src/xnnpack/memory-planner.h
+++ b/src/xnnpack/memory-planner.h
@@ -51,7 +51,10 @@ struct xnn_value_allocation_tracker {
 };
 
 // Initialize the memory allocation tracker for xnn_values.
-XNN_INTERNAL void xnn_init_value_allocation_tracker(
+// Returns xnn_status_out_of_memory if the internal usage array cannot be
+// allocated. On failure the tracker must not be used and does not need to be
+// released.
+XNN_INTERNAL enum xnn_status xnn_init_value_allocation_tracker(
     struct xnn_value_allocation_tracker* tracker,
     const struct xnn_runtime* runtime);
 
@@ -85,7 +88,9 @@ XNN_INTERNAL void xnn_mark_tensor_as_reuse(
 
 // Plan the exact the memory allocation for intermediate tensors according to
 // the xnn_value allocation tracker.
-XNN_INTERNAL void xnn_plan_value_allocation_tracker(
+// Returns xnn_status_out_of_memory if an internal scratch buffer cannot be
+// allocated.
+XNN_INTERNAL enum xnn_status xnn_plan_value_allocation_tracker(
     struct xnn_value_allocation_tracker* tracker);
 
 #ifdef __cplusplus

--- a/src/xnnpack/memory-planner.h
+++ b/src/xnnpack/memory-planner.h
@@ -51,6 +51,7 @@ struct xnn_value_allocation_tracker {
 };
 
 // Initialize the memory allocation tracker for xnn_values.
+//
 // Returns xnn_status_out_of_memory if the internal usage array cannot be
 // allocated. On failure the tracker must not be used and does not need to be
 // released.
@@ -88,6 +89,7 @@ XNN_INTERNAL void xnn_mark_tensor_as_reuse(
 
 // Plan the exact the memory allocation for intermediate tensors according to
 // the xnn_value allocation tracker.
+//
 // Returns xnn_status_out_of_memory if an internal scratch buffer cannot be
 // allocated.
 XNN_INTERNAL enum xnn_status xnn_plan_value_allocation_tracker(


### PR DESCRIPTION
## Summary

`xnn_init_value_allocation_tracker` and `xnn_plan_value_allocation_tracker` each call `xnn_allocate_zero_memory` for internal scratch buffers but do not check the returned pointer before using it. On memory-constrained devices any of the three allocations can return NULL, producing an immediate null pointer dereference.

Three affected sites in `src/memory-planner.c`:

- `xnn_init_value_allocation_tracker` (line 151): `tracker->usage` passed directly to `populate_value_lifecycle`, which indexes it unconditionally
- `xnn_plan_value_allocation_tracker` (line 210): `sorted_usage` written to in the immediately following loop
- `xnn_plan_value_allocation_tracker` (line 221): `current_live_mem_blocks` written to inside the planning loop

Both functions are changed to return `enum xnn_status`. `xnn_plan_memory` in `runtime.c` is updated to check both return values and propagate `xnn_status_out_of_memory` to its caller (`xnn_reshape_runtime` / `xnn_setup_runtime_v2`).

## Changes

- `src/xnnpack/memory-planner.h`: update declarations of `xnn_init_value_allocation_tracker` and `xnn_plan_value_allocation_tracker` to return `enum xnn_status`
- `src/memory-planner.c`: add NULL guards and early returns; add `src/xnnpack/log.h` include for `xnn_log_error`
- `src/runtime.c`: check return values of both planning functions in `xnn_plan_memory`