### PR TITLE
space-to-depth: guard output_channels size against integer overflow

### DIFF
--- a/src/operators/transpose-nd.c
+++ b/src/operators/transpose-nd.c
@@ -1416,7 +1416,16 @@ static enum xnn_status reshape_space_to_depth_nhwc(
   }
 
   const uint32_t block_size = space_to_depth_op->depth_to_space.block_size;
-  const size_t output_channels = input_channels * block_size * block_size;
+  size_t output_channels = 0;
+  if (!xnn_safe_mul(input_channels, block_size, &output_channels) ||
+      !xnn_safe_mul(output_channels, block_size, &output_channels)) {
+    xnn_log_error(
+        "failed to reshape %s operator with %zu input channels and %u "
+        "block size: output channels overflows size_t",
+        xnn_operator_type_to_string(expected_operator_type), input_channels,
+        block_size);
+    return xnn_status_invalid_parameter;
+  }
 
   if (input_width % block_size != 0) {
     xnn_log_error(


### PR DESCRIPTION
`reshape_space_to_depth_nhwc()` in `src/operators/transpose-nd.c` computed `output_channels` as `input_channels * block_size * block_size` with no overflow guard.

On 32-bit `size_t` targets (WASM, ARM32, which this library explicitly supports), entirely plausible dimensions can silently wrap -- e.g. `input_channels=100000, block_size=300` gives a true value of `9,000,000,000`, which wraps to `410,065,408` in unguarded 32-bit arithmetic. Since `output_channels` is reported back to the caller via `output_channels_out` for output-buffer sizing, a wrapped value can cause the caller to under-allocate its output buffer relative to what the operator's internal shape/stride computation actually produces.

This mirrors the `xnn_safe_mul()` guard already applied to 9 sibling operators in this codebase for the identical `size_t`-overflow class: `batch-matrix-multiply-nc.c`, `deconvolution-nhwc.c`, `average-pooling-nhwc.c`, `dynamic-fully-connected-nc.c`, `convolution-nchw.c`/`convolution-nhwc.c`, `resize-bilinear-nchw.c`/`resize-bilinear-nhwc.c`.

Verified standalone (32-bit and 64-bit arithmetic) that the guard correctly rejects the overflowing case while accepting all in-range values unchanged.