### PR TITLE
convolution/deconvolution: fix NULL deref in per-batch zero_buffers allocation loop

### DIFF
--- a/src/operators/convolution-nhwc.c
+++ b/src/operators/convolution-nhwc.c
@@ -3402,6 +3402,12 @@ enum xnn_status reshape_convolution2d_nhwc_qx8_f16_qc8w(
     for (size_t i = 1; i < batch_size; ++i) {
       convolution_op->convolution_op->zero_buffers[i] =
           xnn_allocate_simd_memory(convolution_op->convolution_op->zero_size);
+      if (convolution_op->convolution_op->zero_buffers[i] == NULL) {
+        xnn_log_error(
+            "failed to allocate %zu bytes for zero buffer for batch %zu",
+            convolution_op->convolution_op->zero_size, i);
+        return xnn_status_out_of_memory;
+      }
     }
     convolution_op->convolution_op->valid_batch_size = batch_size;
   }
@@ -3464,6 +3470,12 @@ enum xnn_status reshape_convolution2d_nhwc_qx8_f32_qc8w(
     for (size_t i = 1; i < batch_size; ++i) {
       convolution_op->convolution_op->zero_buffers[i] =
           xnn_allocate_simd_memory(convolution_op->convolution_op->zero_size);
+      if (convolution_op->convolution_op->zero_buffers[i] == NULL) {
+        xnn_log_error(
+            "failed to allocate %zu bytes for zero buffer for batch %zu",
+            convolution_op->convolution_op->zero_size, i);
+        return xnn_status_out_of_memory;
+      }
     }
     convolution_op->convolution_op->valid_batch_size = batch_size;
   }

--- a/src/operators/deconvolution-nhwc.c
+++ b/src/operators/deconvolution-nhwc.c
@@ -2532,6 +2532,12 @@ enum xnn_status reshape_deconvolution2d_nhwc_qx8_f32_qc8w(
     for (size_t i = 1; i < batch_size; ++i) {
       deconvolution_op->convolution_op->zero_buffers[i] =
           xnn_allocate_simd_memory(deconvolution_op->convolution_op->zero_size);
+      if (deconvolution_op->convolution_op->zero_buffers[i] == NULL) {
+        xnn_log_error(
+            "failed to allocate %zu bytes for zero buffer for batch %zu",
+            deconvolution_op->convolution_op->zero_size, i);
+        return xnn_status_out_of_memory;
+      }
     }
     deconvolution_op->convolution_op->valid_batch_size = batch_size;
   }


### PR DESCRIPTION
`xnn_allocate_simd_memory` is a `posix_memalign` / `_mm_malloc` wrapper that returns `NULL` on OOM. In three reshape functions the return value was not checked, so `NULL` was silently stored in `zero_buffers[i]`. At the next inference call `xnn_compute_dq_zero_buffer_igemm` passes `zero_buffers[batch_index]` directly to `memset`, producing a write to address 0x0 and a reliable SIGSEGV.

**Affected functions**
- `reshape_convolution2d_nhwc_qx8_f16_qc8w` (`src/operators/convolution-nhwc.c`)
- `reshape_convolution2d_nhwc_qx8_f32_qc8w` (`src/operators/convolution-nhwc.c`)
- `reshape_deconvolution2d_nhwc_qx8_f32_qc8w` (`src/operators/deconvolution-nhwc.c`)

**Fix**: add a `NULL` guard after `xnn_allocate_simd_memory` inside each per-batch loop and return `xnn_status_out_of_memory` immediately so the error propagates to the caller before inference begins.

**Relation to #10928**: PR #10928 fixes the `xnn_reallocate_memory` NULL deref when resizing the `zero_buffers` pointer array itself. This PR fixes the separate NULL deref inside the subsequent per-batch element allocation loop, which is not addressed by #10928.