### PR TITLE
[RVV]: Add RVV xx-pad ukernel

### DIFF
--- a/cmake/gen/rvv_microkernels.cmake
+++ b/cmake/gen/rvv_microkernels.cmake
@@ -368,6 +368,7 @@ SET(NON_PROD_RVV_MICROKERNEL_SRCS
   src/x32-packw/gen/x32-packw-x8v-gemm-goi-rvv-u8.c
   src/x32-transposec/gen/x32-transposec-8xv1-rvv.c
   src/x32-transposec/gen/x32-transposec-8xv2-rvv.c
-  src/x32-transposec/gen/x32-transposec-8xv4-rvv.c)
+  src/x32-transposec/gen/x32-transposec-8xv4-rvv.c
+  src/xx-pad/xx-pad-rvv-u4v.c)
 
 SET(ALL_RVV_MICROKERNEL_SRCS ${PROD_RVV_MICROKERNEL_SRCS} ${NON_PROD_RVV_MICROKERNEL_SRCS})

--- a/gen/rvv_microkernels.bzl
+++ b/gen/rvv_microkernels.bzl
@@ -366,6 +366,7 @@ NON_PROD_RVV_MICROKERNEL_SRCS = [
     "src/x32-transposec/gen/x32-transposec-8xv1-rvv.c",
     "src/x32-transposec/gen/x32-transposec-8xv2-rvv.c",
     "src/x32-transposec/gen/x32-transposec-8xv4-rvv.c",
+    "src/xx-pad/xx-pad-rvv-u4v.c",
 ]
 
 ALL_RVV_MICROKERNEL_SRCS = PROD_RVV_MICROKERNEL_SRCS + NON_PROD_RVV_MICROKERNEL_SRCS

--- a/src/configs/xx-pad-config.c
+++ b/src/configs/xx-pad-config.c
@@ -8,6 +8,7 @@
 
 #include "src/xnnpack/common.h"
 #include "src/xnnpack/config.h"
+#include "src/xnnpack/hardware-config.h"
 #include "src/xnnpack/init-once.h"
 #include "src/xnnpack/microfnptr.h"
 #include "src/xnnpack/pad.h"
@@ -46,6 +47,14 @@ static void init_xx_pad_config(void) {
     }
   #elif XNN_ARCH_WASMSIMD || XNN_ARCH_WASMRELAXEDSIMD
     xx_pad_config.ukernel = (xnn_pad_ukernel_fn) xnn_xx_pad_ukernel_p16__wasmsimd_u16;
+  #elif XNN_ARCH_RISCV && XNN_ENABLE_RISCV_VECTOR 
+    const struct xnn_hardware_config* hardware_config = xnn_init_hardware_config();
+    assert(hardware_config != NULL);
+    if (hardware_config->arch_flags & xnn_arch_riscv_vector) {
+      xx_pad_config.ukernel = (xnn_pad_ukernel_fn) xnn_xx_pad_ukernel__rvv_u4v;
+    } else {
+      xx_pad_config.ukernel = (xnn_pad_ukernel_fn) xnn_xx_pad_ukernel_p4__scalar_u16;
+    }
   #else
     xx_pad_config.ukernel = (xnn_pad_ukernel_fn) xnn_xx_pad_ukernel_p4__scalar_u16;
   #endif

--- a/src/xx-pad/xx-pad-rvv-u4v.c
+++ b/src/xx-pad/xx-pad-rvv-u4v.c
@@ -1,0 +1,64 @@
+// Copyright 2026 Léandre Le Duc
+// Copyright 2026 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+#include <riscv_vector.h>
+
+#include "src/xnnpack/pad.h"
+
+void xnn_xx_pad_ukernel__rvv_u4v(
+    size_t rows,
+    size_t channels,
+    size_t pre_padding,
+    size_t post_padding,
+    const void* input,
+    size_t input_stride,
+    void* output,
+    size_t output_stride,
+    uint32_t fill_pattern) XNN_OOB_READS
+{
+  assert(rows != 0);
+  assert(channels != 0);
+
+  const size_t input_increment = input_stride - channels;
+  const size_t output_increment = output_stride - (pre_padding + channels + post_padding);
+
+  const vuint8m4_t vfill = __riscv_vreinterpret_v_u32m4_u8m4(
+      __riscv_vmv_v_x_u32m4(fill_pattern, __riscv_vsetvlmax_e32m4()));
+
+  do {
+    // Pre-pad input channels.
+    size_t l = pre_padding;
+    if XNN_LIKELY(l != 0) {
+      for(size_t vl; l > 0; l -= vl, output += vl) {
+        vl = __riscv_vsetvl_e8m4(l);
+        __riscv_vse8_v_u8m4(output, vfill, vl);
+      }
+
+    }
+
+    // Copy input channels.
+    size_t c = channels;
+    for (size_t vl; c > 0; c -= vl, output += vl, input += vl) {
+      vl = __riscv_vsetvl_e8m4(c);
+      const vuint8m4_t vdata = __riscv_vle8_v_u8m4(input, vl);
+      __riscv_vse8_v_u8m4(output, vdata, vl);
+    }
+
+    // Post-pad input channels.
+    size_t r = post_padding;
+    if XNN_LIKELY(r != 0) {
+      for(size_t vl; r > 0; r -= vl, output += vl) {
+        vl = __riscv_vsetvl_e8m4(r);
+        __riscv_vse8_v_u8m4(output, vfill, vl);
+      }
+
+    }
+
+    input = (void*)((uintptr_t)input + input_increment);
+    output = (void*)((uintptr_t)output + output_increment);
+  } while (--rows != 0);
+}

--- a/src/xx-pad/xx-pad.inc
+++ b/src/xx-pad/xx-pad.inc
@@ -20,4 +20,8 @@ XNN_PAD_UKERNEL(xnn_arch_x86_sse2, xnn_xx_pad_ukernel_p16__sse2_u16, 16)
 XNN_PAD_UKERNEL(xnn_arch_none, xnn_xx_pad_ukernel_p16__wasmsimd_u16, 16)
 #endif  // XNN_ARCH_WASMSIMD || XNN_ARCH_WASMRELAXEDSIMD
 
+# if XNN_ARCH_RISCV && XNN_ENABLE_RISCV_VECTOR
+XNN_PAD_UKERNEL(xnn_arch_riscv_vector, xnn_xx_pad_ukernel__rvv_u4v, 1)
+#endif // XNN_ARCH_RISCV && XNN_ENABLE_RISCV_VECTOR
+
 XNN_PAD_UKERNEL(xnn_arch_none, xnn_xx_pad_ukernel_p4__scalar_u16, 4)


### PR DESCRIPTION
## Perf
Measured on k230 (single core, 27 MHz), bytes/s, rvv (m4) vs scalar_u16:

| rows | channels | rvv | scalar | speedup |
|---|---|---|---|---|
| 1 | 16 | 1.89 G/s | 698.9 M/s | 2.70x |
| 1 | 64 | 7.44 G/s | 1.10 G/s | 6.74x |
| 1 | 256 | 10.13 G/s | 1.29 G/s | 7.84x |
| 1 | 1024 | 11.32 G/s | 1.34 G/s | 8.43x |
| 1 | 8192 | 11.72 G/s | 1.47 G/s | 7.98x |
| 100 | 256 | 11.68 G/s | 1.33 G/s | 8.76x |
| 1024 | 16 | 2.91 G/s | 1.03 G/s | 2.82x |