### PR TITLE
deconvolution-nhwc: fix missing null check after xnn_allocate_simd_memory in compute_scale_params_qs8_qc8w

### DIFF
--- a/src/operators/deconvolution-nhwc.c
+++ b/src/operators/deconvolution-nhwc.c
@@ -618,6 +618,13 @@ static enum xnn_status compute_scale_params_qs8_qc8w(
     // This buffer is released in the `cleanup` function.
     context->kernel_scale_for_cleanup = xnn_allocate_simd_memory(
       output_channels * sizeof(float));
+    if (context->kernel_scale_for_cleanup == NULL) {
+      xnn_log_error(
+          "failed to allocate %zu bytes for %s operator packed weights",
+          output_channels * sizeof(float),
+          xnn_operator_type_to_string(context->operator_type));
+      return xnn_status_out_of_memory;
+    }
     context->kernel_scale = context->kernel_scale_for_cleanup;
     float* const kernel_scale = context->kernel_scale_for_cleanup;
     for (size_t output_channel = 0; output_channel < output_channels; ++output_channel) {


### PR DESCRIPTION
## Summary

`compute_scale_params_qs8_qc8w` in `src/operators/deconvolution-nhwc.c` calls `xnn_allocate_simd_memory` twice. The first call (line 606, `scale_params_for_cleanup`) is guarded with a null check. The second call (line 619, `kernel_scale_for_cleanup`) had no null check - on OOM the returned NULL pointer was stored into `context->kernel_scale` and immediately dereferenced in a write loop, causing an unconditional null pointer dereference (SIGSEGV).

The sibling function `broadcast_kernel_scale` in the same `qx8_qc8w_variant` (line 749) already guards the identical allocation pattern. This fix brings `compute_scale_params_qs8_qc8w` into line with both that function and the first allocation within the same function.

**Affected public APIs** (all route through `create_deconvolution2d_nhwc_helper` → `compute_scale_params_qs8_qc8w`):
- `xnn_create_deconvolution2d_nhwc_qs8` - always reaches the unguarded block (scalar `kernel_scale` API leaves `context->kernel_scale = NULL`)
- `xnn_create_deconvolution2d_nhwc_qs8_qc8w` - reaches it when `kernel_scale = NULL`
- `xnn_create_deconvolution2d_nhwc_pqs8_qs8_qc8w` - same

**Allocation size:** `output_channels * sizeof(float)` - 256 bytes for a 64-channel decoder layer, 1,024 bytes for a 256-channel upsampling block. Fails under genuine OOM on memory-constrained devices.

## Fix

Add the same null check + error log + `xnn_status_out_of_memory` return used by `broadcast_kernel_scale` and the first allocation in the same function.

Related: PR #10852 (memory-planner null deref), PR #10855 (f16 create null derefs).