### PR TITLE
packing: fix NULL deref in KleidiAI SME weight packing functions

### DIFF
--- a/src/reference/packing.cc
+++ b/src/reference/packing.cc
@@ -2683,6 +2683,15 @@ void xnn_pack_kai_qs8_qc8w_weights_and_biases_sme(
     // Transpose the weights until the transpose packing function is ready.
     int8_t* tmp_data =
         (int8_t*)malloc(input_channels * output_channels * sizeof(int8_t));
+    if (tmp_data == NULL) {
+      xnn_log_error(
+          "failed to allocate %zu bytes for KleidiAI SME weight transpose buffer",
+          input_channels * output_channels * sizeof(int8_t));
+      if (free_accumulator_init) {
+        free((void*)accumulator_init);
+      }
+      return;
+    }
     transpose_weights_x8((const int8_t*)weights, tmp_data, output_channels,
                          input_channels);
     kai_run_rhs_pack_kxn_qsi8cxp2vlx4sb_qs8cx_f32_i32_sme(
@@ -3051,6 +3060,15 @@ void xnn_pack_kai_f16_conv_goki_w_sme(size_t g, size_t nc, size_t ks,
 
   uint16_t* tmp_data =
       (uint16_t*)xnn_allocate_memory(nc * ks * kc * sizeof(uint16_t));
+  if (tmp_data == NULL) {
+    xnn_log_error(
+        "failed to allocate %zu bytes for KleidiAI SME weight transpose buffer",
+        nc * ks * kc * sizeof(uint16_t));
+    if (tmp_bias != NULL) {
+      xnn_release_memory(tmp_bias);
+    }
+    return;
+  }
   const size_t rhs_row_stride = nc * sizeof(uint16_t);
   const size_t packed_rhs_size =
       kai_get_rhs_packed_size_rhs_imatmul_pack_kxn_x16p2vlx2b_x16_x16_sme(
@@ -3105,6 +3123,15 @@ void xnn_pack_kai_qs8_conv_goki_w_sme(
 
   int8_t* tmp_data =
       (int8_t*)xnn_allocate_memory(nc * ks * kc * sizeof(int8_t));
+  if (tmp_data == NULL) {
+    xnn_log_error(
+        "failed to allocate %zu bytes for KleidiAI SME weight transpose buffer",
+        nc * ks * kc * sizeof(int8_t));
+    if (tmp_bias != NULL) {
+      xnn_release_memory(tmp_bias);
+    }
+    return;
+  }
   const size_t rhs_row_stride = nc * sizeof(int8_t);
   const size_t packed_rhs_size =
       kai_get_rhs_packed_size_rhs_imatmul_pack_kxn_qsi8cxp2vlx4sb_qs8cx_f32_i32_sme(
@@ -3161,6 +3188,13 @@ void xnn_pack_kai_pf32_conv_goki_w_sme(
   }
 
   float* tmp_data = (float*) malloc(nc * ks * kc * sizeof(float));
+  if (tmp_data == NULL) {
+    xnn_log_error(
+        "failed to allocate %zu bytes for KleidiAI SME weight transpose buffer",
+        nc * ks * kc * sizeof(float));
+    free(tmp_bias);
+    return;
+  }
   const size_t rhs_row_stride = nc * sizeof(float);
   const size_t packed_rhs_size = kai_get_rhs_packed_size_rhs_imatmul_pack_kxn_x32p2vlx1b_x32_x32_sme(nc, ks, kc);
 

--- a/src/reference/packing.cc
+++ b/src/reference/packing.cc
@@ -2690,6 +2690,7 @@ void xnn_pack_kai_qs8_qc8w_weights_and_biases_sme(
       if (free_accumulator_init) {
         free((void*)accumulator_init);
       }
+      assert(false);
       return;
     }
     transpose_weights_x8((const int8_t*)weights, tmp_data, output_channels,
@@ -3067,6 +3068,7 @@ void xnn_pack_kai_f16_conv_goki_w_sme(size_t g, size_t nc, size_t ks,
     if (tmp_bias != NULL) {
       xnn_release_memory(tmp_bias);
     }
+    assert(false);
     return;
   }
   const size_t rhs_row_stride = nc * sizeof(uint16_t);
@@ -3130,6 +3132,7 @@ void xnn_pack_kai_qs8_conv_goki_w_sme(
     if (tmp_bias != NULL) {
       xnn_release_memory(tmp_bias);
     }
+    assert(false);
     return;
   }
   const size_t rhs_row_stride = nc * sizeof(int8_t);
@@ -3193,6 +3196,7 @@ void xnn_pack_kai_pf32_conv_goki_w_sme(
         "failed to allocate %zu bytes for KleidiAI SME weight transpose buffer",
         nc * ks * kc * sizeof(float));
     free(tmp_bias);
+    assert(false);
     return;
   }
   const size_t rhs_row_stride = nc * sizeof(float);


### PR DESCRIPTION
`xnn_allocate_memory` and `malloc` return `NULL` on OOM. Four KleidiAI SME weight packing functions allocated a temporary transpose buffer (`tmp_data`) without checking the return value, then immediately passed it to `transpose_weights_x{8,16}` which writes to `out[0]` at address 0x0 on the first loop iteration → SIGSEGV.

**Affected functions**
- `xnn_pack_kai_f16_conv_goki_w_sme` - `tmp_data = xnn_allocate_memory(nc * ks * kc * 2)`
- `xnn_pack_kai_qs8_conv_goki_w_sme` - `tmp_data = xnn_allocate_memory(nc * ks * kc * 1)`
- `xnn_pack_kai_pf32_conv_goki_w_sme` - `tmp_data = malloc(nc * ks * kc * 4)`
- `xnn_pack_kai_qs8_qc8w_weights_and_biases_sme` - `tmp_data = malloc(input_channels * output_channels)`

All four are registered as `pack_igemm_goki` or `pack_weights_and_biases` in `src/configs/gemm-config.c` for ARM SME and SME2 hardware paths.

**Fix**: add a `NULL` guard after each `tmp_data` allocation. On OOM, log the error, release any already-allocated ancillary buffer (`tmp_bias` / `accumulator_init`), and return early before the transpose write occurs.