### PR TITLE
Fix integer overflow in fully-connected-nc.c bias/kernel buffer sizing

### DIFF
--- a/src/operators/fully-connected-nc.c
+++ b/src/operators/fully-connected-nc.c
@@ -1730,7 +1730,16 @@ enum xnn_status xnn_create_fully_connected_nc_f16(
   const void* bias_to_use = bias;
   void* allocated_bias = NULL;
   if (bias != NULL && (flags & XNN_FLAG_FP32_STATIC_BIASES)) {
-    allocated_bias = xnn_allocate_memory(output_channels * sizeof(xnn_float16));
+    size_t allocated_bias_size;
+    if (!xnn_safe_mul(output_channels, sizeof(xnn_float16), &allocated_bias_size)) {
+      xnn_log_error(
+          "failed to create %s operator with %zu output channels: "
+          "output_channels * sizeof(xnn_float16) overflows size_t",
+          xnn_operator_type_to_string(xnn_operator_type_fully_connected_nc_f16),
+          output_channels);
+      return xnn_status_invalid_parameter;
+    }
+    allocated_bias = xnn_allocate_memory(allocated_bias_size);
     if (allocated_bias == NULL) {
       return xnn_status_out_of_memory;
     }
@@ -1773,7 +1782,16 @@ enum xnn_status xnn_create_fully_connected_nc_pf16(
   const void* bias_to_use = bias;
   void* allocated_bias = NULL;
   if (bias != NULL && (flags & XNN_FLAG_FP32_STATIC_BIASES)) {
-    allocated_bias = xnn_allocate_memory(output_channels * sizeof(xnn_float16));
+    size_t allocated_bias_size;
+    if (!xnn_safe_mul(output_channels, sizeof(xnn_float16), &allocated_bias_size)) {
+      xnn_log_error(
+          "failed to create %s operator with %zu output channels: "
+          "output_channels * sizeof(xnn_float16) overflows size_t",
+          xnn_operator_type_to_string(xnn_operator_type_fully_connected_nc_pf16),
+          output_channels);
+      return xnn_status_invalid_parameter;
+    }
+    allocated_bias = xnn_allocate_memory(allocated_bias_size);
     if (allocated_bias == NULL) {
       return xnn_status_out_of_memory;
     }
@@ -2396,8 +2414,20 @@ enum xnn_status xnn_create_fully_connected_nc_f32_f16(
     size_t output_stride, const void* kernel, const void* bias,
     float output_min, float output_max, uint32_t flags,
     xnn_weights_cache_t weights_cache, xnn_operator_t* fully_connected_op_out) {
-  float* fp32_kernel_buffer = (float*)xnn_allocate_memory(
-      input_channels * output_channels * sizeof(float));
+  size_t fp32_kernel_elements;
+  size_t fp32_kernel_buffer_size;
+  if (!xnn_safe_mul(input_channels, output_channels, &fp32_kernel_elements) ||
+      !xnn_safe_mul(fp32_kernel_elements, sizeof(float), &fp32_kernel_buffer_size)) {
+    xnn_log_error(
+        "failed to create %s operator with %zu input channels and %zu "
+        "output channels: input_channels * output_channels * sizeof(float) "
+        "overflows size_t",
+        xnn_operator_type_to_string(xnn_operator_type_fully_connected_nc_f32),
+        input_channels, output_channels);
+    return xnn_status_invalid_parameter;
+  }
+  float* fp32_kernel_buffer =
+      (float*)xnn_allocate_memory(fp32_kernel_buffer_size);
   if (fp32_kernel_buffer == NULL) {
     return xnn_status_out_of_memory;
   }
@@ -2405,12 +2435,22 @@ enum xnn_status xnn_create_fully_connected_nc_f32_f16(
   float* fp32_bias_buffer_to_release = NULL;
   const xnn_float16* f16_kernel = (const xnn_float16*)kernel;
   const xnn_float16* f16_bias = (const xnn_float16*)bias;
-  for (size_t i = 0; i < input_channels * output_channels; ++i) {
+  for (size_t i = 0; i < fp32_kernel_elements; ++i) {
     fp32_kernel_buffer[i] = xnn_float16_to_float(f16_kernel[i]);
   }
   if (bias && !(flags & XNN_FLAG_FP32_STATIC_BIASES)) {
+    size_t fp32_bias_buffer_size;
+    if (!xnn_safe_mul(output_channels, sizeof(float), &fp32_bias_buffer_size)) {
+      xnn_log_error(
+          "failed to create %s operator with %zu output channels: "
+          "output_channels * sizeof(float) overflows size_t",
+          xnn_operator_type_to_string(xnn_operator_type_fully_connected_nc_f32),
+          output_channels);
+      xnn_release_memory(fp32_kernel_buffer);
+      return xnn_status_invalid_parameter;
+    }
     fp32_bias_buffer_to_release =
-        (float*)xnn_allocate_memory(output_channels * sizeof(float));
+        (float*)xnn_allocate_memory(fp32_bias_buffer_size);
     if (fp32_bias_buffer_to_release == NULL) {
       xnn_release_memory(fp32_kernel_buffer);
       return xnn_status_out_of_memory;
@@ -2451,8 +2491,20 @@ enum xnn_status xnn_create_fully_connected_nc_pf32_f16(
     size_t output_stride, const void* kernel, const void* bias,
     float output_min, float output_max, uint32_t flags,
     xnn_weights_cache_t weights_cache, xnn_operator_t* fully_connected_op_out) {
-  float* fp32_kernel_buffer = (float*)xnn_allocate_memory(
-      input_channels * output_channels * sizeof(float));
+  size_t fp32_kernel_elements;
+  size_t fp32_kernel_buffer_size;
+  if (!xnn_safe_mul(input_channels, output_channels, &fp32_kernel_elements) ||
+      !xnn_safe_mul(fp32_kernel_elements, sizeof(float), &fp32_kernel_buffer_size)) {
+    xnn_log_error(
+        "failed to create %s operator with %zu input channels and %zu "
+        "output channels: input_channels * output_channels * sizeof(float) "
+        "overflows size_t",
+        xnn_operator_type_to_string(xnn_operator_type_fully_connected_nc_pf32),
+        input_channels, output_channels);
+    return xnn_status_invalid_parameter;
+  }
+  float* fp32_kernel_buffer =
+      (float*)xnn_allocate_memory(fp32_kernel_buffer_size);
   if (fp32_kernel_buffer == NULL) {
     return xnn_status_out_of_memory;
   }
@@ -2460,12 +2512,22 @@ enum xnn_status xnn_create_fully_connected_nc_pf32_f16(
   float* fp32_bias_buffer_to_release = NULL;
   const xnn_float16* f16_kernel = (const xnn_float16*)kernel;
   const xnn_float16* f16_bias = (const xnn_float16*)bias;
-  for (size_t i = 0; i < input_channels * output_channels; ++i) {
+  for (size_t i = 0; i < fp32_kernel_elements; ++i) {
     fp32_kernel_buffer[i] = xnn_float16_to_float(f16_kernel[i]);
   }
   if (bias && !(flags & XNN_FLAG_FP32_STATIC_BIASES)) {
+    size_t fp32_bias_buffer_size;
+    if (!xnn_safe_mul(output_channels, sizeof(float), &fp32_bias_buffer_size)) {
+      xnn_log_error(
+          "failed to create %s operator with %zu output channels: "
+          "output_channels * sizeof(float) overflows size_t",
+          xnn_operator_type_to_string(xnn_operator_type_fully_connected_nc_pf32),
+          output_channels);
+      xnn_release_memory(fp32_kernel_buffer);
+      return xnn_status_invalid_parameter;
+    }
     fp32_bias_buffer_to_release =
-        (float*)xnn_allocate_memory(output_channels * sizeof(float));
+        (float*)xnn_allocate_memory(fp32_bias_buffer_size);
     if (fp32_bias_buffer_to_release == NULL) {
       xnn_release_memory(fp32_kernel_buffer);
       return xnn_status_out_of_memory;


### PR DESCRIPTION
## Summary

Four sibling functions in `src/operators/fully-connected-nc.c` compute an allocation size by multiplying caller-supplied `output_channels` (and, in two cases, `input_channels * output_channels`) by an element size, with no overflow check, and use the *same* unvalidated value as a write-loop bound immediately after — before any of this file's normal parameter validation (the `output_channels == 0` / stride checks in `create_fully_connected_nc`) has run:

- `xnn_create_fully_connected_nc_f16` — `output_channels * sizeof(xnn_float16)`
- `xnn_create_fully_connected_nc_pf16` — same
- `xnn_create_fully_connected_nc_f32_f16` — `input_channels * output_channels * sizeof(float)`, and `output_channels * sizeof(float)` for the bias buffer
- `xnn_create_fully_connected_nc_pf32_f16` — same

On a 32-bit `size_t` target (XNNPACK supports ARM32 and WASM32 — both real, shipping deployment targets), a channel count just above `2^31` (or `2^30` for the two-factor kernel-buffer case) wraps the multiplication to a small value. The allocation then succeeds at a tiny size while the subsequent loop still iterates the real, unwrapped channel count — a heap-buffer-overflow write. In the `f16` bias-conversion path, the same loop also reads that many elements from the caller's `bias` array, which is only sized for the real (intended) channel count — an out-of-bounds read as well.

This is a narrow, specific gap: the main packed-weights buffer allocation a few hundred lines later in this same file is already correctly guarded with `xnn_safe_mul()` (see `create_fully_connected_nc`, packed_weights_size). This PR applies that exact same, already-established pattern to the four sites above.

## Fix

Each site now computes the allocation size via `xnn_safe_mul()` first and returns `xnn_status_invalid_parameter` (consistent with this file's other validation-failure paths) if it would overflow, before doing any allocation or touching caller memory.

## Verification

- Patch applies cleanly to current `master`.
- `gcc -fsyntax-only -Wall -Wextra` clean against the real repo headers, no new warnings introduced.
- Behavioral test using the repo's real `xnn_safe_mul` (from `src/xnnpack/math.h`) against the patched logic: the previously-overflowing input is now rejected with `xnn_status_invalid_parameter` before any allocation, and a legitimate small `output_channels` still succeeds unchanged.
- Bazel build/test status: see CI on this PR — not run in the reporting environment (no working Bazel/BCR network path available there).
