### PR TITLE
Fix null pointer dereference on OOM in f16→f32/bf16 conversion paths

### DIFF
--- a/src/operators/convolution-nhwc.c
+++ b/src/operators/convolution-nhwc.c
@@ -2504,6 +2504,9 @@ enum xnn_status xnn_create_convolution2d_nhwc_f32_f16(
                                     kernel_height;
   float* fp32_kernel_buffer =
       (float*)xnn_allocate_memory(num_kernel_entries * sizeof(float));
+  if (fp32_kernel_buffer == NULL) {
+    return xnn_status_out_of_memory;
+  }
   const void* bias_buffer = NULL;
   float* fp32_bias_buffer = NULL;
   const xnn_float16* f16_kernel = (const xnn_float16*)kernel;
@@ -2514,6 +2517,10 @@ enum xnn_status xnn_create_convolution2d_nhwc_f32_f16(
   if (bias && !(flags & XNN_FLAG_FP32_STATIC_BIASES)) {
     fp32_bias_buffer = (float*)xnn_allocate_memory(
         groups * group_output_channels * sizeof(float));
+    if (fp32_bias_buffer == NULL) {
+      xnn_release_memory(fp32_kernel_buffer);
+      return xnn_status_out_of_memory;
+    }
     bias_buffer = fp32_bias_buffer;
     for (size_t i = 0; i < groups * group_output_channels; ++i) {
       fp32_bias_buffer[i] = xnn_float16_to_float(f16_bias[i]);
@@ -2583,6 +2590,9 @@ enum xnn_status xnn_create_convolution2d_nhwc_pf32_f16(
                                     kernel_height;
   float* fp32_kernel_buffer =
       (float*)xnn_allocate_memory(num_kernel_entries * sizeof(float));
+  if (fp32_kernel_buffer == NULL) {
+    return xnn_status_out_of_memory;
+  }
   const void* bias_buffer = NULL;
   float* fp32_bias_buffer = NULL;
   const xnn_float16* f16_kernel = (const xnn_float16*)kernel;
@@ -2593,6 +2603,10 @@ enum xnn_status xnn_create_convolution2d_nhwc_pf32_f16(
   if (bias && !(flags & XNN_FLAG_FP32_STATIC_BIASES)) {
     fp32_bias_buffer = (float*)xnn_allocate_memory(
         groups * group_output_channels * sizeof(float));
+    if (fp32_bias_buffer == NULL) {
+      xnn_release_memory(fp32_kernel_buffer);
+      return xnn_status_out_of_memory;
+    }
     bias_buffer = fp32_bias_buffer;
     for (size_t i = 0; i < groups * group_output_channels; ++i) {
       fp32_bias_buffer[i] = xnn_float16_to_float(f16_bias[i]);

--- a/src/operators/deconvolution-nhwc.c
+++ b/src/operators/deconvolution-nhwc.c
@@ -1722,6 +1722,9 @@ enum xnn_status xnn_create_deconvolution2d_nhwc_f32_f16(
                                     kernel_height;
   float* fp32_kernel_buffer =
       (float*)xnn_allocate_memory(num_kernel_entries * sizeof(float));
+  if (fp32_kernel_buffer == NULL) {
+    return xnn_status_out_of_memory;
+  }
   float* fp32_bias_buffer = NULL;
   const xnn_float16* f16_kernel = (const xnn_float16*)kernel;
   const xnn_float16* f16_bias = (const xnn_float16*)bias;
@@ -1731,6 +1734,10 @@ enum xnn_status xnn_create_deconvolution2d_nhwc_f32_f16(
   if (bias && !(flags & XNN_FLAG_FP32_STATIC_BIASES)) {
     fp32_bias_buffer = (float*)xnn_allocate_memory(
         groups * group_output_channels * sizeof(float));
+    if (fp32_bias_buffer == NULL) {
+      xnn_release_memory(fp32_kernel_buffer);
+      return xnn_status_out_of_memory;
+    }
     for (size_t i = 0; i < groups * group_output_channels; ++i) {
       fp32_bias_buffer[i] = xnn_float16_to_float(f16_bias[i]);
     }

--- a/src/operators/fully-connected-nc.c
+++ b/src/operators/fully-connected-nc.c
@@ -1950,6 +1950,9 @@ enum xnn_status xnn_create_fully_connected_nc_qd8_f16_qb4w_f16_scales(
       (input_channels + block_size - 1) / block_size * output_channels;
   xnn_bfloat16* bf16_scale_buffer =
       (xnn_bfloat16*)xnn_allocate_memory(num_blocks * sizeof(xnn_bfloat16));
+  if (bf16_scale_buffer == NULL) {
+    return xnn_status_out_of_memory;
+  }
   for (size_t i = 0; i < num_blocks; ++i) {
     bf16_scale_buffer[i] = xnn_bfloat16_from_float(
         xnn_float16_to_float(((const xnn_float16*)kernel_scale)[i]));
@@ -2395,6 +2398,9 @@ enum xnn_status xnn_create_fully_connected_nc_f32_f16(
     xnn_weights_cache_t weights_cache, xnn_operator_t* fully_connected_op_out) {
   float* fp32_kernel_buffer = (float*)xnn_allocate_memory(
       input_channels * output_channels * sizeof(float));
+  if (fp32_kernel_buffer == NULL) {
+    return xnn_status_out_of_memory;
+  }
   float* fp32_bias_buffer = NULL;
   float* fp32_bias_buffer_to_release = NULL;
   const xnn_float16* f16_kernel = (const xnn_float16*)kernel;
@@ -2405,6 +2411,10 @@ enum xnn_status xnn_create_fully_connected_nc_f32_f16(
   if (bias && !(flags & XNN_FLAG_FP32_STATIC_BIASES)) {
     fp32_bias_buffer_to_release =
         (float*)xnn_allocate_memory(output_channels * sizeof(float));
+    if (fp32_bias_buffer_to_release == NULL) {
+      xnn_release_memory(fp32_kernel_buffer);
+      return xnn_status_out_of_memory;
+    }
     fp32_bias_buffer = fp32_bias_buffer_to_release;
     for (size_t i = 0; i < output_channels; ++i) {
       fp32_bias_buffer[i] = xnn_float16_to_float(f16_bias[i]);
@@ -2443,6 +2453,9 @@ enum xnn_status xnn_create_fully_connected_nc_pf32_f16(
     xnn_weights_cache_t weights_cache, xnn_operator_t* fully_connected_op_out) {
   float* fp32_kernel_buffer = (float*)xnn_allocate_memory(
       input_channels * output_channels * sizeof(float));
+  if (fp32_kernel_buffer == NULL) {
+    return xnn_status_out_of_memory;
+  }
   float* fp32_bias_buffer = NULL;
   float* fp32_bias_buffer_to_release = NULL;
   const xnn_float16* f16_kernel = (const xnn_float16*)kernel;
@@ -2453,6 +2466,10 @@ enum xnn_status xnn_create_fully_connected_nc_pf32_f16(
   if (bias && !(flags & XNN_FLAG_FP32_STATIC_BIASES)) {
     fp32_bias_buffer_to_release =
         (float*)xnn_allocate_memory(output_channels * sizeof(float));
+    if (fp32_bias_buffer_to_release == NULL) {
+      xnn_release_memory(fp32_kernel_buffer);
+      return xnn_status_out_of_memory;
+    }
     fp32_bias_buffer = fp32_bias_buffer_to_release;
     for (size_t i = 0; i < output_channels; ++i) {
       fp32_bias_buffer[i] = xnn_float16_to_float(f16_bias[i]);


### PR DESCRIPTION
## Summary

`xnn_allocate_memory` is a thin `malloc` wrapper that returns `NULL` on allocation failure. Six public operator-create functions allocated temporary buffers to convert float16 kernel weights or activation scales to float32/bfloat16, then immediately dereferenced the returned pointer in a write loop - with no null check in between. On any OOM condition this produces an unconditional null pointer dereference (SIGSEGV) before operator creation even begins.

**Affected functions:**
- `xnn_create_convolution2d_nhwc_f32_f16` (`src/operators/convolution-nhwc.c`)
- `xnn_create_convolution2d_nhwc_pf32_f16` (`src/operators/convolution-nhwc.c`)
- `xnn_create_deconvolution2d_nhwc_f32_f16` (`src/operators/deconvolution-nhwc.c`)
- `xnn_create_fully_connected_nc_f32_f16` (`src/operators/fully-connected-nc.c`)
- `xnn_create_fully_connected_nc_pf32_f16` (`src/operators/fully-connected-nc.c`)
- `xnn_create_fully_connected_nc_qd8_f16_qb4w_f16_scales` (`src/operators/fully-connected-nc.c`)

Note: `xnn_allocate_zero_memory` explicitly checks for `NULL` before calling `memset`, confirming that the codebase expects callers of `xnn_allocate_memory` to guard against NULL returns - the six functions above do not.

## Fix

Add `NULL` checks after each allocation and return `xnn_status_out_of_memory`. For conditional bias/scale buffers, release the already-allocated kernel buffer before returning to avoid a memory leak.