### PR TITLE
convolution/fully-connected: fix NULL deref in generate_fingerprint_data

### DIFF
--- a/src/operators/convolution-nchw.c
+++ b/src/operators/convolution-nchw.c
@@ -957,6 +957,13 @@ static struct fingerprint_buffers generate_fingerprint_data(
   const size_t bias_size = params->group_output_channels * params->groups;
   const size_t bytes = (kernel_size + bias_size) * element_size + XNN_ALLOCATION_ALIGNMENT * 1;
   uint8_t* buffer = xnn_allocate_simd_memory(bytes);
+  if (!buffer) {
+    xnn_log_error(
+        "Could not allocate %zu bytes when generating convolution 2D NCHW "
+        "fingerprint data",
+        bytes);
+    return (struct fingerprint_buffers){0};
+  }
   fill_fingerprint_buffer(buffer, bytes);
   return (struct fingerprint_buffers){
       .data = buffer,
@@ -1016,6 +1023,10 @@ enum xnn_status xnn_fingerprint_convolution2d_nchw(
     return context.status;
   }
   const struct fingerprint_buffers data = generate_fingerprint_data(variant, &params);
+  if (!data.data) {
+    finalize_fingerprint_context(&context);
+    return xnn_status_out_of_memory;
+  }
 
   params.kernel = data.kernel;
   params.bias = data.bias;

--- a/src/operators/convolution-nhwc.c
+++ b/src/operators/convolution-nhwc.c
@@ -1801,6 +1801,13 @@ static struct fingerprint_buffers generate_fingerprint_data(
       kernel_scale_size * sizeof(float) +
       XNN_ALLOCATION_ALIGNMENT * 3;
   uint8_t* buffer = xnn_allocate_simd_memory(bytes);
+  if (!buffer) {
+    xnn_log_error(
+        "Could not allocate %zu bytes when generating convolution 2D NHWC "
+        "fingerprint data",
+        bytes);
+    return (struct fingerprint_buffers){0};
+  }
   fill_fingerprint_buffer(buffer, bytes);
   struct fingerprint_buffers data = {
     .data = buffer,
@@ -1916,6 +1923,10 @@ enum xnn_status xnn_fingerprint_convolution2d_nhwc(
     return f_context.status;
   }
   struct fingerprint_buffers data = generate_fingerprint_data(variant, &context);
+  if (!data.data) {
+    finalize_fingerprint_context(&f_context);
+    return xnn_status_out_of_memory;
+  }
   context.kernel = data.kernel;
   context.bias = data.bias;
   context.kernel_scale = data.kernel_scale;

--- a/src/operators/fully-connected-nc.c
+++ b/src/operators/fully-connected-nc.c
@@ -1636,6 +1636,13 @@ static enum xnn_status generate_fingerprint_data(const struct fc_variant* varian
   const size_t bytes = weights_bytes + bias_bytes + kernel_scale_bytes +
                        kernel_zero_points_bytes + 4 * XNN_ALLOCATION_ALIGNMENT;
   uint8_t* buffer = xnn_allocate_simd_memory(bytes);
+  if (!buffer) {
+    xnn_log_error(
+        "Could not allocate %zu bytes when generating fully connected "
+        "fingerprint data",
+        bytes);
+    return xnn_status_out_of_memory;
+  }
   fill_fingerprint_buffer(buffer, bytes);
   context->fingerprint_data_to_release = buffer;
   context->input_channels = input_channels;


### PR DESCRIPTION
`xnn_allocate_simd_memory` can return NULL under memory pressure, but three `generate_fingerprint_data` functions passed the result directly to `fill_fingerprint_buffer` without a NULL check. `fill_fingerprint_buffer` immediately writes to the pointer (`*((uint64_t*)(data)) = ...`), so a NULL return causes a SIGSEGV.

**Affected functions:**
- `generate_fingerprint_data` in `src/operators/convolution-nchw.c` (line 959)
- `generate_fingerprint_data` in `src/operators/fully-connected-nc.c` (line 1638)
- `generate_fingerprint_data` in `src/operators/convolution-nhwc.c` (line 1803)

The fix pattern already exists in `deconvolution-nhwc.c:1287`:
```c
uint8_t* buffer = xnn_allocate_simd_memory(bytes);
if (!buffer) {
  xnn_log_error("Could not allocate %zu bytes when generating fingerprint data", bytes);
  return xnn_status_out_of_memory;
}
fill_fingerprint_buffer(buffer, bytes);
```

This PR applies the same pattern to the three affected files. For `generate_fingerprint_data` functions that return `struct fingerprint_buffers` (nchw and nhwc variants), a zero-initialized struct is returned on allocation failure and the caller propagates `xnn_status_out_of_memory`.