### PR TITLE
Fix null pointer dereference on OOM in subgraph compilation and NCHW convolution create

### DIFF
--- a/src/operators/convolution-nchw.c
+++ b/src/operators/convolution-nchw.c
@@ -1230,6 +1230,9 @@ enum xnn_status xnn_create_convolution2d_nchw_f32_f16(
                                     kernel_height;
   float* fp32_kernel_buffer =
       (float*)xnn_allocate_memory(num_kernel_entries * sizeof(float));
+  if (fp32_kernel_buffer == NULL) {
+    return xnn_status_out_of_memory;
+  }
   float* fp32_bias_buffer = NULL;
   const xnn_float16* f16_kernel = (const xnn_float16*)kernel;
   const xnn_float16* f16_bias = (const xnn_float16*)bias;
@@ -1239,6 +1242,10 @@ enum xnn_status xnn_create_convolution2d_nchw_f32_f16(
   if (bias && !(flags & XNN_FLAG_FP32_STATIC_BIASES)) {
     fp32_bias_buffer = (float*)xnn_allocate_memory(
         groups * group_output_channels * sizeof(float));
+    if (fp32_bias_buffer == NULL) {
+      xnn_release_memory(fp32_kernel_buffer);
+      return xnn_status_out_of_memory;
+    }
     for (size_t i = 0; i < groups * group_output_channels; ++i) {
       fp32_bias_buffer[i] = xnn_float16_to_float(f16_bias[i]);
     }

--- a/src/subgraph.c
+++ b/src/subgraph.c
@@ -2213,6 +2213,10 @@ void xnn_subgraph_clean_up(xnn_subgraph_t subgraph) {
   uint32_t* nodes_map =
       xnn_allocate_memory(sizeof(uint32_t) * subgraph->num_nodes +
                           sizeof(bool) * subgraph->num_values);
+  if (nodes_map == NULL) {
+    xnn_log_error("failed to allocate nodes_map scratch buffer");
+    return;
+  }
   bool* values_ready = (bool*)&nodes_map[subgraph->num_nodes];
   for (uint32_t i = 0; i < subgraph->num_values; i++) {
     struct xnn_value* value = &subgraph->values[i];
@@ -4490,6 +4494,10 @@ static void replace_in_set(uint32_t* set, uint32_t size, uint32_t old_value,
 void xnn_subgraph_rewrite_ssa(xnn_subgraph_t subgraph) {
   bool* values_written =
       (bool*)xnn_allocate_memory(sizeof(bool) * subgraph->num_values);
+  if (values_written == NULL) {
+    xnn_log_error("failed to allocate values_written scratch buffer");
+    return;
+  }
   for (uint32_t i = 0; i < subgraph->num_values; i++) {
     values_written[i] = false;
   }


### PR DESCRIPTION
## Summary

`xnn_allocate_memory` is a thin `malloc` wrapper that returns `NULL` on allocation failure. Three functions dereference the returned pointer without a null check, producing an unconditional null pointer dereference (SIGSEGV) on any OOM condition.

**`xnn_subgraph_rewrite_ssa` (`src/subgraph.c`)**
Allocates a `bool` scratch buffer sized by `subgraph->num_values` and immediately writes into it in a loop. Called unconditionally at the top of `xnn_create_runtime_v4` before any other subgraph processing - any runtime creation on any subgraph with at least one value reaches this path.

**`xnn_subgraph_clean_up` (`src/subgraph.c`)**
Allocates a combined `nodes_map`/`values_ready` scratch buffer then immediately performs pointer arithmetic on the result (`&nodes_map[subgraph->num_nodes]`) and writes through it. Called from `xnn_subgraph_optimize` inside `xnn_create_runtime_v4`.

**`xnn_create_convolution2d_nchw_f32_f16` (`src/operators/convolution-nchw.c`)**
Allocates temporary `fp32` kernel and bias buffers for f16→f32 weight conversion then immediately dereferences them in a write loop. This is the NCHW-layout counterpart of the six NHWC functions fixed in PR #10855.

## Fix

Add `NULL` checks after each allocation and return early on failure. For the NCHW convolution bias buffer, release the already-allocated kernel buffer before returning to avoid a memory leak. The fix pattern matches PR #10852 and PR #10855.