### PR TITLE
[RVV]: Add RVV  xx-fill kernel

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1588,6 +1588,7 @@ if (!build_with_chromium) {
     "bench/x8-packq.cc",
     "bench/x8-packw.cc",
     "bench/xN-transposec.cc",
+    "bench/xx-fill.cc",
     "bench/xx-pad.cc",
     "bench/xx-transposev.cc",
   ]

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -107,6 +107,7 @@ SET(MICROKERNEL_BENCHMARKS
     vbinary
     indirection
     xN-transposec
+    xx-fill
     xx-pad
     xx-transposev)
 FOREACH(BENCH ${MICROKERNEL_BENCHMARKS})

--- a/bench/xx-fill.cc
+++ b/bench/xx-fill.cc
@@ -1,0 +1,75 @@
+// Copyright 2026 Léandre Le Duc
+// Copyright 2026 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <benchmark/benchmark.h>
+
+#include <cmath>
+#include <vector>
+
+#include "bench/utils.h"
+#include "src/xnnpack/buffer.h"
+#include "src/xnnpack/common.h"
+#include "src/xnnpack/fill.h"
+#include "src/xnnpack/hardware-config.h"
+#include "src/xnnpack/microfnptr.h"
+
+static void xx_fill(benchmark::State& state, xnn_fill_ukernel_fn fill,
+                    uint64_t arch_flags = 0) {
+  if (!benchmark::utils::CheckArchFlags(state, arch_flags)) {
+    return;
+  }
+
+  const size_t rows = state.range(0);
+  const size_t channels = state.range(1);
+
+  const size_t output_stride = channels;
+
+  xnnpack::Buffer<uint8_t, XNN_ALLOCATION_ALIGNMENT> output(
+      rows * output_stride, xnnpack::XnnExtraBytes);
+
+  const uint32_t fill_pattern = 0xDEADBEEF;
+
+  for (auto _ : state) {
+    fill(rows, channels, output.data(), output_stride, fill_pattern);
+  }
+
+  const uint64_t cpu_frequency = benchmark::utils::GetCurrentCpuFrequency();
+  if (cpu_frequency != 0) {
+    state.counters["cpufreq"] = cpu_frequency;
+  }
+
+  const size_t elements_per_iteration = rows * output_stride;
+  state.counters["elements"] =
+      benchmark::Counter(uint64_t(state.iterations()) * elements_per_iteration,
+                         benchmark::Counter::kIsRate);
+
+  const size_t bytes_per_iteration = rows * output_stride;
+  state.counters["bytes"] =
+      benchmark::Counter(uint64_t(state.iterations()) * bytes_per_iteration,
+                         benchmark::Counter::kIsRate);
+}
+
+static void BenchmarkFill(benchmark::Benchmark* b) {
+  b->ArgNames({"rows", "channels"});
+  b->Args({1, 16});
+  b->Args({1, 64});
+  b->Args({1, 256});
+  b->Args({1, 1024});
+  b->Args({1, 8192});
+  b->Args({100, 256});
+  b->Args({1024, 16});
+}
+
+#define XNN_FILL_UKERNEL(arch_flags, ukernel)              \
+  BENCHMARK_CAPTURE(xx_fill, ukernel, ukernel, arch_flags) \
+      ->Apply(BenchmarkFill)                               \
+      ->UseRealTime();
+#include "src/xx-fill/xx-fill.inc"
+#undef XNN_FILL_UKERNEL
+
+#ifndef XNNPACK_BENCHMARK_NO_MAIN
+XNN_BENCHMARK_MAIN();
+#endif

