### PR TITLE
fully-connected: fix NULL deref after xnn_allocate_memory in qb4w_f16_scales variants

### DIFF
--- a/src/operators/fully-connected-nc.c
+++ b/src/operators/fully-connected-nc.c
@@ -2184,6 +2184,9 @@ enum xnn_status xnn_create_fully_connected_nc_qp8_f32_qb4w_f16_scales(
       (input_channels + block_size - 1) / block_size * output_channels;
   xnn_bfloat16* bf16_scale_buffer =
       (xnn_bfloat16*)xnn_allocate_memory(num_blocks * sizeof(xnn_bfloat16));
+  if (bf16_scale_buffer == NULL) {
+    return xnn_status_out_of_memory;
+  }
   for (size_t i = 0; i < num_blocks; ++i) {
     bf16_scale_buffer[i] = xnn_bfloat16_from_float(
         xnn_float16_to_float(((const xnn_float16*)kernel_scale)[i]));
@@ -2234,6 +2237,9 @@ enum xnn_status xnn_create_fully_connected_nc_qd8_f32_qb4w_f16_scales(
       (input_channels + block_size - 1) / block_size * output_channels;
   xnn_bfloat16* bf16_scale_buffer =
       (xnn_bfloat16*)xnn_allocate_memory(num_blocks * sizeof(xnn_bfloat16));
+  if (bf16_scale_buffer == NULL) {
+    return xnn_status_out_of_memory;
+  }
   for (size_t i = 0; i < num_blocks; ++i) {
     bf16_scale_buffer[i] =
         xnn_bfloat16_from_float(xnn_float16_to_float(kernel_scale[i]));
@@ -2283,6 +2289,9 @@ enum xnn_status xnn_create_fully_connected_nc_qdu8_f32_qb4w_f16_scales(
       (input_channels + block_size - 1) / block_size * output_channels;
   xnn_bfloat16* bf16_scale_buffer =
       (xnn_bfloat16*)xnn_allocate_memory(num_blocks * sizeof(xnn_bfloat16));
+  if (bf16_scale_buffer == NULL) {
+    return xnn_status_out_of_memory;
+  }
   for (size_t i = 0; i < num_blocks; ++i) {
     bf16_scale_buffer[i] =
         xnn_bfloat16_from_float(xnn_float16_to_float(kernel_scale[i]));


### PR DESCRIPTION
Addresses VRP report https://issuetracker.google.com/issues/543699689

Three \`xnn_create_fully_connected_nc_*_qb4w_f16_scales\` functions allocate a \`bf16_scale_buffer\` with \`xnn_allocate_memory\` and immediately write into it through a loop with no NULL check between the allocation and the write. \`xnn_allocate_memory\` is a \`malloc\` wrapper that returns NULL on OOM; when it does, the loop writes to address 0x0 on the first iteration → SIGSEGV.

**Affected functions** (all in \`src/operators/fully-connected-nc.c\`):
- \`xnn_create_fully_connected_nc_qp8_f32_qb4w_f16_scales\` (~line 2185)
- \`xnn_create_fully_connected_nc_qd8_f32_qb4w_f16_scales\` (~line 2235)
- \`xnn_create_fully_connected_nc_qdu8_f32_qb4w_f16_scales\` (~line 2284)

The sibling function \`xnn_create_fully_connected_nc_qd8_f16_qb4w_f16_scales\` already has the correct guard at line ~1954; this PR adds the same check to the three f32-output variants that were added later without it.

**Fix:** add `if (bf16_scale_buffer == NULL) { return xnn_status_out_of_memory; }` after each allocation, consistent with the existing pattern in the guarded sibling.