### PR TITLE
Add RVV Zvfh microkernels for f16-qs8, f16-qu8, qs8-f16 vcvt

### DIFF
--- a/cmake/gen/rvvfp16arith_microkernels.cmake
+++ b/cmake/gen/rvvfp16arith_microkernels.cmake
@@ -25,6 +25,8 @@ SET(PROD_RVVFP16ARITH_MICROKERNEL_SRCS
   src/f16-igemm/gen/f16-igemm-1x4v-minmax-rvvfp16arith.c
   src/f16-igemm/gen/f16-igemm-7x4v-minmax-rvvfp16arith.c
   src/f16-maxpool/gen/f16-maxpool-9p-minmax-rvvfp16arith-u2v.c
+  src/f16-qs8-vcvt/gen/f16-qs8-vcvt-rvvfp16arith-u8v.c
+  src/f16-qu8-vcvt/gen/f16-qu8-vcvt-rvvfp16arith-u8v.c
   src/f16-raddstoreexpminusmax/gen/f16-raddstoreexpminusmax-rvvfp16arith-rr2-p2-u4v.c
   src/f16-rdminmax/gen/f16-rdmax-2p2x-rvvfp16arith-u8v.c
   src/f16-rdminmax/gen/f16-rdmin-2p2x-rvvfp16arith-u8v.c
@@ -80,7 +82,8 @@ SET(PROD_RVVFP16ARITH_MICROKERNEL_SRCS
   src/qd8-f16-qc8w-gemm/gen/qd8-f16-qc8w-gemm-1x2v-minmax-rvvfp16arith.c
   src/qd8-f16-qc8w-gemm/gen/qd8-f16-qc8w-gemm-7x2v-minmax-rvvfp16arith.c
   src/qd8-f16-qc8w-igemm/gen/qd8-f16-qc8w-igemm-1x2v-minmax-rvvfp16arith.c
-  src/qd8-f16-qc8w-igemm/gen/qd8-f16-qc8w-igemm-7x2v-minmax-rvvfp16arith.c)
+  src/qd8-f16-qc8w-igemm/gen/qd8-f16-qc8w-igemm-7x2v-minmax-rvvfp16arith.c
+  src/qs8-f16-vcvt/gen/qs8-f16-vcvt-rvvfp16arith-u2v.c)
 
 SET(NON_PROD_RVVFP16ARITH_MICROKERNEL_SRCS
   src/f16-dwconv/gen/f16-dwconv-3p4vc-minmax-rvvfp16arith.c
@@ -95,6 +98,12 @@ SET(NON_PROD_RVVFP16ARITH_MICROKERNEL_SRCS
   src/f16-f32acc-rsum2/gen/f16-f32acc-rsum2-rvvfp16arith-u2v.c
   src/f16-gemm/gen/f16-gemm-4x4v-minmax-rvvfp16arith.c
   src/f16-igemm/gen/f16-igemm-4x4v-minmax-rvvfp16arith.c
+  src/f16-qs8-vcvt/gen/f16-qs8-vcvt-rvvfp16arith-u1v.c
+  src/f16-qs8-vcvt/gen/f16-qs8-vcvt-rvvfp16arith-u2v.c
+  src/f16-qs8-vcvt/gen/f16-qs8-vcvt-rvvfp16arith-u4v.c
+  src/f16-qu8-vcvt/gen/f16-qu8-vcvt-rvvfp16arith-u1v.c
+  src/f16-qu8-vcvt/gen/f16-qu8-vcvt-rvvfp16arith-u2v.c
+  src/f16-qu8-vcvt/gen/f16-qu8-vcvt-rvvfp16arith-u4v.c
   src/f16-raddstoreexpminusmax/gen/f16-raddstoreexpminusmax-rvvfp16arith-rr2-p2-u1v.c
   src/f16-raddstoreexpminusmax/gen/f16-raddstoreexpminusmax-rvvfp16arith-rr2-p2-u2v.c
   src/f16-rminmax/gen/f16-rmax-rvvfp16arith-u4v.c
@@ -231,6 +240,8 @@ SET(NON_PROD_RVVFP16ARITH_MICROKERNEL_SRCS
   src/f32-f16-vcvt/gen/f32-f16-vcvt-rvvfp16arith-u4v.c
   src/qd8-f16-qc4w-gemm/gen/qd8-f16-qc4w-gemm-4x2v-minmax-rvvfp16arith.c
   src/qd8-f16-qc8w-gemm/gen/qd8-f16-qc8w-gemm-4x2v-minmax-rvvfp16arith.c
-  src/qd8-f16-qc8w-igemm/gen/qd8-f16-qc8w-igemm-4x2v-minmax-rvvfp16arith.c)
+  src/qd8-f16-qc8w-igemm/gen/qd8-f16-qc8w-igemm-4x2v-minmax-rvvfp16arith.c
+  src/qs8-f16-vcvt/gen/qs8-f16-vcvt-rvvfp16arith-u1v.c
+  src/qs8-f16-vcvt/gen/qs8-f16-vcvt-rvvfp16arith-u4v.c)
 
 SET(ALL_RVVFP16ARITH_MICROKERNEL_SRCS ${PROD_RVVFP16ARITH_MICROKERNEL_SRCS} ${NON_PROD_RVVFP16ARITH_MICROKERNEL_SRCS})

--- a/gen/rvvfp16arith_microkernels.bzl
+++ b/gen/rvvfp16arith_microkernels.bzl
@@ -21,6 +21,8 @@ PROD_RVVFP16ARITH_MICROKERNEL_SRCS = [
     "src/f16-igemm/gen/f16-igemm-1x4v-minmax-rvvfp16arith.c",
     "src/f16-igemm/gen/f16-igemm-7x4v-minmax-rvvfp16arith.c",
     "src/f16-maxpool/gen/f16-maxpool-9p-minmax-rvvfp16arith-u2v.c",
+    "src/f16-qs8-vcvt/gen/f16-qs8-vcvt-rvvfp16arith-u8v.c",
+    "src/f16-qu8-vcvt/gen/f16-qu8-vcvt-rvvfp16arith-u8v.c",
     "src/f16-raddstoreexpminusmax/gen/f16-raddstoreexpminusmax-rvvfp16arith-rr2-p2-u4v.c",
     "src/f16-rdminmax/gen/f16-rdmax-2p2x-rvvfp16arith-u8v.c",
     "src/f16-rdminmax/gen/f16-rdmin-2p2x-rvvfp16arith-u8v.c",
@@ -77,6 +79,7 @@ PROD_RVVFP16ARITH_MICROKERNEL_SRCS = [
     "src/qd8-f16-qc8w-gemm/gen/qd8-f16-qc8w-gemm-7x2v-minmax-rvvfp16arith.c",
     "src/qd8-f16-qc8w-igemm/gen/qd8-f16-qc8w-igemm-1x2v-minmax-rvvfp16arith.c",
     "src/qd8-f16-qc8w-igemm/gen/qd8-f16-qc8w-igemm-7x2v-minmax-rvvfp16arith.c",
+    "src/qs8-f16-vcvt/gen/qs8-f16-vcvt-rvvfp16arith-u2v.c",
 ]
 
 NON_PROD_RVVFP16ARITH_MICROKERNEL_SRCS = [
@@ -92,6 +95,12 @@ NON_PROD_RVVFP16ARITH_MICROKERNEL_SRCS = [
     "src/f16-f32acc-rsum2/gen/f16-f32acc-rsum2-rvvfp16arith-u2v.c",
     "src/f16-gemm/gen/f16-gemm-4x4v-minmax-rvvfp16arith.c",
     "src/f16-igemm/gen/f16-igemm-4x4v-minmax-rvvfp16arith.c",
+    "src/f16-qs8-vcvt/gen/f16-qs8-vcvt-rvvfp16arith-u1v.c",
+    "src/f16-qs8-vcvt/gen/f16-qs8-vcvt-rvvfp16arith-u2v.c",
+    "src/f16-qs8-vcvt/gen/f16-qs8-vcvt-rvvfp16arith-u4v.c",
+    "src/f16-qu8-vcvt/gen/f16-qu8-vcvt-rvvfp16arith-u1v.c",
+    "src/f16-qu8-vcvt/gen/f16-qu8-vcvt-rvvfp16arith-u2v.c",
+    "src/f16-qu8-vcvt/gen/f16-qu8-vcvt-rvvfp16arith-u4v.c",
     "src/f16-raddstoreexpminusmax/gen/f16-raddstoreexpminusmax-rvvfp16arith-rr2-p2-u1v.c",
     "src/f16-raddstoreexpminusmax/gen/f16-raddstoreexpminusmax-rvvfp16arith-rr2-p2-u2v.c",
     "src/f16-rminmax/gen/f16-rmax-rvvfp16arith-u4v.c",
@@ -229,6 +238,8 @@ NON_PROD_RVVFP16ARITH_MICROKERNEL_SRCS = [
     "src/qd8-f16-qc4w-gemm/gen/qd8-f16-qc4w-gemm-4x2v-minmax-rvvfp16arith.c",
     "src/qd8-f16-qc8w-gemm/gen/qd8-f16-qc8w-gemm-4x2v-minmax-rvvfp16arith.c",
     "src/qd8-f16-qc8w-igemm/gen/qd8-f16-qc8w-igemm-4x2v-minmax-rvvfp16arith.c",
+    "src/qs8-f16-vcvt/gen/qs8-f16-vcvt-rvvfp16arith-u1v.c",
+    "src/qs8-f16-vcvt/gen/qs8-f16-vcvt-rvvfp16arith-u4v.c",
 ]
 
 ALL_RVVFP16ARITH_MICROKERNEL_SRCS = PROD_RVVFP16ARITH_MICROKERNEL_SRCS + NON_PROD_RVVFP16ARITH_MICROKERNEL_SRCS

--- a/scripts/generate-f32-qs8-vcvt.sh
+++ b/scripts/generate-f32-qs8-vcvt.sh
@@ -42,6 +42,16 @@ tools/xngen src/f32-qs8-vcvt/rvv.c.in -D LMUL=2 -D DATATYPE=QU8 -o src/f32-qu8-v
 tools/xngen src/f32-qs8-vcvt/rvv.c.in -D LMUL=4 -D DATATYPE=QU8 -o src/f32-qu8-vcvt/gen/f32-qu8-vcvt-rvv-u4v.c &
 tools/xngen src/f32-qs8-vcvt/rvv.c.in -D LMUL=8 -D DATATYPE=QU8 -o src/f32-qu8-vcvt/gen/f32-qu8-vcvt-rvv-u8v.c &
 
+tools/xngen src/f16-qs8-vcvt/rvvfp16arith.c.in -D LMUL=1 -D DATATYPE=QS8 -o src/f16-qs8-vcvt/gen/f16-qs8-vcvt-rvvfp16arith-u1v.c &
+tools/xngen src/f16-qs8-vcvt/rvvfp16arith.c.in -D LMUL=2 -D DATATYPE=QS8 -o src/f16-qs8-vcvt/gen/f16-qs8-vcvt-rvvfp16arith-u2v.c &
+tools/xngen src/f16-qs8-vcvt/rvvfp16arith.c.in -D LMUL=4 -D DATATYPE=QS8 -o src/f16-qs8-vcvt/gen/f16-qs8-vcvt-rvvfp16arith-u4v.c &
+tools/xngen src/f16-qs8-vcvt/rvvfp16arith.c.in -D LMUL=8 -D DATATYPE=QS8 -o src/f16-qs8-vcvt/gen/f16-qs8-vcvt-rvvfp16arith-u8v.c &
+
+tools/xngen src/f16-qs8-vcvt/rvvfp16arith.c.in -D LMUL=1 -D DATATYPE=QU8 -o src/f16-qu8-vcvt/gen/f16-qu8-vcvt-rvvfp16arith-u1v.c &
+tools/xngen src/f16-qs8-vcvt/rvvfp16arith.c.in -D LMUL=2 -D DATATYPE=QU8 -o src/f16-qu8-vcvt/gen/f16-qu8-vcvt-rvvfp16arith-u2v.c &
+tools/xngen src/f16-qs8-vcvt/rvvfp16arith.c.in -D LMUL=4 -D DATATYPE=QU8 -o src/f16-qu8-vcvt/gen/f16-qu8-vcvt-rvvfp16arith-u4v.c &
+tools/xngen src/f16-qs8-vcvt/rvvfp16arith.c.in -D LMUL=8 -D DATATYPE=QU8 -o src/f16-qu8-vcvt/gen/f16-qu8-vcvt-rvvfp16arith-u8v.c &
+
 ################################# x86 128-bit #################################
 tools/xngen src/f32-qs8-vcvt/sse.c.in -D SSE=2 -D BATCH_TILE=8  -D DATATYPE=QS8 -o src/f32-qs8-vcvt/gen/f32-qs8-vcvt-sse2-u8.c &
 tools/xngen src/f32-qs8-vcvt/sse.c.in -D SSE=2 -D BATCH_TILE=16 -D DATATYPE=QS8 -o src/f32-qs8-vcvt/gen/f32-qs8-vcvt-sse2-u16.c &

--- a/scripts/generate-qs8-f16-vcvt.sh
+++ b/scripts/generate-qs8-f16-vcvt.sh
@@ -10,3 +10,10 @@ tools/xngen src/qs8-f16-vcvt/avx2.c.in -D BATCH_TILE=16 -o src/qs8-f16-vcvt/gen/
 tools/xngen src/qs8-f16-vcvt/avx2.c.in -D BATCH_TILE=24 -o src/qs8-f16-vcvt/gen/qs8-f16-vcvt-avx2-u24.c &
 tools/xngen src/qs8-f16-vcvt/avx2.c.in -D BATCH_TILE=32 -o src/qs8-f16-vcvt/gen/qs8-f16-vcvt-avx2-u32.c &
 tools/xngen src/qs8-f16-vcvt/avx2.c.in -D BATCH_TILE=64 -o src/qs8-f16-vcvt/gen/qs8-f16-vcvt-avx2-u64.c &
+
+############################# RISC-V Vector ###################################
+tools/xngen src/qs8-f16-vcvt/rvvfp16arith.c.in -D LMUL=1 -o src/qs8-f16-vcvt/gen/qs8-f16-vcvt-rvvfp16arith-u1v.c &
+tools/xngen src/qs8-f16-vcvt/rvvfp16arith.c.in -D LMUL=2 -o src/qs8-f16-vcvt/gen/qs8-f16-vcvt-rvvfp16arith-u2v.c &
+tools/xngen src/qs8-f16-vcvt/rvvfp16arith.c.in -D LMUL=4 -o src/qs8-f16-vcvt/gen/qs8-f16-vcvt-rvvfp16arith-u4v.c &
+
+wait

--- a/src/configs/unary-elementwise-config.c
+++ b/src/configs/unary-elementwise-config.c
@@ -1347,6 +1347,18 @@ static void init_f16_to_qu8_cvt_config(void) {
       f16_to_qu8_cvt_config.element_tile = 4;
       f16_to_qu8_cvt_config.init = (xnn_init_unary_uparams_fn) xnn_init_f16_qu8_cvt_scalar_params;
     }
+  #elif XNN_ARCH_RISCV && XNN_ENABLE_RISCV_VECTOR && XNN_ENABLE_RISCV_FP16_VECTOR
+    const struct xnn_hardware_config* hardware_config = xnn_init_hardware_config();
+    assert(hardware_config != NULL);
+    if (hardware_config->arch_flags & xnn_arch_riscv_vector_fp16_arith) {
+      f16_to_qu8_cvt_config.ukernel = XNN_INIT_UNARY_UKERNEL(xnn_f16_qu8_vcvt_ukernel__rvvfp16arith_u8v);
+      f16_to_qu8_cvt_config.element_tile = 8 * hardware_config->vlenb / sizeof(xnn_float16);
+      f16_to_qu8_cvt_config.init = (xnn_init_unary_uparams_fn) xnn_init_f16_qu8_cvt_scalar_params;
+    } else {
+      f16_to_qu8_cvt_config.ukernel = XNN_INIT_UNARY_UKERNEL(xnn_f16_qu8_vcvt_ukernel__scalar_imagic_u4);
+      f16_to_qu8_cvt_config.element_tile = 4;
+      f16_to_qu8_cvt_config.init = (xnn_init_unary_uparams_fn) xnn_init_f16_qu8_cvt_scalar_params;
+    }
   #else
     f16_to_qu8_cvt_config.ukernel = XNN_INIT_UNARY_UKERNEL(xnn_f16_qu8_vcvt_ukernel__scalar_imagic_u4);
     f16_to_qu8_cvt_config.element_tile = 4;
@@ -1380,6 +1392,18 @@ static void init_f16_to_qs8_cvt_config(void) {
       } else
     #endif
     {
+      f16_to_qs8_cvt_config.ukernel = XNN_INIT_UNARY_UKERNEL(xnn_f16_qs8_vcvt_ukernel__scalar_imagic_u4);
+      f16_to_qs8_cvt_config.element_tile = 4;
+      f16_to_qs8_cvt_config.init = (xnn_init_unary_uparams_fn) xnn_init_f16_qs8_cvt_scalar_params;
+    }
+  #elif XNN_ARCH_RISCV && XNN_ENABLE_RISCV_VECTOR && XNN_ENABLE_RISCV_FP16_VECTOR
+    const struct xnn_hardware_config* hardware_config = xnn_init_hardware_config();
+    assert(hardware_config != NULL);
+    if (hardware_config->arch_flags & xnn_arch_riscv_vector_fp16_arith) {
+      f16_to_qs8_cvt_config.ukernel = XNN_INIT_UNARY_UKERNEL(xnn_f16_qs8_vcvt_ukernel__rvvfp16arith_u8v);
+      f16_to_qs8_cvt_config.element_tile = 8 * hardware_config->vlenb / sizeof(xnn_float16);
+      f16_to_qs8_cvt_config.init = (xnn_init_unary_uparams_fn) xnn_init_f16_qs8_cvt_scalar_params;
+    } else {
       f16_to_qs8_cvt_config.ukernel = XNN_INIT_UNARY_UKERNEL(xnn_f16_qs8_vcvt_ukernel__scalar_imagic_u4);
       f16_to_qs8_cvt_config.element_tile = 4;
       f16_to_qs8_cvt_config.init = (xnn_init_unary_uparams_fn) xnn_init_f16_qs8_cvt_scalar_params;
@@ -3584,6 +3608,14 @@ static void init_qs8_to_f16_cvt_config(void) {
         qs8_to_f16_cvt_config.init = (xnn_init_unary_uparams_fn) xnn_init_qs8_f16_cvt_scalar_params;
       }
     #endif
+  #elif XNN_ARCH_RISCV && XNN_ENABLE_RISCV_VECTOR && XNN_ENABLE_RISCV_FP16_VECTOR
+    const struct xnn_hardware_config* hardware_config = xnn_init_hardware_config();
+    assert(hardware_config != NULL);
+    if (hardware_config->arch_flags & xnn_arch_riscv_vector_fp16_arith) {
+      qs8_to_f16_cvt_config.ukernel = XNN_INIT_UNARY_UKERNEL(xnn_qs8_f16_vcvt_ukernel__rvvfp16arith_u2v);
+      qs8_to_f16_cvt_config.element_tile = 2 * hardware_config->vlenb / sizeof(int8_t);
+      qs8_to_f16_cvt_config.init = (xnn_init_unary_uparams_fn) xnn_init_qs8_f16_cvt_scalar_params;
+    }
   #endif
 }
 

--- a/src/f16-qs8-vcvt/f16-qs8-vcvt.inc
+++ b/src/f16-qs8-vcvt/f16-qs8-vcvt.inc
@@ -24,6 +24,13 @@ XNN_UKERNEL(xnn_arch_x86_avx512skx, xnn_f16_qs8_vcvt_ukernel__avx512skx_u96, 96,
 XNN_UKERNEL(xnn_arch_x86_avx512skx, xnn_f16_qs8_vcvt_ukernel__avx512skx_u128, 128, false, xnn_float16, XNN_QUANTIZED(int8_t), struct xnn_f16_qs8_cvt_params, xnn_init_f16_qs8_cvt_scalar_params)
 #endif  // XNN_ENABLE_AVX512SKX && (XNN_ARCH_X86 || XNN_ARCH_X86_64)
 
+#if XNN_ARCH_RISCV && XNN_ENABLE_RISCV_FP16_VECTOR
+XNN_UKERNEL(xnn_arch_riscv_vector_fp16_arith, xnn_f16_qs8_vcvt_ukernel__rvvfp16arith_u1v, 1, true, xnn_float16, XNN_QUANTIZED(int8_t), struct xnn_f16_qs8_cvt_params, xnn_init_f16_qs8_cvt_scalar_params)
+XNN_UKERNEL(xnn_arch_riscv_vector_fp16_arith, xnn_f16_qs8_vcvt_ukernel__rvvfp16arith_u2v, 2, true, xnn_float16, XNN_QUANTIZED(int8_t), struct xnn_f16_qs8_cvt_params, xnn_init_f16_qs8_cvt_scalar_params)
+XNN_UKERNEL(xnn_arch_riscv_vector_fp16_arith, xnn_f16_qs8_vcvt_ukernel__rvvfp16arith_u4v, 4, true, xnn_float16, XNN_QUANTIZED(int8_t), struct xnn_f16_qs8_cvt_params, xnn_init_f16_qs8_cvt_scalar_params)
+XNN_UKERNEL(xnn_arch_riscv_vector_fp16_arith, xnn_f16_qs8_vcvt_ukernel__rvvfp16arith_u8v, 8, true, xnn_float16, XNN_QUANTIZED(int8_t), struct xnn_f16_qs8_cvt_params, xnn_init_f16_qs8_cvt_scalar_params)
+#endif  // XNN_ARCH_RISCV && XNN_ENABLE_RISCV_FP16_VECTOR
+
 XNN_UKERNEL(xnn_arch_none, xnn_f16_qs8_vcvt_ukernel__scalar_fmagic_u1, 1, false, xnn_float16, XNN_QUANTIZED(int8_t), struct xnn_f16_qs8_cvt_params, xnn_init_f16_qs8_cvt_scalar_params)
 XNN_UKERNEL(xnn_arch_none, xnn_f16_qs8_vcvt_ukernel__scalar_fmagic_u2, 2, false, xnn_float16, XNN_QUANTIZED(int8_t), struct xnn_f16_qs8_cvt_params, xnn_init_f16_qs8_cvt_scalar_params)
 XNN_UKERNEL(xnn_arch_none, xnn_f16_qs8_vcvt_ukernel__scalar_fmagic_u3, 3, false, xnn_float16, XNN_QUANTIZED(int8_t), struct xnn_f16_qs8_cvt_params, xnn_init_f16_qs8_cvt_scalar_params)

--- a/src/f16-qs8-vcvt/gen/f16-qs8-vcvt-rvvfp16arith-u1v.c
+++ b/src/f16-qs8-vcvt/gen/f16-qs8-vcvt-rvvfp16arith-u1v.c
@@ -1,0 +1,71 @@
+// clang-format off
+// Auto-generated file. Do not edit!
+//   Template: src/f16-qs8-vcvt/rvvfp16arith.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2026 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+#include <stdint.h>
+
+#include <riscv_vector.h>
+
+#include "src/xnnpack/common.h"
+#include "src/xnnpack/math.h"
+#include "src/xnnpack/vcvt.h"
+
+
+void xnn_f16_qs8_vcvt_ukernel__rvvfp16arith_u1v(
+    size_t batch,
+    const xnn_float16* input,
+    int8_t* output,
+    const struct xnn_f16_qs8_cvt_params* restrict params)
+{
+  assert(batch != 0);
+  assert(batch % sizeof(xnn_float16) == 0);
+  assert(input != NULL);
+  assert(output != NULL);
+
+  batch >>= XNN_LOG2_SIZEOF_FLOAT16;
+
+  // A reciprocal output scale that underflows fp16 to zero would turn an
+  // infinite input into NaN via inf * 0, which the clamp below resolves to the
+  // wrong bound. Clamp the scale to the smallest positive fp16 so infinities
+  // saturate by sign, mirroring the scalar kernel's max(FLT_MIN, scale) guard.
+  // Nothing representable lies between 0 and 0x1.0p-24, so non-zero scales are
+  // unaffected.
+  xnn_float16 vscale = params->scalar.scale;
+  if (!(vscale > (xnn_float16) 0x1.0p-24f)) {
+    vscale = (xnn_float16) 0x1.0p-24f;
+  }
+  const int16_t voutput_zero_point = params->scalar.output_zero_point;
+  // vfcvt and vncvt do not saturate, so clamp before converting. The bounds
+  // span at most [-255, 255], which fp16 represents exactly, and the scaled
+  // value is in [-128, 127] once the zero point is added back.
+  const xnn_float16 voutput_min_less_zero_point =
+      (xnn_float16) (-128 - (int32_t) voutput_zero_point);
+  const xnn_float16 voutput_max_less_zero_point =
+      (xnn_float16) (127 - (int32_t) voutput_zero_point);
+
+  do {
+    const size_t n = __riscv_vsetvl_e16m1(batch);
+
+    vfloat16m1_t vx = __riscv_vle16_v_f16m1(input, n);
+    input += n;
+
+    vx = __riscv_vfmul_vf_f16m1(vx, vscale, n);
+    vx = __riscv_vfmax_vf_f16m1(vx, voutput_min_less_zero_point, n);
+    vx = __riscv_vfmin_vf_f16m1(vx, voutput_max_less_zero_point, n);
+
+    vint16m1_t vacc = __riscv_vfcvt_x_f_v_i16m1(vx, n);
+    vacc = __riscv_vadd_vx_i16m1(vacc, voutput_zero_point, n);
+
+    __riscv_vse8_v_i8mf2(output, __riscv_vncvt_x_x_w_i8mf2(vacc, n), n);
+    output += n;
+
+    batch -= n;
+  } while (batch != 0);
+}

--- a/src/f16-qs8-vcvt/gen/f16-qs8-vcvt-rvvfp16arith-u2v.c
+++ b/src/f16-qs8-vcvt/gen/f16-qs8-vcvt-rvvfp16arith-u2v.c
@@ -1,0 +1,71 @@
+// clang-format off
+// Auto-generated file. Do not edit!
+//   Template: src/f16-qs8-vcvt/rvvfp16arith.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2026 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+#include <stdint.h>
+
+#include <riscv_vector.h>
+
+#include "src/xnnpack/common.h"
+#include "src/xnnpack/math.h"
+#include "src/xnnpack/vcvt.h"
+
+
+void xnn_f16_qs8_vcvt_ukernel__rvvfp16arith_u2v(
+    size_t batch,
+    const xnn_float16* input,
+    int8_t* output,
+    const struct xnn_f16_qs8_cvt_params* restrict params)
+{
+  assert(batch != 0);
+  assert(batch % sizeof(xnn_float16) == 0);
+  assert(input != NULL);
+  assert(output != NULL);
+
+  batch >>= XNN_LOG2_SIZEOF_FLOAT16;
+
+  // A reciprocal output scale that underflows fp16 to zero would turn an
+  // infinite input into NaN via inf * 0, which the clamp below resolves to the
+  // wrong bound. Clamp the scale to the smallest positive fp16 so infinities
+  // saturate by sign, mirroring the scalar kernel's max(FLT_MIN, scale) guard.
+  // Nothing representable lies between 0 and 0x1.0p-24, so non-zero scales are
+  // unaffected.
+  xnn_float16 vscale = params->scalar.scale;
+  if (!(vscale > (xnn_float16) 0x1.0p-24f)) {
+    vscale = (xnn_float16) 0x1.0p-24f;
+  }
+  const int16_t voutput_zero_point = params->scalar.output_zero_point;
+  // vfcvt and vncvt do not saturate, so clamp before converting. The bounds
+  // span at most [-255, 255], which fp16 represents exactly, and the scaled
+  // value is in [-128, 127] once the zero point is added back.
+  const xnn_float16 voutput_min_less_zero_point =
+      (xnn_float16) (-128 - (int32_t) voutput_zero_point);
+  const xnn_float16 voutput_max_less_zero_point =
+      (xnn_float16) (127 - (int32_t) voutput_zero_point);
+
+  do {
+    const size_t n = __riscv_vsetvl_e16m2(batch);
+
+    vfloat16m2_t vx = __riscv_vle16_v_f16m2(input, n);
+    input += n;
+
+    vx = __riscv_vfmul_vf_f16m2(vx, vscale, n);
+    vx = __riscv_vfmax_vf_f16m2(vx, voutput_min_less_zero_point, n);
+    vx = __riscv_vfmin_vf_f16m2(vx, voutput_max_less_zero_point, n);
+
+    vint16m2_t vacc = __riscv_vfcvt_x_f_v_i16m2(vx, n);
+    vacc = __riscv_vadd_vx_i16m2(vacc, voutput_zero_point, n);
+
+    __riscv_vse8_v_i8m1(output, __riscv_vncvt_x_x_w_i8m1(vacc, n), n);
+    output += n;
+
+    batch -= n;
+  } while (batch != 0);
+}

--- a/src/f16-qs8-vcvt/gen/f16-qs8-vcvt-rvvfp16arith-u4v.c
+++ b/src/f16-qs8-vcvt/gen/f16-qs8-vcvt-rvvfp16arith-u4v.c
@@ -1,0 +1,71 @@
+// clang-format off
+// Auto-generated file. Do not edit!
+//   Template: src/f16-qs8-vcvt/rvvfp16arith.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2026 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+#include <stdint.h>
+
+#include <riscv_vector.h>
+
+#include "src/xnnpack/common.h"
+#include "src/xnnpack/math.h"
+#include "src/xnnpack/vcvt.h"
+
+
+void xnn_f16_qs8_vcvt_ukernel__rvvfp16arith_u4v(
+    size_t batch,
+    const xnn_float16* input,
+    int8_t* output,
+    const struct xnn_f16_qs8_cvt_params* restrict params)
+{
+  assert(batch != 0);
+  assert(batch % sizeof(xnn_float16) == 0);
+  assert(input != NULL);
+  assert(output != NULL);
+
+  batch >>= XNN_LOG2_SIZEOF_FLOAT16;
+
+  // A reciprocal output scale that underflows fp16 to zero would turn an
+  // infinite input into NaN via inf * 0, which the clamp below resolves to the
+  // wrong bound. Clamp the scale to the smallest positive fp16 so infinities
+  // saturate by sign, mirroring the scalar kernel's max(FLT_MIN, scale) guard.
+  // Nothing representable lies between 0 and 0x1.0p-24, so non-zero scales are
+  // unaffected.
+  xnn_float16 vscale = params->scalar.scale;
+  if (!(vscale > (xnn_float16) 0x1.0p-24f)) {
+    vscale = (xnn_float16) 0x1.0p-24f;
+  }
+  const int16_t voutput_zero_point = params->scalar.output_zero_point;
+  // vfcvt and vncvt do not saturate, so clamp before converting. The bounds
+  // span at most [-255, 255], which fp16 represents exactly, and the scaled
+  // value is in [-128, 127] once the zero point is added back.
+  const xnn_float16 voutput_min_less_zero_point =
+      (xnn_float16) (-128 - (int32_t) voutput_zero_point);
+  const xnn_float16 voutput_max_less_zero_point =
+      (xnn_float16) (127 - (int32_t) voutput_zero_point);
+
+  do {
+    const size_t n = __riscv_vsetvl_e16m4(batch);
+
+    vfloat16m4_t vx = __riscv_vle16_v_f16m4(input, n);
+    input += n;
+
+    vx = __riscv_vfmul_vf_f16m4(vx, vscale, n);
+    vx = __riscv_vfmax_vf_f16m4(vx, voutput_min_less_zero_point, n);
+    vx = __riscv_vfmin_vf_f16m4(vx, voutput_max_less_zero_point, n);
+
+    vint16m4_t vacc = __riscv_vfcvt_x_f_v_i16m4(vx, n);
+    vacc = __riscv_vadd_vx_i16m4(vacc, voutput_zero_point, n);
+
+    __riscv_vse8_v_i8m2(output, __riscv_vncvt_x_x_w_i8m2(vacc, n), n);
+    output += n;
+
+    batch -= n;
+  } while (batch != 0);
+}

--- a/src/f16-qs8-vcvt/gen/f16-qs8-vcvt-rvvfp16arith-u8v.c
+++ b/src/f16-qs8-vcvt/gen/f16-qs8-vcvt-rvvfp16arith-u8v.c
@@ -1,0 +1,71 @@
+// clang-format off
+// Auto-generated file. Do not edit!
+//   Template: src/f16-qs8-vcvt/rvvfp16arith.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2026 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+#include <stdint.h>
+
+#include <riscv_vector.h>
+
+#include "src/xnnpack/common.h"
+#include "src/xnnpack/math.h"
+#include "src/xnnpack/vcvt.h"
+
+
+void xnn_f16_qs8_vcvt_ukernel__rvvfp16arith_u8v(
+    size_t batch,
+    const xnn_float16* input,
+    int8_t* output,
+    const struct xnn_f16_qs8_cvt_params* restrict params)
+{
+  assert(batch != 0);
+  assert(batch % sizeof(xnn_float16) == 0);
+  assert(input != NULL);
+  assert(output != NULL);
+
+  batch >>= XNN_LOG2_SIZEOF_FLOAT16;
+
+  // A reciprocal output scale that underflows fp16 to zero would turn an
+  // infinite input into NaN via inf * 0, which the clamp below resolves to the
+  // wrong bound. Clamp the scale to the smallest positive fp16 so infinities
+  // saturate by sign, mirroring the scalar kernel's max(FLT_MIN, scale) guard.
+  // Nothing representable lies between 0 and 0x1.0p-24, so non-zero scales are
+  // unaffected.
+  xnn_float16 vscale = params->scalar.scale;
+  if (!(vscale > (xnn_float16) 0x1.0p-24f)) {
+    vscale = (xnn_float16) 0x1.0p-24f;
+  }
+  const int16_t voutput_zero_point = params->scalar.output_zero_point;
+  // vfcvt and vncvt do not saturate, so clamp before converting. The bounds
+  // span at most [-255, 255], which fp16 represents exactly, and the scaled
+  // value is in [-128, 127] once the zero point is added back.
+  const xnn_float16 voutput_min_less_zero_point =
+      (xnn_float16) (-128 - (int32_t) voutput_zero_point);
+  const xnn_float16 voutput_max_less_zero_point =
+      (xnn_float16) (127 - (int32_t) voutput_zero_point);
+
+  do {
+    const size_t n = __riscv_vsetvl_e16m8(batch);
+
+    vfloat16m8_t vx = __riscv_vle16_v_f16m8(input, n);
+    input += n;
+
+    vx = __riscv_vfmul_vf_f16m8(vx, vscale, n);
+    vx = __riscv_vfmax_vf_f16m8(vx, voutput_min_less_zero_point, n);
+    vx = __riscv_vfmin_vf_f16m8(vx, voutput_max_less_zero_point, n);
+
+    vint16m8_t vacc = __riscv_vfcvt_x_f_v_i16m8(vx, n);
+    vacc = __riscv_vadd_vx_i16m8(vacc, voutput_zero_point, n);
+
+    __riscv_vse8_v_i8m4(output, __riscv_vncvt_x_x_w_i8m4(vacc, n), n);
+    output += n;
+
+    batch -= n;
+  } while (batch != 0);
+}

--- a/src/f16-qs8-vcvt/rvvfp16arith.c.in
+++ b/src/f16-qs8-vcvt/rvvfp16arith.c.in
@@ -1,0 +1,75 @@
+// Copyright 2026 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+$assert LMUL in [1, 2, 4, 8]
+$assert DATATYPE in ["QS8", "QU8"]
+$LMUL_8 = {1: "f2", 2: "1", 4: "2", 8: "4"}[LMUL]
+$XINT8_T = {"QS8": "int8_t", "QU8": "uint8_t"}[DATATYPE]
+$OUTPUT_MIN = {"QS8": -128, "QU8": 0}[DATATYPE]
+$OUTPUT_MAX = {"QS8": 127, "QU8": 255}[DATATYPE]
+#include <assert.h>
+#include <stdint.h>
+
+#include <riscv_vector.h>
+
+#include "src/xnnpack/common.h"
+#include "src/xnnpack/math.h"
+#include "src/xnnpack/vcvt.h"
+
+
+void xnn_f16_${DATATYPE.lower()}_vcvt_ukernel__rvvfp16arith_u${LMUL}v(
+    size_t batch,
+    const xnn_float16* input,
+    ${XINT8_T}* output,
+    const struct xnn_f16_${DATATYPE.lower()}_cvt_params* restrict params)
+{
+  assert(batch != 0);
+  assert(batch % sizeof(xnn_float16) == 0);
+  assert(input != NULL);
+  assert(output != NULL);
+
+  batch >>= XNN_LOG2_SIZEOF_FLOAT16;
+
+  // A reciprocal output scale that underflows fp16 to zero would turn an
+  // infinite input into NaN via inf * 0, which the clamp below resolves to the
+  // wrong bound. Clamp the scale to the smallest positive fp16 so infinities
+  // saturate by sign, mirroring the scalar kernel's max(FLT_MIN, scale) guard.
+  // Nothing representable lies between 0 and 0x1.0p-24, so non-zero scales are
+  // unaffected.
+  xnn_float16 vscale = params->scalar.scale;
+  if (!(vscale > (xnn_float16) 0x1.0p-24f)) {
+    vscale = (xnn_float16) 0x1.0p-24f;
+  }
+  const int16_t voutput_zero_point = params->scalar.output_zero_point;
+  // vfcvt and vncvt do not saturate, so clamp before converting. The bounds
+  // span at most [-255, 255], which fp16 represents exactly, and the scaled
+  // value is in [${OUTPUT_MIN}, ${OUTPUT_MAX}] once the zero point is added back.
+  const xnn_float16 voutput_min_less_zero_point =
+      (xnn_float16) (${OUTPUT_MIN} - (int32_t) voutput_zero_point);
+  const xnn_float16 voutput_max_less_zero_point =
+      (xnn_float16) (${OUTPUT_MAX} - (int32_t) voutput_zero_point);
+
+  do {
+    const size_t n = __riscv_vsetvl_e16m${LMUL}(batch);
+
+    vfloat16m${LMUL}_t vx = __riscv_vle16_v_f16m${LMUL}(input, n);
+    input += n;
+
+    vx = __riscv_vfmul_vf_f16m${LMUL}(vx, vscale, n);
+    vx = __riscv_vfmax_vf_f16m${LMUL}(vx, voutput_min_less_zero_point, n);
+    vx = __riscv_vfmin_vf_f16m${LMUL}(vx, voutput_max_less_zero_point, n);
+
+    vint16m${LMUL}_t vacc = __riscv_vfcvt_x_f_v_i16m${LMUL}(vx, n);
+    vacc = __riscv_vadd_vx_i16m${LMUL}(vacc, voutput_zero_point, n);
+
+    $if DATATYPE == "QS8":
+      __riscv_vse8_v_i8m${LMUL_8}(output, __riscv_vncvt_x_x_w_i8m${LMUL_8}(vacc, n), n);
+    $else:
+      __riscv_vse8_v_u8m${LMUL_8}(output, __riscv_vncvt_x_x_w_u8m${LMUL_8}(__riscv_vreinterpret_v_i16m${LMUL}_u16m${LMUL}(vacc), n), n);
+    output += n;
+
+    batch -= n;
+  } while (batch != 0);
+}

--- a/src/f16-qu8-vcvt/f16-qu8-vcvt.inc
+++ b/src/f16-qu8-vcvt/f16-qu8-vcvt.inc
@@ -17,6 +17,13 @@ XNN_UKERNEL(xnn_arch_x86_avx512skx, xnn_f16_qu8_vcvt_ukernel__avx512skx_u96, 96,
 XNN_UKERNEL(xnn_arch_x86_avx512skx, xnn_f16_qu8_vcvt_ukernel__avx512skx_u128, 128, false, xnn_float16, XNN_QUANTIZED(uint8_t), struct xnn_f16_qu8_cvt_params, xnn_init_f16_qu8_cvt_scalar_params)
 #endif  // XNN_ENABLE_AVX512SKX && (XNN_ARCH_X86 || XNN_ARCH_X86_64)
 
+#if XNN_ARCH_RISCV && XNN_ENABLE_RISCV_FP16_VECTOR
+XNN_UKERNEL(xnn_arch_riscv_vector_fp16_arith, xnn_f16_qu8_vcvt_ukernel__rvvfp16arith_u1v, 1, true, xnn_float16, XNN_QUANTIZED(uint8_t), struct xnn_f16_qu8_cvt_params, xnn_init_f16_qu8_cvt_scalar_params)
+XNN_UKERNEL(xnn_arch_riscv_vector_fp16_arith, xnn_f16_qu8_vcvt_ukernel__rvvfp16arith_u2v, 2, true, xnn_float16, XNN_QUANTIZED(uint8_t), struct xnn_f16_qu8_cvt_params, xnn_init_f16_qu8_cvt_scalar_params)
+XNN_UKERNEL(xnn_arch_riscv_vector_fp16_arith, xnn_f16_qu8_vcvt_ukernel__rvvfp16arith_u4v, 4, true, xnn_float16, XNN_QUANTIZED(uint8_t), struct xnn_f16_qu8_cvt_params, xnn_init_f16_qu8_cvt_scalar_params)
+XNN_UKERNEL(xnn_arch_riscv_vector_fp16_arith, xnn_f16_qu8_vcvt_ukernel__rvvfp16arith_u8v, 8, true, xnn_float16, XNN_QUANTIZED(uint8_t), struct xnn_f16_qu8_cvt_params, xnn_init_f16_qu8_cvt_scalar_params)
+#endif  // XNN_ARCH_RISCV && XNN_ENABLE_RISCV_FP16_VECTOR
+
 XNN_UKERNEL(xnn_arch_none, xnn_f16_qu8_vcvt_ukernel__scalar_imagic_u1, 1, false, xnn_float16, XNN_QUANTIZED(uint8_t), struct xnn_f16_qu8_cvt_params, xnn_init_f16_qu8_cvt_scalar_params)
 XNN_UKERNEL(xnn_arch_none, xnn_f16_qu8_vcvt_ukernel__scalar_imagic_u2, 2, false, xnn_float16, XNN_QUANTIZED(uint8_t), struct xnn_f16_qu8_cvt_params, xnn_init_f16_qu8_cvt_scalar_params)
 XNN_UKERNEL(xnn_arch_none, xnn_f16_qu8_vcvt_ukernel__scalar_imagic_u3, 3, false, xnn_float16, XNN_QUANTIZED(uint8_t), struct xnn_f16_qu8_cvt_params, xnn_init_f16_qu8_cvt_scalar_params)

--- a/src/f16-qu8-vcvt/gen/f16-qu8-vcvt-rvvfp16arith-u1v.c
+++ b/src/f16-qu8-vcvt/gen/f16-qu8-vcvt-rvvfp16arith-u1v.c
@@ -1,0 +1,71 @@
+// clang-format off
+// Auto-generated file. Do not edit!
+//   Template: src/f16-qs8-vcvt/rvvfp16arith.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2026 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+#include <stdint.h>
+
+#include <riscv_vector.h>
+
+#include "src/xnnpack/common.h"
+#include "src/xnnpack/math.h"
+#include "src/xnnpack/vcvt.h"
+
+
+void xnn_f16_qu8_vcvt_ukernel__rvvfp16arith_u1v(
+    size_t batch,
+    const xnn_float16* input,
+    uint8_t* output,
+    const struct xnn_f16_qu8_cvt_params* restrict params)
+{
+  assert(batch != 0);
+  assert(batch % sizeof(xnn_float16) == 0);
+  assert(input != NULL);
+  assert(output != NULL);
+
+  batch >>= XNN_LOG2_SIZEOF_FLOAT16;
+
+  // A reciprocal output scale that underflows fp16 to zero would turn an
+  // infinite input into NaN via inf * 0, which the clamp below resolves to the
+  // wrong bound. Clamp the scale to the smallest positive fp16 so infinities
+  // saturate by sign, mirroring the scalar kernel's max(FLT_MIN, scale) guard.
+  // Nothing representable lies between 0 and 0x1.0p-24, so non-zero scales are
+  // unaffected.
+  xnn_float16 vscale = params->scalar.scale;
+  if (!(vscale > (xnn_float16) 0x1.0p-24f)) {
+    vscale = (xnn_float16) 0x1.0p-24f;
+  }
+  const int16_t voutput_zero_point = params->scalar.output_zero_point;
+  // vfcvt and vncvt do not saturate, so clamp before converting. The bounds
+  // span at most [-255, 255], which fp16 represents exactly, and the scaled
+  // value is in [0, 255] once the zero point is added back.
+  const xnn_float16 voutput_min_less_zero_point =
+      (xnn_float16) (0 - (int32_t) voutput_zero_point);
+  const xnn_float16 voutput_max_less_zero_point =
+      (xnn_float16) (255 - (int32_t) voutput_zero_point);
+
+  do {
+    const size_t n = __riscv_vsetvl_e16m1(batch);
+
+    vfloat16m1_t vx = __riscv_vle16_v_f16m1(input, n);
+    input += n;
+
+    vx = __riscv_vfmul_vf_f16m1(vx, vscale, n);
+    vx = __riscv_vfmax_vf_f16m1(vx, voutput_min_less_zero_point, n);
+    vx = __riscv_vfmin_vf_f16m1(vx, voutput_max_less_zero_point, n);
+
+    vint16m1_t vacc = __riscv_vfcvt_x_f_v_i16m1(vx, n);
+    vacc = __riscv_vadd_vx_i16m1(vacc, voutput_zero_point, n);
+
+    __riscv_vse8_v_u8mf2(output, __riscv_vncvt_x_x_w_u8mf2(__riscv_vreinterpret_v_i16m1_u16m1(vacc), n), n);
+    output += n;
+
+    batch -= n;
+  } while (batch != 0);
+}

--- a/src/f16-qu8-vcvt/gen/f16-qu8-vcvt-rvvfp16arith-u2v.c
+++ b/src/f16-qu8-vcvt/gen/f16-qu8-vcvt-rvvfp16arith-u2v.c
@@ -1,0 +1,71 @@
+// clang-format off
+// Auto-generated file. Do not edit!
+//   Template: src/f16-qs8-vcvt/rvvfp16arith.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2026 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+#include <stdint.h>
+
+#include <riscv_vector.h>
+
+#include "src/xnnpack/common.h"
+#include "src/xnnpack/math.h"
+#include "src/xnnpack/vcvt.h"
+
+
+void xnn_f16_qu8_vcvt_ukernel__rvvfp16arith_u2v(
+    size_t batch,
+    const xnn_float16* input,
+    uint8_t* output,
+    const struct xnn_f16_qu8_cvt_params* restrict params)
+{
+  assert(batch != 0);
+  assert(batch % sizeof(xnn_float16) == 0);
+  assert(input != NULL);
+  assert(output != NULL);
+
+  batch >>= XNN_LOG2_SIZEOF_FLOAT16;
+
+  // A reciprocal output scale that underflows fp16 to zero would turn an
+  // infinite input into NaN via inf * 0, which the clamp below resolves to the
+  // wrong bound. Clamp the scale to the smallest positive fp16 so infinities
+  // saturate by sign, mirroring the scalar kernel's max(FLT_MIN, scale) guard.
+  // Nothing representable lies between 0 and 0x1.0p-24, so non-zero scales are
+  // unaffected.
+  xnn_float16 vscale = params->scalar.scale;
+  if (!(vscale > (xnn_float16) 0x1.0p-24f)) {
+    vscale = (xnn_float16) 0x1.0p-24f;
+  }
+  const int16_t voutput_zero_point = params->scalar.output_zero_point;
+  // vfcvt and vncvt do not saturate, so clamp before converting. The bounds
+  // span at most [-255, 255], which fp16 represents exactly, and the scaled
+  // value is in [0, 255] once the zero point is added back.
+  const xnn_float16 voutput_min_less_zero_point =
+      (xnn_float16) (0 - (int32_t) voutput_zero_point);
+  const xnn_float16 voutput_max_less_zero_point =
+      (xnn_float16) (255 - (int32_t) voutput_zero_point);
+
+  do {
+    const size_t n = __riscv_vsetvl_e16m2(batch);
+
+    vfloat16m2_t vx = __riscv_vle16_v_f16m2(input, n);
+    input += n;
+
+    vx = __riscv_vfmul_vf_f16m2(vx, vscale, n);
+    vx = __riscv_vfmax_vf_f16m2(vx, voutput_min_less_zero_point, n);
+    vx = __riscv_vfmin_vf_f16m2(vx, voutput_max_less_zero_point, n);
+
+    vint16m2_t vacc = __riscv_vfcvt_x_f_v_i16m2(vx, n);
+    vacc = __riscv_vadd_vx_i16m2(vacc, voutput_zero_point, n);
+
+    __riscv_vse8_v_u8m1(output, __riscv_vncvt_x_x_w_u8m1(__riscv_vreinterpret_v_i16m2_u16m2(vacc), n), n);
+    output += n;
+
+    batch -= n;
+  } while (batch != 0);
+}

--- a/src/f16-qu8-vcvt/gen/f16-qu8-vcvt-rvvfp16arith-u4v.c
+++ b/src/f16-qu8-vcvt/gen/f16-qu8-vcvt-rvvfp16arith-u4v.c
@@ -1,0 +1,71 @@
+// clang-format off
+// Auto-generated file. Do not edit!
+//   Template: src/f16-qs8-vcvt/rvvfp16arith.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2026 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+#include <stdint.h>
+
+#include <riscv_vector.h>
+
+#include "src/xnnpack/common.h"
+#include "src/xnnpack/math.h"
+#include "src/xnnpack/vcvt.h"
+
+
+void xnn_f16_qu8_vcvt_ukernel__rvvfp16arith_u4v(
+    size_t batch,
+    const xnn_float16* input,
+    uint8_t* output,
+    const struct xnn_f16_qu8_cvt_params* restrict params)
+{
+  assert(batch != 0);
+  assert(batch % sizeof(xnn_float16) == 0);
+  assert(input != NULL);
+  assert(output != NULL);
+
+  batch >>= XNN_LOG2_SIZEOF_FLOAT16;
+
+  // A reciprocal output scale that underflows fp16 to zero would turn an
+  // infinite input into NaN via inf * 0, which the clamp below resolves to the
+  // wrong bound. Clamp the scale to the smallest positive fp16 so infinities
+  // saturate by sign, mirroring the scalar kernel's max(FLT_MIN, scale) guard.
+  // Nothing representable lies between 0 and 0x1.0p-24, so non-zero scales are
+  // unaffected.
+  xnn_float16 vscale = params->scalar.scale;
+  if (!(vscale > (xnn_float16) 0x1.0p-24f)) {
+    vscale = (xnn_float16) 0x1.0p-24f;
+  }
+  const int16_t voutput_zero_point = params->scalar.output_zero_point;
+  // vfcvt and vncvt do not saturate, so clamp before converting. The bounds
+  // span at most [-255, 255], which fp16 represents exactly, and the scaled
+  // value is in [0, 255] once the zero point is added back.
+  const xnn_float16 voutput_min_less_zero_point =
+      (xnn_float16) (0 - (int32_t) voutput_zero_point);
+  const xnn_float16 voutput_max_less_zero_point =
+      (xnn_float16) (255 - (int32_t) voutput_zero_point);
+
+  do {
+    const size_t n = __riscv_vsetvl_e16m4(batch);
+
+    vfloat16m4_t vx = __riscv_vle16_v_f16m4(input, n);
+    input += n;
+
+    vx = __riscv_vfmul_vf_f16m4(vx, vscale, n);
+    vx = __riscv_vfmax_vf_f16m4(vx, voutput_min_less_zero_point, n);
+    vx = __riscv_vfmin_vf_f16m4(vx, voutput_max_less_zero_point, n);
+
+    vint16m4_t vacc = __riscv_vfcvt_x_f_v_i16m4(vx, n);
+    vacc = __riscv_vadd_vx_i16m4(vacc, voutput_zero_point, n);
+
+    __riscv_vse8_v_u8m2(output, __riscv_vncvt_x_x_w_u8m2(__riscv_vreinterpret_v_i16m4_u16m4(vacc), n), n);
+    output += n;
+
+    batch -= n;
+  } while (batch != 0);
+}

--- a/src/f16-qu8-vcvt/gen/f16-qu8-vcvt-rvvfp16arith-u8v.c
+++ b/src/f16-qu8-vcvt/gen/f16-qu8-vcvt-rvvfp16arith-u8v.c
@@ -1,0 +1,71 @@
+// clang-format off
+// Auto-generated file. Do not edit!
+//   Template: src/f16-qs8-vcvt/rvvfp16arith.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2026 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+#include <stdint.h>
+
+#include <riscv_vector.h>
+
+#include "src/xnnpack/common.h"
+#include "src/xnnpack/math.h"
+#include "src/xnnpack/vcvt.h"
+
+
+void xnn_f16_qu8_vcvt_ukernel__rvvfp16arith_u8v(
+    size_t batch,
+    const xnn_float16* input,
+    uint8_t* output,
+    const struct xnn_f16_qu8_cvt_params* restrict params)
+{
+  assert(batch != 0);
+  assert(batch % sizeof(xnn_float16) == 0);
+  assert(input != NULL);
+  assert(output != NULL);
+
+  batch >>= XNN_LOG2_SIZEOF_FLOAT16;
+
+  // A reciprocal output scale that underflows fp16 to zero would turn an
+  // infinite input into NaN via inf * 0, which the clamp below resolves to the
+  // wrong bound. Clamp the scale to the smallest positive fp16 so infinities
+  // saturate by sign, mirroring the scalar kernel's max(FLT_MIN, scale) guard.
+  // Nothing representable lies between 0 and 0x1.0p-24, so non-zero scales are
+  // unaffected.
+  xnn_float16 vscale = params->scalar.scale;
+  if (!(vscale > (xnn_float16) 0x1.0p-24f)) {
+    vscale = (xnn_float16) 0x1.0p-24f;
+  }
+  const int16_t voutput_zero_point = params->scalar.output_zero_point;
+  // vfcvt and vncvt do not saturate, so clamp before converting. The bounds
+  // span at most [-255, 255], which fp16 represents exactly, and the scaled
+  // value is in [0, 255] once the zero point is added back.
+  const xnn_float16 voutput_min_less_zero_point =
+      (xnn_float16) (0 - (int32_t) voutput_zero_point);
+  const xnn_float16 voutput_max_less_zero_point =
+      (xnn_float16) (255 - (int32_t) voutput_zero_point);
+
+  do {
+    const size_t n = __riscv_vsetvl_e16m8(batch);
+
+    vfloat16m8_t vx = __riscv_vle16_v_f16m8(input, n);
+    input += n;
+
+    vx = __riscv_vfmul_vf_f16m8(vx, vscale, n);
+    vx = __riscv_vfmax_vf_f16m8(vx, voutput_min_less_zero_point, n);
+    vx = __riscv_vfmin_vf_f16m8(vx, voutput_max_less_zero_point, n);
+
+    vint16m8_t vacc = __riscv_vfcvt_x_f_v_i16m8(vx, n);
+    vacc = __riscv_vadd_vx_i16m8(vacc, voutput_zero_point, n);
+
+    __riscv_vse8_v_u8m4(output, __riscv_vncvt_x_x_w_u8m4(__riscv_vreinterpret_v_i16m8_u16m8(vacc), n), n);
+    output += n;
+
+    batch -= n;
+  } while (batch != 0);
+}

--- a/src/qs8-f16-vcvt/gen/qs8-f16-vcvt-rvvfp16arith-u1v.c
+++ b/src/qs8-f16-vcvt/gen/qs8-f16-vcvt-rvvfp16arith-u1v.c
@@ -1,0 +1,56 @@
+// clang-format off
+// Auto-generated file. Do not edit!
+//   Template: src/qs8-f16-vcvt/rvvfp16arith.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2026 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+#include <stdint.h>
+
+#include <riscv_vector.h>
+
+#include "src/xnnpack/common.h"
+#include "src/xnnpack/math.h"
+#include "src/xnnpack/vcvt.h"
+
+
+void xnn_qs8_f16_vcvt_ukernel__rvvfp16arith_u1v(
+    size_t batch,
+    const int8_t* input,
+    xnn_float16* output,
+    const struct xnn_qs8_f16_cvt_params* restrict params)
+{
+  assert(batch != 0);
+  assert(batch % sizeof(int8_t) == 0);
+  assert(input != NULL);
+  assert(output != NULL);
+
+  batch >>= XNN_LOG2_SIZEOF_INT8_T;
+
+  const int16_t vminus_zero_point = -params->scalar.zero_point;
+  const xnn_float16 vscale = params->scalar.scale;
+
+  do {
+    const size_t n = __riscv_vsetvl_e8m1(batch);
+
+    vint8m1_t vx = __riscv_vle8_v_i8m1(input, n);
+    input += n;
+
+    // int8 minus the zero point is in [-255, 255], which fp16 represents
+    // exactly, so the widened value converts without rounding.
+    vint16m2_t vacc = __riscv_vsext_vf2_i16m2(vx, n);
+    vacc = __riscv_vadd_vx_i16m2(vacc, vminus_zero_point, n);
+
+    vfloat16m2_t vy = __riscv_vfcvt_f_x_v_f16m2(vacc, n);
+    vy = __riscv_vfmul_vf_f16m2(vy, vscale, n);
+
+    __riscv_vse16_v_f16m2(output, vy, n);
+    output += n;
+
+    batch -= n;
+  } while (batch != 0);
+}

--- a/src/qs8-f16-vcvt/gen/qs8-f16-vcvt-rvvfp16arith-u2v.c
+++ b/src/qs8-f16-vcvt/gen/qs8-f16-vcvt-rvvfp16arith-u2v.c
@@ -1,0 +1,56 @@
+// clang-format off
+// Auto-generated file. Do not edit!
+//   Template: src/qs8-f16-vcvt/rvvfp16arith.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2026 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+#include <stdint.h>
+
+#include <riscv_vector.h>
+
+#include "src/xnnpack/common.h"
+#include "src/xnnpack/math.h"
+#include "src/xnnpack/vcvt.h"
+
+
+void xnn_qs8_f16_vcvt_ukernel__rvvfp16arith_u2v(
+    size_t batch,
+    const int8_t* input,
+    xnn_float16* output,
+    const struct xnn_qs8_f16_cvt_params* restrict params)
+{
+  assert(batch != 0);
+  assert(batch % sizeof(int8_t) == 0);
+  assert(input != NULL);
+  assert(output != NULL);
+
+  batch >>= XNN_LOG2_SIZEOF_INT8_T;
+
+  const int16_t vminus_zero_point = -params->scalar.zero_point;
+  const xnn_float16 vscale = params->scalar.scale;
+
+  do {
+    const size_t n = __riscv_vsetvl_e8m2(batch);
+
+    vint8m2_t vx = __riscv_vle8_v_i8m2(input, n);
+    input += n;
+
+    // int8 minus the zero point is in [-255, 255], which fp16 represents
+    // exactly, so the widened value converts without rounding.
+    vint16m4_t vacc = __riscv_vsext_vf2_i16m4(vx, n);
+    vacc = __riscv_vadd_vx_i16m4(vacc, vminus_zero_point, n);
+
+    vfloat16m4_t vy = __riscv_vfcvt_f_x_v_f16m4(vacc, n);
+    vy = __riscv_vfmul_vf_f16m4(vy, vscale, n);
+
+    __riscv_vse16_v_f16m4(output, vy, n);
+    output += n;
+
+    batch -= n;
+  } while (batch != 0);
+}

--- a/src/qs8-f16-vcvt/gen/qs8-f16-vcvt-rvvfp16arith-u4v.c
+++ b/src/qs8-f16-vcvt/gen/qs8-f16-vcvt-rvvfp16arith-u4v.c
@@ -1,0 +1,56 @@
+// clang-format off
+// Auto-generated file. Do not edit!
+//   Template: src/qs8-f16-vcvt/rvvfp16arith.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2026 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+#include <stdint.h>
+
+#include <riscv_vector.h>
+
+#include "src/xnnpack/common.h"
+#include "src/xnnpack/math.h"
+#include "src/xnnpack/vcvt.h"
+
+
+void xnn_qs8_f16_vcvt_ukernel__rvvfp16arith_u4v(
+    size_t batch,
+    const int8_t* input,
+    xnn_float16* output,
+    const struct xnn_qs8_f16_cvt_params* restrict params)
+{
+  assert(batch != 0);
+  assert(batch % sizeof(int8_t) == 0);
+  assert(input != NULL);
+  assert(output != NULL);
+
+  batch >>= XNN_LOG2_SIZEOF_INT8_T;
+
+  const int16_t vminus_zero_point = -params->scalar.zero_point;
+  const xnn_float16 vscale = params->scalar.scale;
+
+  do {
+    const size_t n = __riscv_vsetvl_e8m4(batch);
+
+    vint8m4_t vx = __riscv_vle8_v_i8m4(input, n);
+    input += n;
+
+    // int8 minus the zero point is in [-255, 255], which fp16 represents
+    // exactly, so the widened value converts without rounding.
+    vint16m8_t vacc = __riscv_vsext_vf2_i16m8(vx, n);
+    vacc = __riscv_vadd_vx_i16m8(vacc, vminus_zero_point, n);
+
+    vfloat16m8_t vy = __riscv_vfcvt_f_x_v_f16m8(vacc, n);
+    vy = __riscv_vfmul_vf_f16m8(vy, vscale, n);
+
+    __riscv_vse16_v_f16m8(output, vy, n);
+    output += n;
+
+    batch -= n;
+  } while (batch != 0);
+}

--- a/src/qs8-f16-vcvt/qs8-f16-vcvt.inc
+++ b/src/qs8-f16-vcvt/qs8-f16-vcvt.inc
@@ -25,6 +25,12 @@ XNN_UKERNEL(xnn_arch_x86_avx2, xnn_qs8_f16_vcvt_ukernel__avx2_u32, 32, false, XN
 XNN_UKERNEL(xnn_arch_x86_avx2, xnn_qs8_f16_vcvt_ukernel__avx2_u64, 64, false, XNN_QUANTIZED(int8_t), xnn_float16, struct xnn_qs8_f16_cvt_params, xnn_init_qs8_f16_cvt_scalar_params)
 #endif  // XNN_ENABLE_AVX2 && (XNN_ARCH_X86 || XNN_ARCH_X86_64)
 
+#if XNN_ARCH_RISCV && XNN_ENABLE_RISCV_FP16_VECTOR
+XNN_UKERNEL(xnn_arch_riscv_vector_fp16_arith, xnn_qs8_f16_vcvt_ukernel__rvvfp16arith_u1v, 1, true, XNN_QUANTIZED(int8_t), xnn_float16, struct xnn_qs8_f16_cvt_params, xnn_init_qs8_f16_cvt_scalar_params)
+XNN_UKERNEL(xnn_arch_riscv_vector_fp16_arith, xnn_qs8_f16_vcvt_ukernel__rvvfp16arith_u2v, 2, true, XNN_QUANTIZED(int8_t), xnn_float16, struct xnn_qs8_f16_cvt_params, xnn_init_qs8_f16_cvt_scalar_params)
+XNN_UKERNEL(xnn_arch_riscv_vector_fp16_arith, xnn_qs8_f16_vcvt_ukernel__rvvfp16arith_u4v, 4, true, XNN_QUANTIZED(int8_t), xnn_float16, struct xnn_qs8_f16_cvt_params, xnn_init_qs8_f16_cvt_scalar_params)
+#endif  // XNN_ARCH_RISCV && XNN_ENABLE_RISCV_FP16_VECTOR
+
 #ifdef XNN_DEFINED_QUANTIZED
 #undef XNN_DEFINED_QUANTIZED
 #undef XNN_QUANTIZED

--- a/src/qs8-f16-vcvt/rvvfp16arith.c.in
+++ b/src/qs8-f16-vcvt/rvvfp16arith.c.in
@@ -1,0 +1,53 @@
+// Copyright 2026 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+$assert LMUL in [1, 2, 4]
+$LMUL_16 = LMUL * 2
+#include <assert.h>
+#include <stdint.h>
+
+#include <riscv_vector.h>
+
+#include "src/xnnpack/common.h"
+#include "src/xnnpack/math.h"
+#include "src/xnnpack/vcvt.h"
+
+
+void xnn_qs8_f16_vcvt_ukernel__rvvfp16arith_u${LMUL}v(
+    size_t batch,
+    const int8_t* input,
+    xnn_float16* output,
+    const struct xnn_qs8_f16_cvt_params* restrict params)
+{
+  assert(batch != 0);
+  assert(batch % sizeof(int8_t) == 0);
+  assert(input != NULL);
+  assert(output != NULL);
+
+  batch >>= XNN_LOG2_SIZEOF_INT8_T;
+
+  const int16_t vminus_zero_point = -params->scalar.zero_point;
+  const xnn_float16 vscale = params->scalar.scale;
+
+  do {
+    const size_t n = __riscv_vsetvl_e8m${LMUL}(batch);
+
+    vint8m${LMUL}_t vx = __riscv_vle8_v_i8m${LMUL}(input, n);
+    input += n;
+
+    // int8 minus the zero point is in [-255, 255], which fp16 represents
+    // exactly, so the widened value converts without rounding.
+    vint16m${LMUL_16}_t vacc = __riscv_vsext_vf2_i16m${LMUL_16}(vx, n);
+    vacc = __riscv_vadd_vx_i16m${LMUL_16}(vacc, vminus_zero_point, n);
+
+    vfloat16m${LMUL_16}_t vy = __riscv_vfcvt_f_x_v_f16m${LMUL_16}(vacc, n);
+    vy = __riscv_vfmul_vf_f16m${LMUL_16}(vy, vscale, n);
+
+    __riscv_vse16_v_f16m${LMUL_16}(output, vy, n);
+    output += n;
+
+    batch -= n;
+  } while (batch != 0);
+}


### PR DESCRIPTION
## Add RVV Zvfh microkernels for f16↔int8 vcvt

Adds native RISC-V Vector (Zvfh) microkernels for three float16↔int8 conversions that had no RVV implementation:

| Operator | Direction | Unrolls | Before |
|---|---|---|---|
| `f16-qs8-vcvt` | fp16 → int8 | LMUL 1/2/4/8 | scalar fallback |
| `f16-qu8-vcvt` | fp16 → uint8 | LMUL 1/2/4/8 | scalar fallback |
| `qs8-f16-vcvt` | int8 → fp16 | LMUL 1/2/4 | `unsupported_hardware` |

### Notes
- Clamp happens in the fp16 domain **before** narrowing, since RVV `vncvt` truncates rather than saturates.
- Scale is clamped to the smallest positive fp16 so infinite inputs saturate by sign (avoids `inf * 0 = NaN` when the reciprocal scale underflows), mirroring the scalar kernel's `max(FLT_MIN, scale)` guard.
- Full wiring: `.inc` registries, config dispatch, and PROD/NON_PROD build lists (matches `update-microkernels.py`).

### Verification (native RISC-V, GCC 15.2, `-march=rv64gcv_zvfh`)
- **Correctness**: 72 / 64 / 18 tests pass, robust across 180+ randomized runs.
- **Performance** (vs scalar): ~6.9× (f16→qs8/qu8), ~6.2× (qs8→f16).