### PR TITLE
litert/arithmetic: add bounds checks to Gather, Slice, and TopK shape inference

### DIFF
--- a/litert/tensor/arithmetic.h
+++ b/litert/tensor/arithmetic.h
@@ -2195,23 +2195,30 @@ Tensor<Mixins...> Gather(Tensor<Mixins...> input, Tensor<Mixins...> indices,
   graph::TensorInformation& output_info = *GetInfo(output.GetRaw());
   output_info.type = input_info.type;
   output_info.shape.clear();
-  if (axis < 0 || axis >= static_cast<int>(input_info.shape.size())) {
+  int resolved_axis = axis;
+  if (resolved_axis < 0) {
+    resolved_axis += static_cast<int>(input_info.shape.size());
+  }
+  if (resolved_axis < 0 ||
+      resolved_axis >= static_cast<int>(input_info.shape.size())) {
     return Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
         "The Gather axis is out of range.")));
   }
+  op->axis = resolved_axis;
   if (batch_dims < 0 ||
       batch_dims > static_cast<int>(indices_info.shape.size())) {
     return Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
         "The Gather batch_dims is out of range.")));
   }
   int i = 0;
-  for (; i < axis; ++i) {
+  for (; i < resolved_axis; ++i) {
     output_info.shape.push_back(input_info.shape[i]);
   }
   output_info.shape.insert(output_info.shape.end(),
                            indices_info.shape.begin() + batch_dims,
                            indices_info.shape.end());
-  for (i = axis + 1; i < input_info.shape.size(); ++i) {
+  for (i = resolved_axis + 1;
+       i < static_cast<int>(input_info.shape.size()); ++i) {
     output_info.shape.push_back(input_info.shape[i]);
   }
 

--- a/litert/tensor/arithmetic.h
+++ b/litert/tensor/arithmetic.h
@@ -1888,6 +1888,10 @@ Tensor<Mixins...> Slice(Tensor<Mixins...> input, Tensor<Mixins...> begin,
   output_info.type = input_info.type;
   if (size_info.buffer) {
     const auto size_data = size_info.buffer->Lock().As<const int32_t>();
+    if (size_data.size() != input_info.shape.size()) {
+      return Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
+          "Slice size tensor length must equal input rank.")));
+    }
     output_info.shape.assign(size_data.begin(), size_data.end());
     for (size_t i = 0; i < output_info.shape.size(); ++i) {
       if (output_info.shape[i] == -1) {
@@ -2090,8 +2094,20 @@ std::vector<Tensor<Mixins...>> TopK(
   graph::TensorInformation& values_info = *GetInfo(values.GetRaw());
   values_info.type = input_info.type;
   values_info.shape = input_info.shape;
+  if (GetInfo(k.GetRaw())->buffer == nullptr) {
+    auto error = absl::InvalidArgumentError(
+        "TopK k tensor must have a buffer.");
+    return {Tensor<Mixins...>(graph::ErrorTensor(error)),
+            Tensor<Mixins...>(graph::ErrorTensor(error))};
+  }
   LockedBufferSpan<const int32_t> k_lock =
       GetInfo(k.GetRaw())->buffer->Lock().template As<const int32_t>();
+  if (k_lock.size() < 1) {
+    auto error = absl::InvalidArgumentError(
+        "TopK k tensor buffer must contain at least one element.");
+    return {Tensor<Mixins...>(graph::ErrorTensor(error)),
+            Tensor<Mixins...>(graph::ErrorTensor(error))};
+  }
   const int k_val = k_lock.data()[0];
   values_info.shape.back() = k_val;
   outputs.push_back(values);
@@ -2179,6 +2195,15 @@ Tensor<Mixins...> Gather(Tensor<Mixins...> input, Tensor<Mixins...> indices,
   graph::TensorInformation& output_info = *GetInfo(output.GetRaw());
   output_info.type = input_info.type;
   output_info.shape.clear();
+  if (axis < 0 || axis >= static_cast<int>(input_info.shape.size())) {
+    return Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
+        "The Gather axis is out of range.")));
+  }
+  if (batch_dims < 0 ||
+      batch_dims > static_cast<int>(indices_info.shape.size())) {
+    return Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
+        "The Gather batch_dims is out of range.")));
+  }
   int i = 0;
   for (; i < axis; ++i) {
     output_info.shape.push_back(input_info.shape[i]);


### PR DESCRIPTION
## Summary

`litert/tensor/arithmetic.h` contains three shape-inference functions with missing input validation, following the same pattern fixed for ten other functions by PRs #10464 and #10702.

- **Gather**: `axis` and `batch_dims` were used as direct loop bounds and iterator offsets against `std::vector<int>` shape vectors without validating them against the actual tensor rank. An out-of-range `axis` caused heap out-of-bounds reads via `input_info.shape[i]`; an out-of-range `batch_dims` produced an invalid iterator passed to `insert`.

- **Slice**: The size tensor buffer length was not checked against the input tensor rank before the `-1` sentinel loop. When `size_data.size() > input_info.shape.size()` and a `-1` element appeared at index `i >= input rank`, the code read `input_info.shape[i]` past the end of the allocated vector.

- **TopK**: The `k` tensor's buffer pointer was dereferenced without a null check (every comparable function — `Sum`, `ReduceMax`, `Mean`, `ArgMax` — checks `buffer == nullptr` first), and `k_lock.data()[0]` was accessed without verifying the buffer contained at least one element.

## Fix

Added the same `InvalidArgumentError` guard pattern used throughout the rest of the file:
- `Gather`: validate `0 <= axis < input rank` and `0 <= batch_dims <= indices rank` before the loop and insert.
- `Slice`: validate `size_data.size() == input_info.shape.size()` before assigning the output shape.
- `TopK`: check `buffer != nullptr` and `k_lock.size() >= 1` before reading `k_lock.data()[0]`.