### PR TITLE
cvt_to_fp32: fix missing NULL checks after xnn_allocate_zero_memory in FallbackToFp32

### DIFF
--- a/src/subgraph/rewrites/cvt_to_fp32.cc
+++ b/src/subgraph/rewrites/cvt_to_fp32.cc
@@ -639,6 +639,14 @@ xnn_status FallbackToFp32(xnn_subgraph_t subgraph, int optimization_flags,
           fp32_value.to_fp32_fallback.original_data = fp32_value.data;
           fp32_value.data =
               xnn_allocate_zero_memory(fp32_value.size + XNN_EXTRA_BYTES);
+          if (fp32_value.data == nullptr) {
+            xnn_log_error(
+                "failed to allocate %zu bytes for %s fp32 fallback output "
+                "buffer",
+                fp32_value.size + XNN_EXTRA_BYTES,
+                xnn_datatype_to_string(from_dt));
+            return xnn_status_out_of_memory;
+          }
           fp32_value.flags |= XNN_VALUE_FLAG_NEEDS_CLEANUP;
         } else {
           fp32_value.allocation_type = xnn_allocation_type_workspace;
@@ -702,6 +710,14 @@ xnn_status FallbackToFp32(xnn_subgraph_t subgraph, int optimization_flags,
             // inserting a convert node.
             fp32_value.data =
                 xnn_allocate_zero_memory(fp32_value.size + XNN_EXTRA_BYTES);
+            if (fp32_value.data == nullptr) {
+              xnn_log_error(
+                  "failed to allocate %zu bytes for %s fp32 fallback static "
+                  "conversion buffer",
+                  fp32_value.size + XNN_EXTRA_BYTES,
+                  xnn_datatype_to_string(from_dt));
+              return xnn_status_out_of_memory;
+            }
             fp32_value.flags |= XNN_VALUE_FLAG_NEEDS_CLEANUP;
             fp32_value.to_fp32_fallback.original_data = value.data;
             xnn_run_unary_elementwise_nc(


### PR DESCRIPTION
Addresses VRP report https://issuetracker.google.com/issues/542866069

xnn_allocate_zero_memory wraps malloc and returns NULL on allocation failure. FallbackToFp32 called it at two sites without checking the result before use:

**External output path** (`cvt_to_fp32.cc` line 641): on OOM, `fp32_value.data` becomes NULL and is silently inserted into the subgraph. At the first inference run the conversion kernel writes to address 0 → SIGSEGV.

**Static input path** (`cvt_to_fp32.cc` line 704): on OOM, NULL is passed immediately as the `output` argument to `xnn_run_unary_elementwise_nc`, which stores it into `op->context.univector_contiguous.y`. When the kernel executes it writes to address 0 → SIGSEGV.

Both sites now check the allocation result and return `xnn_status_out_of_memory` on failure, consistent with the guard pattern used in `broadcast_kernel_scale` (deconvolution-nhwc.c line 749) and the first allocation in `compute_scale_params_qs8_qc8w` (deconvolution-nhwc.c line 610).