### PR TITLE
Use xnn_safe_mul for output_size in reshape_igemm

### DIFF
--- a/src/operators/convolution-nhwc.c
+++ b/src/operators/convolution-nhwc.c
@@ -2694,7 +2694,10 @@ static enum xnn_status reshape_igemm(
   }
   const size_t output_height = convolution_op->convolution_op->output_height;
   const size_t output_width = convolution_op->convolution_op->output_width;
-  const size_t output_size = output_height * output_width;
+  size_t output_size;
+  if (!xnn_safe_mul(output_height, output_width, &output_size)) {
+    return xnn_status_out_of_memory;
+  }
 
   const uint32_t nr = convolution_op->ukernel.igemm->nr;
   struct xnn_hmp_igemm_ukernel* igemm_cases =


### PR DESCRIPTION
## Summary
- Replace bare `output_height * output_width` with `xnn_safe_mul` when computing `output_size` in `reshape_igemm`.
- Matches the existing overflow checks for `kernel_size` and `indirection_buffer_size` in the same function.
- On 32-bit platforms, wrapping `output_size` can undersize the indirection buffer and lead to out-of-bounds reads during IGEMM.

## Test plan
- [ ] Existing XNNPACK unit / convolution tests still pass
- [ ] On 32-bit (or simulated wrap), oversized `output_height`/`output_width` now return `xnn_status_out_of_memory` instead of allocating an undersized indirection buffer
- [ ] Valid reshape paths with in-range dimensions still succeed


Made with [Cursor](https://cursor.com)