--- a/cmake/gen/rvv_microkernels.cmake
+++ b/cmake/gen/rvv_microkernels.cmake
@@ -146,7 +146,8 @@ SET(PROD_RVV_MICROKERNEL_SRCS
   src/x32-transposec/gen/x32-transposec-4x4-rvv.c
   src/x32-transposec/gen/x32-transposec-8x8-rvv.c
   src/x32-transposec/gen/x32-transposec-16x8-rvv.c
-  src/x32-transposec/gen/x32-transposec-32x8-rvv.c)
+  src/x32-transposec/gen/x32-transposec-32x8-rvv.c
+  src/xx-fill/xx-fill-rvv-u4v.c)
 
 SET(NON_PROD_RVV_MICROKERNEL_SRCS
   src/f32-conv-hwc2chw/f32-conv-hwc2chw-3x3s2p1c3x2v-rvv-1x1.c

--- a/gen/rvv_microkernels.bzl
+++ b/gen/rvv_microkernels.bzl
@@ -143,6 +143,7 @@ PROD_RVV_MICROKERNEL_SRCS = [
     "src/x32-transposec/gen/x32-transposec-8x8-rvv.c",
     "src/x32-transposec/gen/x32-transposec-16x8-rvv.c",
     "src/x32-transposec/gen/x32-transposec-32x8-rvv.c",
+    "src/xx-fill/xx-fill-rvv-u4v.c",
 ]
 
 NON_PROD_RVV_MICROKERNEL_SRCS = [

--- a/src/configs/xx-fill-config.c
+++ b/src/configs/xx-fill-config.c
@@ -9,6 +9,7 @@
 #include "src/xnnpack/common.h"
 #include "src/xnnpack/config.h"
 #include "src/xnnpack/fill.h"
+#include "src/xnnpack/hardware-config.h"
 #include "src/xnnpack/init-once.h"
 #include "src/xnnpack/microfnptr.h"
 
@@ -41,8 +42,14 @@ static void init_xx_fill_config(void) {
     }
   #elif XNN_ARCH_WASMSIMD || XNN_ARCH_WASMRELAXEDSIMD
     xx_fill_config.ukernel = (xnn_fill_ukernel_fn) xnn_xx_fill_ukernel__wasmsimd_u64;
-  #elif XNN_ARCH_RISCV
-    xx_fill_config.ukernel = (xnn_fill_ukernel_fn) xnn_xx_fill_ukernel__scalar_u16;
+  #elif XNN_ARCH_RISCV && XNN_ENABLE_RISCV_VECTOR
+    const struct xnn_hardware_config* hardware_config = xnn_init_hardware_config();
+    assert(hardware_config != NULL);
+    if (hardware_config->arch_flags && xnn_arch_riscv_vector) {
+      xx_fill_config.ukernel = (xnn_fill_ukernel_fn) xnn_xx_fill_ukernel__rvv_u4v;
+    } else {
+      xx_fill_config.ukernel = (xnn_fill_ukernel_fn) xnn_xx_fill_ukernel__scalar_u16;
+    }
   #else
     xx_fill_config.ukernel = (xnn_fill_ukernel_fn) xnn_xx_fill_ukernel__scalar_u16;
   #endif

--- a/src/xx-fill/xx-fill-rvv-u4v.c
+++ b/src/xx-fill/xx-fill-rvv-u4v.c
@@ -1,0 +1,31 @@
+// Copyright 2026 Léandre Le Duc
+// Copyright 2026 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+#include <riscv_vector.h>
+
+#include "src/xnnpack/fill.h"
+
+void xnn_xx_fill_ukernel__rvv_u4v(size_t rows, size_t channels, void* output,
+                                  size_t output_stride,
+                                  const uint32_t fill_pattern) {
+  assert(rows != 0);
+  assert(channels != 0);
+
+  const size_t output_increment = output_stride - channels;
+
+  const vuint8m4_t vfill = __riscv_vreinterpret_v_u32m4_u8m4(
+      __riscv_vmv_v_x_u32m4(fill_pattern, __riscv_vsetvlmax_e32m4()));
+
+  do {
+    size_t c = channels;
+    for (size_t vl; c > 0; c -= vl, output += vl) {
+      vl = __riscv_vsetvl_e8m4(c);
+      __riscv_vse8_v_u8m4(output, vfill, vl);
+    }
+    output = (void*)((uintptr_t)output + output_increment);
+  } while (--rows != 0);
+}

--- a/src/xx-fill/xx-fill.inc
+++ b/src/xx-fill/xx-fill.inc
@@ -16,4 +16,8 @@ XNN_FILL_UKERNEL(xnn_arch_x86_sse2, xnn_xx_fill_ukernel__sse2_u64)
 XNN_FILL_UKERNEL(xnn_arch_none, xnn_xx_fill_ukernel__wasmsimd_u64)
 #endif  // XNN_ARCH_WASMSIMD || XNN_ARCH_WASMRELAXEDSIMD
 
+# if XNN_ARCH_RISCV && XNN_ENABLE_RISCV_VECTOR
+XNN_FILL_UKERNEL(xnn_arch_riscv_vector, xnn_xx_fill_ukernel__rvv_u4v)
+#endif // XNN_ARCH_RISCV && XNN_ENABLE_RISCV_VECTOR
+
 XNN_FILL_UKERNEL(xnn_arch_none, xnn_xx_fill_ukernel__scalar_u16)


### PR DESCRIPTION
## Summary
- Add `xnn_xx_fill_ukernel__rvv_u4v`, an RVV implementation of the `xx-fill` microkernel (fills a buffer with a repeating 32-bit pattern) using LMUL=4, registered in the `xx-fill` config/build files.
- Add `bench/xx-fill.cc` (modeled on `bench/xx-pad.cc`) to benchmark it against the `scalar_u16` fallback.

## LMUL tuning
Tuned empirically on k230 across m8/m4/m2:
- `m4` matches `m8`'s peak throughput on large shapes while fixing `m8`'s only weak spot (small channel counts).
- `m2` trades away large-shape throughput (-21% to -37%) for a bit more on the smallest shape only, a bad trade, not used.

## Perf
Measured on k230 (single core, 27 MHz), bytes/s, rvv (m4) vs scalar_u16:

| rows | channels | rvv | scalar | speedup |
|---|---|---|---|---|
| 1 | 16 | 1.00 G/s | 806.0 M/s | 1.24x |
| 1 | 64 | 4.00 G/s | 1.22 G/s | 3.28x |
| 1 | 256 | 8.16 G/s | 1.40 G/s | 5.84x |
| 1 | 1024 | 11.03 G/s | 1.45 G/s | 7.61x |
| 1 | 8192 | 12.20 G/s | 1.47 G/s | 8.32x |
| 100 | 256 | 11.94 G/s | 1.45 G/s | 8.25x |
| 1024 | 16 | 2.47 G/s | 1.25 G/s | 1.98x |
