### PR TITLE
Fix integer overflow in qc2w/qc4w requantization scale allocation

### DIFF
--- a/src/operators/fully-connected-nc.c
+++ b/src/operators/fully-connected-nc.c
@@ -952,11 +952,19 @@ static enum xnn_status setup_scale_params_qs8(const struct fc_variant* variant,
 
 static enum xnn_status setup_scale_params_qx8_qcyw(const struct fc_variant* variant,
                                               struct fc_context* context) {
-  context->requantization_scale.f32 = xnn_allocate_simd_memory(context->output_channels * sizeof(float));
+  size_t requantization_scale_bytes = 0;
+  if (!xnn_safe_mul(context->output_channels, sizeof(float), &requantization_scale_bytes)) {
+    xnn_log_error(
+        "failed to create %s operator: requantization scale size overflows "
+        "size_t (output_channels=%zu)",
+        xnn_operator_type_to_string(context->operator_type), context->output_channels);
+    return xnn_status_unsupported_parameter;
+  }
+  context->requantization_scale.f32 = xnn_allocate_simd_memory(requantization_scale_bytes);
   context->requantization_scale_to_release = context->requantization_scale.f32;
   if (context->requantization_scale.f32 == NULL) {
     xnn_log_error("failed to allocate %zu bytes for %s operator packed weights",
-                  context->output_channels * sizeof(float),
+                  requantization_scale_bytes,
                   xnn_operator_type_to_string(context->operator_type));
     return xnn_status_out_of_memory;
   }

--- a/src/operators/fully-connected-nc.c
+++ b/src/operators/fully-connected-nc.c
@@ -1013,11 +1013,19 @@ static enum xnn_status setup_scale_params_qs8(const struct fc_variant* variant,
 
 static enum xnn_status setup_scale_params_qx8_qcyw(const struct fc_variant* variant,
                                               struct fc_context* context) {
-  context->requantization_scale.f32 = xnn_allocate_simd_memory(context->output_channels * sizeof(float));
+  size_t requantization_scale_bytes = 0;
+  if (!xnn_safe_mul(context->output_channels, sizeof(float), &requantization_scale_bytes)) {
+    xnn_log_error(
+        "failed to create %s operator: requantization scale size overflows "
+        "size_t (output_channels=%zu)",
+        xnn_operator_type_to_string(context->operator_type), context->output_channels);
+    return xnn_status_unsupported_parameter;
+  }
+  context->requantization_scale.f32 = xnn_allocate_simd_memory(requantization_scale_bytes);
   context->requantization_scale_to_release = context->requantization_scale.f32;
   if (context->requantization_scale.f32 == NULL) {
     xnn_log_error("failed to allocate %zu bytes for %s operator packed weights",
-                  context->output_channels * sizeof(float),
+                  requantization_scale_bytes,
                   xnn_operator_type_to_string(context->operator_type));
     return xnn_status_out_of_memory;
   }


### PR DESCRIPTION
setup_scale_params_qx8_qcyw computed the requantization-scale buffer size as an unguarded context-> output_channels * sizeof(float), where output_channels is a direct parameter of the public API xnn_create_fully_connected_nc_qs8_qc2w (and its qc4w/qd8/qdu8 siblings sharing this scale-params setup function). A caller supplying a large output_channels value overflows size_t, causing the allocation to wrap to a small value; the subsequent per-channel scale computation loop then reads and writes using the real, unwrapped output_channels.\n\nConfirmed via ASan (heap-buffer-overflow read and write) with output_channels = (1 << 62) + 16, which wraps the allocation to exactly 64 bytes.\n\nApplies xnn_safe_mul to the computation, consistent with the pattern already used for the main packed-weights allocation in this same file (line 264) and in convolution-nhwc.c / deconvolution-nhwc.c.