### PR TITLE
convolution/deconvolution: fix NULL deref after xnn_reallocate_memory for zero_buffers

### DIFF
--- a/src/operators/convolution-nhwc.c
+++ b/src/operators/convolution-nhwc.c
@@ -3394,9 +3394,16 @@ enum xnn_status reshape_convolution2d_nhwc_qx8_f16_qc8w(
             convolution_op->convolution_op->zero_buffers[i]);
       }
     }
-    convolution_op->convolution_op->zero_buffers =
-        xnn_reallocate_memory(convolution_op->convolution_op->zero_buffers,
-                              batch_size * sizeof(void*));
+    void** new_zero_buffers = xnn_reallocate_memory(
+        convolution_op->convolution_op->zero_buffers,
+        batch_size * sizeof(void*));
+    if (new_zero_buffers == NULL) {
+      xnn_log_error(
+          "failed to reallocate %zu bytes for zero_buffers",
+          batch_size * sizeof(void*));
+      return xnn_status_out_of_memory;
+    }
+    convolution_op->convolution_op->zero_buffers = new_zero_buffers;
     convolution_op->convolution_op->zero_buffers[0] =
         convolution_op->zero_buffer;
     for (size_t i = 1; i < batch_size; ++i) {
@@ -3456,9 +3463,16 @@ enum xnn_status reshape_convolution2d_nhwc_qx8_f32_qc8w(
             convolution_op->convolution_op->zero_buffers[i]);
       }
     }
-    convolution_op->convolution_op->zero_buffers =
-        xnn_reallocate_memory(convolution_op->convolution_op->zero_buffers,
-                              batch_size * sizeof(void*));
+    void** new_zero_buffers = xnn_reallocate_memory(
+        convolution_op->convolution_op->zero_buffers,
+        batch_size * sizeof(void*));
+    if (new_zero_buffers == NULL) {
+      xnn_log_error(
+          "failed to reallocate %zu bytes for zero_buffers",
+          batch_size * sizeof(void*));
+      return xnn_status_out_of_memory;
+    }
+    convolution_op->convolution_op->zero_buffers = new_zero_buffers;
     convolution_op->convolution_op->zero_buffers[0] =
         convolution_op->zero_buffer;
     for (size_t i = 1; i < batch_size; ++i) {

--- a/src/operators/deconvolution-nhwc.c
+++ b/src/operators/deconvolution-nhwc.c
@@ -2524,9 +2524,16 @@ enum xnn_status reshape_deconvolution2d_nhwc_qx8_f32_qc8w(
       }
     }
 
-    deconvolution_op->convolution_op->zero_buffers =
-        xnn_reallocate_memory(deconvolution_op->convolution_op->zero_buffers,
-                              batch_size * sizeof(void*));
+    void** new_zero_buffers = xnn_reallocate_memory(
+        deconvolution_op->convolution_op->zero_buffers,
+        batch_size * sizeof(void*));
+    if (new_zero_buffers == NULL) {
+      xnn_log_error(
+          "failed to reallocate %zu bytes for zero_buffers",
+          batch_size * sizeof(void*));
+      return xnn_status_out_of_memory;
+    }
+    deconvolution_op->convolution_op->zero_buffers = new_zero_buffers;
     deconvolution_op->convolution_op->zero_buffers[0] =
         deconvolution_op->zero_buffer;
     for (size_t i = 1; i < batch_size; ++i) {


### PR DESCRIPTION
Three reshape functions for quantized NHWC convolution and deconvolution store the result of `xnn_reallocate_memory` directly into `zero_buffers` and then immediately dereference it - a NULL dereference (SIGSEGV) if `realloc` fails under memory pressure.

**Affected functions:**
- `reshape_convolution2d_nhwc_qx8_f16_qc8w` (`src/operators/convolution-nhwc.c`)
- `reshape_convolution2d_nhwc_qx8_f32_qc8w` (`src/operators/convolution-nhwc.c`)
- `reshape_deconvolution2d_nhwc_qx8_f32_qc8w` (`src/operators/deconvolution-nhwc.c`)

**Before:**
```c
convolution_op->convolution_op->zero_buffers =
    xnn_reallocate_memory(convolution_op->convolution_op->zero_buffers,
                          batch_size * sizeof(void*));
convolution_op->convolution_op->zero_buffers[0] =   // NULL deref if realloc failed
    convolution_op->zero_buffer;
```

**After:**
```c
void** new_zero_buffers = xnn_reallocate_memory(
    convolution_op->convolution_op->zero_buffers,
    batch_size * sizeof(void*));
if (new_zero_buffers == NULL) {
  xnn_log_error("failed to reallocate %zu bytes for zero_buffers",
                batch_size * sizeof(void*));
  return xnn_status_out_of_memory;
}
convolution_op->convolution_op->zero_buffers = new_zero_buffers;
convolution_op->convolution_op->zero_buffers[0] = convolution_op->zero_buffer;
```

The fix saves to a temporary, checks for NULL, and propagates `xnn_status_out_of_memory` - consistent with the guard pattern used for other allocations in the same files.