### PR TITLE
Add KleidiAI Advanced SIMD PF16 6x32 GEMM kernel

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -527,6 +527,9 @@ if (current_cpu == "arm64") {
       ":microkernel_defs",
       ":microkernel_headers",
     ]
+    if (xnnpack_enable_arm_kleidiai) {
+      deps += [ "//third_party/kleidiai" ]
+    }
     sources = ALL_NEONFP16_MICROKERNEL_SRCS
     sources += ALL_NEONFP16ARITH_AARCH64_MICROKERNEL_SRCS
     sources += ALL_NEONFP16ARITH_MICROKERNEL_SRCS

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -517,6 +517,9 @@ if (current_cpu == "arm64") {
       ":microkernel_defs",
       ":microkernel_headers",
     ]
+    if (xnnpack_enable_arm_kleidiai) {
+      deps += [ "//third_party/kleidiai" ]
+    }
     sources = ALL_NEONFP16_MICROKERNEL_SRCS
     sources += ALL_NEONFP16ARITH_AARCH64_MICROKERNEL_SRCS
     sources += ALL_NEONFP16ARITH_MICROKERNEL_SRCS

--- a/DEPS
+++ b/DEPS
@@ -111,7 +111,7 @@ deps = {
     'url': Var('chromium_url') + '/chromium/src/third_party/abseil-cpp' + '@' + 'df548c50b2cda67158364d3d23c63043881b391d',
   },
   'third_party/kleidiai/src': {
-    'url': 'https://gitlab.arm.com/kleidi/kleidiai@v1.25.0',
+    'url': 'https://github.com/ARM-software/kleidiai.git@v1.28.0',
     'condition': 'checkout_kleidiai'
   },
   'third_party/libc++/src':

--- a/DEPS
+++ b/DEPS
@@ -111,7 +111,7 @@ deps = {
     'url': Var('chromium_url') + '/chromium/src/third_party/abseil-cpp' + '@' + '5c3e051186c88b1e7ee66750eda59096a51abc73',
   },
   'third_party/kleidiai/src': {
-    'url': 'https://gitlab.arm.com/kleidi/kleidiai@v1.25.0',
+    'url': 'https://github.com/ARM-software/kleidiai.git@v1.28.0',
     'condition': 'checkout_kleidiai'
   },
   'third_party/libc++/src':

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -101,10 +101,10 @@ http_archive(
 # KleidiAI library, used for ARM microkernels.
 http_archive(
     name = "KleidiAI",
-    sha256 = "6b3e6630be314a28f6ea28fed14f7109b0b7c472f1e06d2dba17ffccda3b9466",
-    strip_prefix = "kleidiai-dce86647385ab2638aa5abebcb652f3e4271970d",
+    sha256 = "8c2efc083e5d583c365b5c45b63b217b930ea8fcc33902dddaff55915231ab57",
+    strip_prefix = "kleidiai-1231da54581a9ef8c2e608bc0e68cbef6119d1ff",
     urls = [
-        "https://gitlab.arm.com/kleidi/kleidiai/-/archive/dce86647385ab2638aa5abebcb652f3e4271970d/kleidiai-dce86647385ab2638aa5abebcb652f3e4271970d.zip",
+        "https://github.com/ARM-software/kleidiai/archive/1231da54581a9ef8c2e608bc0e68cbef6119d1ff.zip",
     ],
 )
 # LINT.ThenChange(cmake/DownloadKleidiAI.cmake)

--- a/bench/gemm-benchmark.cc
+++ b/bench/gemm-benchmark.cc
@@ -1475,7 +1475,7 @@ void GEMMBenchmark(benchmark::State& state,
 }
 #endif //   XNN_ENABLE_KLEIDIAI && (XNN_ENABLE_ARM_SME2 || XNN_ENABLE_ARM_SME)
 
-#if XNN_ENABLE_KLEIDIAI && (XNN_ENABLE_ARM_SME2 || XNN_ENABLE_ARM_SME)
+#if XNN_ENABLE_KLEIDIAI
 void GEMMBenchmark(benchmark::State& state,
                    xnn_pf16_gemm_minmax_ukernel_fn gemm,
                    xnn_init_f16_minmax_params_fn init_minmax_params,
@@ -1523,14 +1523,24 @@ void GEMMBenchmark(benchmark::State& state,
       packed_w_size * num_buffers, /*extra_bytes=*/{0}, "w");
 
   // Pack the left-hand operand.
+  xnn_pack_lh_ukernel_fn pack_lh = nullptr;
+  xnn_pack_lh_size_fn packed_lh_size = nullptr;
+  xnn_pack_lh_offset_fn packed_lh_offset = nullptr;
+#if XNN_ENABLE_ARM_SME2 || XNN_ENABLE_ARM_SME
+  if (arch_flags & (xnn_arch_arm_sme2 | xnn_arch_arm_sme)) {
+    pack_lh = (xnn_pack_lh_ukernel_fn)xnn_x16_pack_lh_ukernel__neonsme;
+    packed_lh_size = xnn_x16_pack_lh_size__neonsme;
+    packed_lh_offset = xnn_x16_pack_lh_offset__neonsme;
+  }
+#endif
   const size_t input_packed_size =
-      xnn_x16_pack_lh_size__neonsme(mc, kc, mr_packed, kr, sr);
+      pack_lh == nullptr ? 0 : packed_lh_size(mc, kc, mr_packed, kr, sr);
   xnnpack::Buffer<uint8_t, XNN_ALLOCATION_ALIGNMENT> input_packed(
       input_packed_size, /*extra_bytes=*/{0}, "input_packed");
-  xnn_x16_pack_lh_ukernel__neonsme(mc, kc, mr_packed, kr, sr,
-                                    /*m_idx_start=*/0, a.data(),
-                                    /*lhs_stride=*/kc * sizeof(xnn_float16),
-                                    input_packed.data());
+  if (pack_lh != nullptr) {
+    pack_lh(mc, kc, mr_packed, kr, sr, /*m_idx_start=*/0, a.data(),
+            /*lhs_stride=*/kc * sizeof(xnn_float16), input_packed.data());
+  }
 
   // RHS packing
   pack_weights(/*flags=*/0, &gemm_config, kc, nc,
@@ -1567,9 +1577,12 @@ void GEMMBenchmark(benchmark::State& state,
 
     for (uint32_t m = 0; m < mc; m += mr) {
       const uint32_t mb = min(mc - m, mr);
-      gemm(mb, nc, kc * sizeof(xnn_float16),
-            input_packed.data() +
-                xnn_x16_pack_lh_offset__neonsme(m, kc, mr_packed, kr, sr),
+      const void* input =
+          pack_lh == nullptr
+              ? static_cast<const void*>(a.data() + m * kc)
+              : input_packed.data() +
+                    packed_lh_offset(m, kc, mr_packed, kr, sr);
+      gemm(mb, nc, kc * sizeof(xnn_float16), input,
             w.data() + packed_w_size * buffer_index,
             &c[c_elements * buffer_index], nc * sizeof(xnn_float16),
             sizeof(xnn_float16), &minmax_params);
@@ -1585,6 +1598,9 @@ void GEMMBenchmark(benchmark::State& state,
       static_cast<uint64_t>(state.iterations()) * 2 * mc * nc * kc,
       benchmark::Counter::kIsRate);
 }
+#endif  // XNN_ENABLE_KLEIDIAI
+
+#if XNN_ENABLE_KLEIDIAI && (XNN_ENABLE_ARM_SME2 || XNN_ENABLE_ARM_SME)
 
 void GEMMBenchmark(benchmark::State& state,
                    xnn_pqs8_qc8w_gemm_minmax_ukernel_fn gemm,

--- a/bench/pf16-gemm-minmax.cc
+++ b/bench/pf16-gemm-minmax.cc
@@ -26,6 +26,24 @@ namespace {
 
 
 
+#if XNN_ENABLE_ARM_FP16_VECTOR && XNN_ARCH_ARM64
+  #if XNN_ENABLE_KLEIDIAI
+  static void pf16_gemm_minmax_ukernel_6x32__kai_aarch64_neonfp16arith(benchmark::State& state) {
+    GEMMBenchmark(state,
+      xnn_pf16_gemm_minmax_ukernel_6x32__kai_aarch64_neonfp16arith,
+      xnn_init_f16_minmax_scalar_params,
+      xnn_pack_kai_f16_6x32_weights_and_biases,
+      xnn_packed_stride_kai_f16_6x32_weights_and_biases,
+      /*mr=*/6, /*nr=*/32, /*kr=*/1, /*sr=*/1,
+      /*mr_packed=*/6,
+      /*arch_flags=*/xnn_arch_arm_neon_fp16_arith);
+  }
+
+  BENCHMARK_GEMM(pf16_gemm_minmax_ukernel_6x32__kai_aarch64_neonfp16arith)
+  #endif  // XNN_ENABLE_KLEIDIAI
+#endif  // XNN_ENABLE_ARM_FP16_VECTOR && XNN_ARCH_ARM64
+
+
 #if XNN_ENABLE_ARM_SME2 && XNN_ARCH_ARM64
   #if XNN_ENABLE_KLEIDIAI
   static void pf16_gemm_minmax_ukernel_1x32c2__neonsme2(benchmark::State& state) {

--- a/build_params.bzl
+++ b/build_params.bzl
@@ -351,6 +351,9 @@ XNNPACK_PARAMS_FOR_ARCH = {
     "neonfp16arith_aarch64": _create_params(
         cond = "//:arm_aarch64_fp16_vector_enabled",
         copts = ["-march=armv8.2-a+fp16"],
+        extra_deps = xnnpack_if_kleidiai_enabled([
+            "@KleidiAI//kai/ukernels/matmul:matmul",
+        ]),
     ),
     "neonbf16": _create_params(
         cond = "//:arm_bf16_enabled",

--- a/cmake/DownloadKleidiAI.cmake
+++ b/cmake/DownloadKleidiAI.cmake
@@ -18,8 +18,8 @@ ENDIF()
 # LINT.IfChange
 INCLUDE(ExternalProject)
 ExternalProject_Add(kleidiai
-  URL https://gitlab.arm.com/kleidi/kleidiai/-/archive/dce86647385ab2638aa5abebcb652f3e4271970d/kleidiai-dce86647385ab2638aa5abebcb652f3e4271970d.zip
-  URL_HASH SHA256=6b3e6630be314a28f6ea28fed14f7109b0b7c472f1e06d2dba17ffccda3b9466
+  URL https://github.com/ARM-software/kleidiai/archive/1231da54581a9ef8c2e608bc0e68cbef6119d1ff.zip
+  URL_HASH SHA256=8c2efc083e5d583c365b5c45b63b217b930ea8fcc33902dddaff55915231ab57
   SOURCE_DIR "${CMAKE_BINARY_DIR}/kleidiai-source"
   BINARY_DIR "${CMAKE_BINARY_DIR}/kleidiai"
   CONFIGURE_COMMAND ""

--- a/cmake/gen/neonfp16arith_aarch64_microkernels.cmake
+++ b/cmake/gen/neonfp16arith_aarch64_microkernels.cmake
@@ -13,7 +13,8 @@ SET(PROD_NEONFP16ARITH_AARCH64_MICROKERNEL_SRCS
   src/f16-vbinary/gen/f16-vdiv-aarch64-neonfp16arith-u8.c
   src/f16-vbinary/gen/f16-vdivc-aarch64-neonfp16arith-u8.c
   src/f16-vbinary/gen/f16-vrdivc-aarch64-neonfp16arith-u8.c
-  src/f16-vsqrt/gen/f16-vsqrt-aarch64-neonfp16arith-sqrt-u8.c)
+  src/f16-vsqrt/gen/f16-vsqrt-aarch64-neonfp16arith-sqrt-u8.c
+  src/pf16-gemm/pf16-gemm-6x32-minmax-aarch64-neonfp16arith.c)
 
 SET(NON_PROD_NEONFP16ARITH_AARCH64_MICROKERNEL_SRCS
   src/f16-vbinary/gen/f16-vdiv-aarch64-neonfp16arith-u16.c

--- a/gen/neonfp16arith_aarch64_microkernels.bzl
+++ b/gen/neonfp16arith_aarch64_microkernels.bzl
@@ -10,6 +10,7 @@ PROD_NEONFP16ARITH_AARCH64_MICROKERNEL_SRCS = [
     "src/f16-vbinary/gen/f16-vdivc-aarch64-neonfp16arith-u8.c",
     "src/f16-vbinary/gen/f16-vrdivc-aarch64-neonfp16arith-u8.c",
     "src/f16-vsqrt/gen/f16-vsqrt-aarch64-neonfp16arith-sqrt-u8.c",
+    "src/pf16-gemm/pf16-gemm-6x32-minmax-aarch64-neonfp16arith.c",
 ]
 
 NON_PROD_NEONFP16ARITH_AARCH64_MICROKERNEL_SRCS = [

--- a/src/configs/gemm-config.c
+++ b/src/configs/gemm-config.c
@@ -392,7 +392,8 @@ static void init_pf16_gemm_config(void) {
   const struct xnn_hardware_config* hardware_config =
   xnn_init_hardware_config();
   assert(hardware_config != NULL);
-if ((hardware_config->arch_flags & xnn_arch_arm_sme2)) {
+if (XNN_ENABLE_ARM_SME2 &&
+    (hardware_config->arch_flags & xnn_arch_arm_sme2)) {
 #if XNN_ENABLE_ARM_SME2
     const size_t mr = xnn_pf16_gemm_minmax_ukernel_32x32c2__neonsme2_get_mr();
     size_t nr = xnn_pf16_gemm_minmax_ukernel_32x32c2__neonsme2_get_nr();
@@ -414,7 +415,8 @@ if ((hardware_config->arch_flags & xnn_arch_arm_sme2)) {
     pf16_gemm_config.nr = nr < nstep_min ? nstep_min : nr;
     pf16_gemm_config.log2_kr = 1;
 #endif // XNN_ENABLE_ARM_SME2
-  } else if ((hardware_config->arch_flags & xnn_arch_arm_sme)) {
+  } else if (XNN_ENABLE_ARM_SME &&
+             (hardware_config->arch_flags & xnn_arch_arm_sme)) {
 #if XNN_ENABLE_ARM_SME
     const size_t mr = xnn_pf16_gemm_minmax_ukernel_32x32c2__neonsme_get_mr();
     size_t nr = xnn_pf16_gemm_minmax_ukernel_32x32c2__neonsme_get_nr();
@@ -438,7 +440,33 @@ if ((hardware_config->arch_flags & xnn_arch_arm_sme2)) {
     pf16_gemm_config.nr = nr < nstep_min ? nstep_min : nr;
     pf16_gemm_config.log2_kr = 1;
 #endif // XNN_ENABLE_ARM_SME
-  }else {
+  } else if (XNN_ENABLE_ARM_FP16_VECTOR &&
+             (hardware_config->arch_flags & xnn_arch_arm_neon_fp16_arith)) {
+#if XNN_ENABLE_ARM_FP16_VECTOR
+    const size_t mr = 6;
+    const size_t nr = 32;
+    pf16_gemm_config.arch = xnn_arch_arm_neon_fp16_arith;
+    pf16_gemm_config.minmax.gemm[XNN_MR_TO_INDEX(mr)] =
+        XNN_INIT_HMP_GEMM_UKERNEL(
+            xnn_pf16_gemm_minmax_ukernel_6x32__kai_aarch64_neonfp16arith);
+    for (size_t i = 0; i < XNN_MAX_UARCH_TYPES; i++) {
+      if (hardware_config->uarch[i] == xnn_uarch_cortex_a55) {
+        pf16_gemm_config.minmax.gemm[XNN_MR_TO_INDEX(mr)].function[i] =
+            XNN_INIT_GEMM_UKERNEL(
+                xnn_pf16_gemm_minmax_ukernel_6x32__kai_aarch64_neonfp16arith_cortex_a55);
+      }
+    }
+    pf16_gemm_config.init.f16 = xnn_init_f16_minmax_scalar_params;
+    pf16_gemm_config.pack_weights_and_biases =
+        xnn_pack_kai_f16_6x32_weights_and_biases;
+    pf16_gemm_config.packed_stride_weights_and_biases =
+        xnn_packed_stride_kai_f16_6x32_weights_and_biases;
+    pf16_gemm_config.mr = mr;
+    pf16_gemm_config.mr_packed = mr;
+    pf16_gemm_config.nr = nr;
+    pf16_gemm_config.log2_kr = 0;
+#endif  // XNN_ENABLE_ARM_FP16_VECTOR
+  } else {
     /* no action */
   }
   assert(pf16_gemm_config.mr <= XNN_MAX_MR);

--- a/src/configs/pack-lh-config.c
+++ b/src/configs/pack-lh-config.c
@@ -5,6 +5,7 @@
 
 #include <assert.h>
 #include <stddef.h>
+#include <string.h>
 
 #include "src/xnnpack/common.h"
 #include "src/xnnpack/config-types.h"
@@ -30,6 +31,32 @@ XNN_INIT_ONCE_GUARD(x32_pack_lh);
 XNN_INIT_ONCE_GUARD(x32_igemm_pack_lh);
 XNN_INIT_ONCE_GUARD(x8_igemm_pack_lh);
 XNN_INIT_ONCE_GUARD(x16_igemm_pack_lh);
+
+#if XNN_ARCH_ARM64 && XNN_ENABLE_KLEIDIAI
+static void x16_pack_lh_direct(
+    size_t m, size_t k, size_t unused_mr, size_t unused_kr, size_t unused_sr,
+    size_t unused_m_idx_start, const void* lhs, size_t lhs_stride,
+    void* lhs_packed) {
+  (void)unused_mr;
+  (void)unused_kr;
+  (void)unused_sr;
+  (void)unused_m_idx_start;
+  const size_t row_size = k * sizeof(xnn_float16);
+  for (size_t row = 0; row < m; row++) {
+    memcpy((void*)((uintptr_t)lhs_packed + row * row_size),
+           (const void*)((uintptr_t)lhs + row * lhs_stride), row_size);
+  }
+}
+
+static size_t x16_pack_lh_direct_size(
+    size_t m, size_t k, size_t unused_mr, size_t unused_kr,
+    size_t unused_sr) {
+  (void)unused_mr;
+  (void)unused_kr;
+  (void)unused_sr;
+  return m * k * sizeof(xnn_float16);
+}
+#endif  // XNN_ARCH_ARM64 && XNN_ENABLE_KLEIDIAI
 
 static void init_qp8_pack_lh_config(void) {
 #if XNN_ARCH_ARM64 && XNN_ENABLE_KLEIDIAI
@@ -139,6 +166,9 @@ static void init_x16_pack_lh_config(void) {
   assert(hardware_config != NULL);
   (void)hardware_config;
 #if XNN_ARCH_ARM64 && XNN_ENABLE_KLEIDIAI
+  x16_pack_lh_config.pack_lh_fn = x16_pack_lh_direct;
+  x16_pack_lh_config.size_fn = x16_pack_lh_direct_size;
+  x16_pack_lh_config.offset_fn = x16_pack_lh_direct_size;
 #if XNN_ENABLE_ARM_SME
   if ((hardware_config->arch_flags & xnn_arch_arm_sme)) {
     x16_pack_lh_config.pack_lh_fn =

--- a/src/pf16-gemm/pf16-gemm-6x32-minmax-aarch64-neonfp16arith.c
+++ b/src/pf16-gemm/pf16-gemm-6x32-minmax-aarch64-neonfp16arith.c
@@ -1,0 +1,71 @@
+// Copyright 2026 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+#include <stddef.h>
+
+#include "src/xnnpack/math.h"
+#include "src/xnnpack/microparams.h"
+
+#if XNN_ENABLE_KLEIDIAI
+#include "kai/ukernels/matmul/matmul_clamp_f16_f16_f16p/kai_matmul_clamp_f16_f16_f16p32x1b_6x32_neon_mla.h"
+#include "kai/ukernels/matmul/matmul_clamp_f16_f16_f16p/kai_matmul_clamp_f16_f16_f16p32x1b_6x32_neon_mla_cortexa55.h"
+#endif  // XNN_ENABLE_KLEIDIAI
+
+void xnn_pf16_gemm_minmax_ukernel_6x32__kai_aarch64_neonfp16arith(
+    size_t m, size_t n, size_t k, const void* lhs_packed,
+    const void* rhs_packed, void* dst, size_t dst_stride_row,
+    size_t dst_stride_col,
+    const struct xnn_f16_minmax_params* minmax_params) {
+#if XNN_ENABLE_KLEIDIAI
+  kai_run_matmul_clamp_f16_f16_f16p32x1b_6x32_neon_mla(
+      m, n, k / sizeof(xnn_float16), lhs_packed,
+      /*lhs_stride=*/k, rhs_packed, dst, dst_stride_row, dst_stride_col,
+      xnn_float16_to_float(minmax_params->scalar.min),
+      xnn_float16_to_float(minmax_params->scalar.max));
+#else
+  (void)m;
+  (void)n;
+  (void)k;
+  (void)lhs_packed;
+  (void)rhs_packed;
+  (void)dst;
+  (void)dst_stride_row;
+  (void)dst_stride_col;
+  (void)minmax_params;
+  assert(
+      "Calling KleidiAI Adv SIMD F16 6x32 wrapper, but XNNPACK was compiled "
+      "without `XNN_ENABLE_KLEIDIAI`." &&
+      0);
+#endif  // XNN_ENABLE_KLEIDIAI
+}
+
+void xnn_pf16_gemm_minmax_ukernel_6x32__kai_aarch64_neonfp16arith_cortex_a55(
+    size_t m, size_t n, size_t k, const void* lhs_packed,
+    const void* rhs_packed, void* dst, size_t dst_stride_row,
+    size_t dst_stride_col,
+    const struct xnn_f16_minmax_params* minmax_params) {
+#if XNN_ENABLE_KLEIDIAI
+  kai_run_matmul_clamp_f16_f16_f16p32x1b_6x32_neon_mla_cortexa55(
+      m, n, k / sizeof(xnn_float16), lhs_packed,
+      /*lhs_stride=*/k, rhs_packed, dst, dst_stride_row, dst_stride_col,
+      xnn_float16_to_float(minmax_params->scalar.min),
+      xnn_float16_to_float(minmax_params->scalar.max));
+#else
+  (void)m;
+  (void)n;
+  (void)k;
+  (void)lhs_packed;
+  (void)rhs_packed;
+  (void)dst;
+  (void)dst_stride_row;
+  (void)dst_stride_col;
+  (void)minmax_params;
+  assert(
+      "Calling KleidiAI Adv SIMD F16 6x32 Arm(R) Cortex(TM)-A55 wrapper, but XNNPACK was "
+      "compiled without `XNN_ENABLE_KLEIDIAI`." &&
+      0);
+#endif  // XNN_ENABLE_KLEIDIAI
+}

--- a/src/reference/packing.cc
+++ b/src/reference/packing.cc
@@ -33,12 +33,14 @@
 #include "kai/ukernels/matmul/pack/kai_rhs_pack_kxn_qsi8cxp2vlx4sb_qs8cx_f32_i32_sme.h"
 #include "kai/ukernels/matmul/pack/kai_rhs_pack_kxn_qsi8cxp_qsi8cx_neon.h"
 #include "kai/ukernels/matmul/pack/kai_rhs_pack_kxn_x16p2vlx2b_x16_x16_sme.h"
+#include "kai/ukernels/matmul/pack/kai_rhs_pack_kxn_x16p32x1b_x16_x16_neon.h"
 #include "kai/ukernels/matmul/pack/kai_rhs_pack_nxk_f32p2vlx1biasf32_f32_f32_sme.h"
 #include "kai/ukernels/matmul/pack/kai_rhs_pack_nxk_qsi4c32p_qsu4c32s1s0.h"
 #include "kai/ukernels/matmul/pack/kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0.h"
 #include "kai/ukernels/matmul/pack/kai_rhs_pack_nxk_qsi4cxps1s0_qsu4cxs1s0_neon.h"
 #include "kai/ukernels/matmul/pack/kai_rhs_pack_nxk_qsi8cxp_qsi8cx_neon.h"
 #include "kai/ukernels/matmul/pack/kai_rhs_pack_nxk_x16p2vlx2b_x16_x16_sme.h"
+#include "kai/ukernels/matmul/pack/kai_rhs_pack_nxk_x16p32x1bx16_x16_x16_neon.h"
 #include "src/xnnpack/allocator.h"
 #endif  // XNN_ENABLE_KLEIDIAI
 
@@ -2850,6 +2852,87 @@ void xnn_pack_kai_f16_weights_and_biases(
           free_accumulator_init
               ? accumulator_init
               : (const float*)(accumulator_init) + group * output_channels,
+          /*scale=*/NULL,
+          /*rhs_packed=*/
+          (void*)((uintptr_t)packed_weights_ptr +
+                  group * packed_weights_group_stride),
+          /*extra_bytes=*/0, /*params=*/NULL);
+    }
+  }
+  if (free_accumulator_init) {
+    free((void*)accumulator_init);
+  }
+}
+
+size_t xnn_packed_stride_kai_f16_6x32_weights_and_biases(
+    const struct xnn_gemm_config* unused_gemm_config, size_t k,
+    size_t unused_block_size, size_t unused_k_stride,
+    size_t unused_extra_bytes) {
+  return kai_get_rhs_packed_stride_rhs_pack_kxn_x16p32x1b_x16_x16_neon(k) /
+         kai_get_n_step_rhs_pack_kxn_x16p32x1b_x16_x16_neon();
+}
+
+void xnn_pack_kai_f16_6x32_weights_and_biases(
+    uint32_t flags, const struct xnn_gemm_config* gemm_config,
+    size_t input_channels, size_t output_channels, size_t groups,
+    size_t unused_block_size, size_t k_stride, const void* accumulator_init,
+    const void* weights, xnn_init_scale_params_fn init_extra_data0_fn,
+    const void* extra_data0, size_t extra_data0_element_size,
+    xnn_init_scale_params_fn init_extra_data1_fn, const void* extra_data1,
+    size_t extra_data1_element_size, void* packed_weights_ptr,
+    const void* params) {
+  assert(extra_data0 == nullptr);
+  assert(extra_data1 == nullptr);
+  const uint32_t nr = gemm_config->nr;
+  const uint32_t kr = UINT32_C(1) << gemm_config->log2_kr;
+  const uint32_t sr = UINT32_C(1) << gemm_config->log2_sr;
+
+  bool free_accumulator_init = false;
+  if (accumulator_init == NULL) {
+    accumulator_init = calloc(output_channels, sizeof(xnn_float16));
+    free_accumulator_init = true;
+  }
+
+  const size_t rhs_stride = k_stride * sizeof(xnn_float16);
+  const size_t weights_group_stride =
+      sizeof(xnn_float16) * k_stride *
+      ((flags & XNN_FLAG_TRANSPOSE_WEIGHTS) ? input_channels
+                                            : output_channels);
+  const size_t n_stride = round_up(output_channels, nr);
+  const size_t packed_weights_group_stride =
+      n_stride * xnn_packed_stride_kai_f16_6x32_weights_and_biases(
+                     gemm_config, input_channels, unused_block_size,
+                     /*unused_k_stride=*/0,
+                     /*unused_extra_bytes=*/0);
+
+  if (flags & XNN_FLAG_TRANSPOSE_WEIGHTS) {
+    for (size_t group = 0; group < groups; group++) {
+      kai_run_rhs_pack_kxn_x16p32x1b_x16_x16_neon(
+          /*groups=*/1, output_channels, input_channels, nr, kr, sr, rhs_stride,
+          /*rhs=*/
+          (const void*)((uintptr_t)weights + group * weights_group_stride),
+          /*bias=*/
+          free_accumulator_init
+              ? accumulator_init
+              : (const xnn_float16*)(accumulator_init) +
+                    group * output_channels,
+          /*scale=*/NULL,
+          /*rhs_packed=*/
+          (void*)((uintptr_t)packed_weights_ptr +
+                  group * packed_weights_group_stride),
+          /*extra_bytes=*/0, /*params=*/NULL);
+    }
+  } else {
+    for (size_t group = 0; group < groups; group++) {
+      kai_run_rhs_pack_nxk_x16p32x1bx16_x16_x16_neon(
+          /*groups=*/1, output_channels, input_channels, nr, kr, sr, rhs_stride,
+          /*rhs=*/
+          (const void*)((uintptr_t)weights + group * weights_group_stride),
+          /*bias=*/
+          free_accumulator_init
+              ? accumulator_init
+              : (const xnn_float16*)(accumulator_init) +
+                    group * output_channels,
           /*scale=*/NULL,
           /*rhs_packed=*/
           (void*)((uintptr_t)packed_weights_ptr +

--- a/src/reference/packing.cc
+++ b/src/reference/packing.cc
@@ -33,12 +33,14 @@
 #include "kai/ukernels/matmul/pack/kai_rhs_pack_kxn_qsi8cxp2vlx4sb_qs8cx_f32_i32_sme.h"
 #include "kai/ukernels/matmul/pack/kai_rhs_pack_kxn_qsi8cxp_qsi8cx_neon.h"
 #include "kai/ukernels/matmul/pack/kai_rhs_pack_kxn_x16p2vlx2b_x16_x16_sme.h"
+#include "kai/ukernels/matmul/pack/kai_rhs_pack_kxn_x16p32x1b_x16_x16_neon.h"
 #include "kai/ukernels/matmul/pack/kai_rhs_pack_nxk_f32p2vlx1biasf32_f32_f32_sme.h"
 #include "kai/ukernels/matmul/pack/kai_rhs_pack_nxk_qsi4c32p_qsu4c32s1s0.h"
 #include "kai/ukernels/matmul/pack/kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0.h"
 #include "kai/ukernels/matmul/pack/kai_rhs_pack_nxk_qsi4cxps1s0_qsu4cxs1s0_neon.h"
 #include "kai/ukernels/matmul/pack/kai_rhs_pack_nxk_qsi8cxp_qsi8cx_neon.h"
 #include "kai/ukernels/matmul/pack/kai_rhs_pack_nxk_x16p2vlx2b_x16_x16_sme.h"
+#include "kai/ukernels/matmul/pack/kai_rhs_pack_nxk_x16p32x1bx16_x16_x16_neon.h"
 #include "src/xnnpack/allocator.h"
 #endif  // XNN_ENABLE_KLEIDIAI
 
@@ -2867,6 +2869,87 @@ void xnn_pack_kai_f16_weights_and_biases(
           free_accumulator_init
               ? accumulator_init
               : (const float*)(accumulator_init) + group * output_channels,
+          /*scale=*/NULL,
+          /*rhs_packed=*/
+          (void*)((uintptr_t)packed_weights_ptr +
+                  group * packed_weights_group_stride),
+          /*extra_bytes=*/0, /*params=*/NULL);
+    }
+  }
+  if (free_accumulator_init) {
+    free((void*)accumulator_init);
+  }
+}
+
+size_t xnn_packed_stride_kai_f16_6x32_weights_and_biases(
+    const struct xnn_gemm_config* unused_gemm_config, size_t k,
+    size_t unused_block_size, size_t unused_k_stride,
+    size_t unused_extra_bytes) {
+  return kai_get_rhs_packed_stride_rhs_pack_kxn_x16p32x1b_x16_x16_neon(k) /
+         kai_get_n_step_rhs_pack_kxn_x16p32x1b_x16_x16_neon();
+}
+
+void xnn_pack_kai_f16_6x32_weights_and_biases(
+    uint32_t flags, const struct xnn_gemm_config* gemm_config,
+    size_t input_channels, size_t output_channels, size_t groups,
+    size_t unused_block_size, size_t k_stride, const void* accumulator_init,
+    const void* weights, xnn_init_scale_params_fn init_extra_data0_fn,
+    const void* extra_data0, size_t extra_data0_element_size,
+    xnn_init_scale_params_fn init_extra_data1_fn, const void* extra_data1,
+    size_t extra_data1_element_size, void* packed_weights_ptr,
+    const void* params) {
+  assert(extra_data0 == nullptr);
+  assert(extra_data1 == nullptr);
+  const uint32_t nr = gemm_config->nr;
+  const uint32_t kr = UINT32_C(1) << gemm_config->log2_kr;
+  const uint32_t sr = UINT32_C(1) << gemm_config->log2_sr;
+
+  bool free_accumulator_init = false;
+  if (accumulator_init == NULL) {
+    accumulator_init = calloc(output_channels, sizeof(xnn_float16));
+    free_accumulator_init = true;
+  }
+
+  const size_t rhs_stride = k_stride * sizeof(xnn_float16);
+  const size_t weights_group_stride =
+      sizeof(xnn_float16) * k_stride *
+      ((flags & XNN_FLAG_TRANSPOSE_WEIGHTS) ? input_channels
+                                            : output_channels);
+  const size_t n_stride = round_up(output_channels, nr);
+  const size_t packed_weights_group_stride =
+      n_stride * xnn_packed_stride_kai_f16_6x32_weights_and_biases(
+                     gemm_config, input_channels, unused_block_size,
+                     /*unused_k_stride=*/0,
+                     /*unused_extra_bytes=*/0);
+
+  if (flags & XNN_FLAG_TRANSPOSE_WEIGHTS) {
+    for (size_t group = 0; group < groups; group++) {
+      kai_run_rhs_pack_kxn_x16p32x1b_x16_x16_neon(
+          /*groups=*/1, output_channels, input_channels, nr, kr, sr, rhs_stride,
+          /*rhs=*/
+          (const void*)((uintptr_t)weights + group * weights_group_stride),
+          /*bias=*/
+          free_accumulator_init
+              ? accumulator_init
+              : (const xnn_float16*)(accumulator_init) +
+                    group * output_channels,
+          /*scale=*/NULL,
+          /*rhs_packed=*/
+          (void*)((uintptr_t)packed_weights_ptr +
+                  group * packed_weights_group_stride),
+          /*extra_bytes=*/0, /*params=*/NULL);
+    }
+  } else {
+    for (size_t group = 0; group < groups; group++) {
+      kai_run_rhs_pack_nxk_x16p32x1bx16_x16_x16_neon(
+          /*groups=*/1, output_channels, input_channels, nr, kr, sr, rhs_stride,
+          /*rhs=*/
+          (const void*)((uintptr_t)weights + group * weights_group_stride),
+          /*bias=*/
+          free_accumulator_init
+              ? accumulator_init
+              : (const xnn_float16*)(accumulator_init) +
+                    group * output_channels,
           /*scale=*/NULL,
           /*rhs_packed=*/
           (void*)((uintptr_t)packed_weights_ptr +

--- a/src/subgraph.c
+++ b/src/subgraph.c
@@ -4127,6 +4127,8 @@ enum xnn_status xnn_subgraph_optimize_packed_lhs(xnn_subgraph_t subgraph,
         const enum xnn_datatype input_datatype = input_value->datatype;
         const enum xnn_datatype kernel_datatype = kernel_value->datatype;
         const enum xnn_datatype output_datatype = output_value->datatype;
+        const struct xnn_gemm_config* pf16_gemm_config =
+            xnn_init_pf16_gemm_config();
 
         // Check if we can do anything special with this operation.
         if (input_datatype == xnn_datatype_qint8 &&
@@ -4165,7 +4167,8 @@ enum xnn_status xnn_subgraph_optimize_packed_lhs(xnn_subgraph_t subgraph,
             (kernel_datatype == xnn_datatype_fp16 ||
             kernel_datatype == xnn_datatype_fp32) &&
             output_datatype == xnn_datatype_fp16 &&
-            xnn_init_pf16_gemm_config() != NULL &&
+            pf16_gemm_config != NULL &&
+            pf16_gemm_config->pack_igemm_goki != NULL &&
             !(optimization_flags & XNN_FLAG_NO_INLINED_LHS_PACKING)) {
           // Note that there is currently no option to not use inlining for this
           // iGEMM kernel.

--- a/src/subgraph/rewrites/cvt_to_fp32.cc
+++ b/src/subgraph/rewrites/cvt_to_fp32.cc
@@ -65,7 +65,8 @@ bool IsValid(const Config* config) {
   } else if constexpr (std::is_same_v<Config, xnn_dwconv_config>) {
     return config && config->minmax;
   } else if constexpr (std::is_same_v<Config, xnn_gemm_config>) {
-    return config && config->minmax.gemm[0].function[0];
+    return config && config->mr != 0 &&
+           config->minmax.gemm[config->mr - 1].function[0];
   } else {
     return config && config->op_ukernel;
   }

--- a/src/xnnpack/gemm.h
+++ b/src/xnnpack/gemm.h
@@ -351,6 +351,10 @@ DECLARE_PF16_GEMM_MINMAX_UKERNEL_FUNCTION(
 DECLARE_PF16_GEMM_MINMAX_UKERNEL_FUNCTION(
     xnn_pf16_gemm_minmax_ukernel_32x32c2__neonsme2)
 DECLARE_PF16_GEMM_MINMAX_UKERNEL_FUNCTION(
+    xnn_pf16_gemm_minmax_ukernel_6x32__kai_aarch64_neonfp16arith)
+DECLARE_PF16_GEMM_MINMAX_UKERNEL_FUNCTION(
+    xnn_pf16_gemm_minmax_ukernel_6x32__kai_aarch64_neonfp16arith_cortex_a55)
+DECLARE_PF16_GEMM_MINMAX_UKERNEL_FUNCTION(
     xnn_pf16_gemm_minmax_ukernel_1x32c2__neonsme)
 DECLARE_PF16_GEMM_MINMAX_UKERNEL_FUNCTION(
     xnn_pf16_gemm_minmax_ukernel_32x32c2__neonsme)

--- a/src/xnnpack/pack.h
+++ b/src/xnnpack/pack.h
@@ -464,6 +464,13 @@ size_t xnn_packed_stride_kai_f16_weights_and_biases(
     size_t unused_k_stride,                     //
     size_t extra_bytes);
 
+size_t xnn_packed_stride_kai_f16_6x32_weights_and_biases(
+    const struct xnn_gemm_config* gemm_config,  //
+    size_t k,                                   //
+    size_t unused_block_size,                   //
+    size_t unused_k_stride,                     //
+    size_t extra_bytes);
+
 size_t xnn_packed_stride_kai_f32_weights_and_biases(
     const struct xnn_gemm_config* gemm_config,  //
     size_t k,                                   //
@@ -489,6 +496,25 @@ void xnn_pack_kai_qs8_qc8w_weights_and_biases_sme(
     const void* params);
 
 void xnn_pack_kai_f16_weights_and_biases(
+    uint32_t flags,                                //
+    const struct xnn_gemm_config* gemm_config,     //
+    size_t input_channels,                         //
+    size_t output_channels,                        //
+    size_t groups,                                 //
+    size_t unused_block_size,                      //
+    size_t k_stride,                               //
+    const void* accumulator_init,                  //
+    const void* weights,                           //
+    xnn_init_scale_params_fn init_extra_data0_fn,  //
+    const void* extra_data0,                       //
+    size_t extra_data0_element_size,               //
+    xnn_init_scale_params_fn init_extra_data1_fn,  //
+    const void* extra_data1,                       //
+    size_t extra_data1_element_size,               //
+    void* packed_weights_ptr,                      //
+    const void* params);
+
+void xnn_pack_kai_f16_6x32_weights_and_biases(
     uint32_t flags,                                //
     const struct xnn_gemm_config* gemm_config,     //
     size_t input_channels,                         //

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -1097,6 +1097,7 @@ xnnpack_unit_test(
     deps = MICROKERNEL_TEST_DEPS + [
         "//:microkernel_utils",
         "//:operator_utils",
+        "//src/configs:microkernel_configs",
     ],
 )
 

--- a/test/gemm-microkernel-tester.cc
+++ b/test/gemm-microkernel-tester.cc
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <cstdlib>
 #include <functional>
 #include <limits>
@@ -3156,6 +3157,17 @@ void GemmMicrokernelTester::Test_PF16(
     xnn_init_f16_minmax_params_fn init_minmax_params,
     xnn_pack_weights_and_biases_fn pack,
     xnn_packed_stride_weights_and_biases_fn packed_stride) {
+  Test_PF16(gemm, init_minmax_params, /*pack_lh=*/nullptr,
+            /*packed_lh_size=*/nullptr, pack, packed_stride);
+}
+
+void GemmMicrokernelTester::Test_PF16(
+    xnn_pf16_gemm_minmax_ukernel_fn gemm,
+    xnn_init_f16_minmax_params_fn init_minmax_params,
+    xnn_pack_lh_ukernel_fn pack_lh,
+    xnn_pack_lh_size_fn packed_lh_size,
+    xnn_pack_weights_and_biases_fn pack,
+    xnn_packed_stride_weights_and_biases_fn packed_stride) {
   ASSERT_LE(m(), mr());
 
   xnnpack::ReplicableRandomDevice rng;
@@ -3189,11 +3201,6 @@ void GemmMicrokernelTester::Test_PF16(
       packed_w_size,
       /*extra_bytes=*/{0}, "packed_w");
 
-  // Get the LHS packing config.
-  const struct xnn_pack_lh_config* pack_lh_config =
-      xnn_init_x16_pack_lh_config();
-  ASSERT_NE(pack_lh_config, nullptr);
-
   // Loop over the iterations.
   for (size_t idx = 0; idx < input_f16.size(); idx++) {
     input_f16[idx] = xnn_float16_from_float(f32rng());
@@ -3201,13 +3208,18 @@ void GemmMicrokernelTester::Test_PF16(
 
   // Pack the left-hand operand.
   const size_t input_packed_size =
-      pack_lh_config->size_fn(m(), k(), mr_packed(), kr(), sr());
+      packed_lh_size == nullptr
+          ? input_f16.size() * sizeof(xnn_float16)
+          : packed_lh_size(m(), k(), mr_packed(), kr(), sr());
   xnnpack::Buffer<int8_t> input_packed(input_packed_size, /*extra_bytes=*/{0},
                                        "input_packed");
-  pack_lh_config->pack_lh_fn(m(), k(), mr_packed(), kr(), sr(),
-                             /*m_idx_start=*/0, input_f16.data(),
-                             /*lhs_stride=*/k() * sizeof(xnn_float16),
-                             input_packed.data());
+  if (pack_lh == nullptr) {
+    std::memcpy(input_packed.data(), input_f16.data(), input_packed_size);
+  } else {
+    pack_lh(m(), k(), mr_packed(), kr(), sr(), /*m_idx_start=*/0,
+            input_f16.data(), /*lhs_stride=*/k() * sizeof(xnn_float16),
+            input_packed.data());
+  }
 
   for (size_t idx = 0; idx < weights.size(); idx++) {
     weights[idx] = xnn_float16_from_float(f32rng());

--- a/test/gemm-microkernel-tester.h
+++ b/test/gemm-microkernel-tester.h
@@ -376,6 +376,13 @@ class GemmMicrokernelTester {
                  xnn_pack_weights_and_biases_fn pack,
                  xnn_packed_stride_weights_and_biases_fn packed_stride);
 
+  void Test_PF16(xnn_pf16_gemm_minmax_ukernel_fn gemm,
+                 xnn_init_f16_minmax_params_fn init_minmax_params,
+                 xnn_pack_lh_ukernel_fn pack_lh,
+                 xnn_pack_lh_size_fn packed_lh_size,
+                 xnn_pack_weights_and_biases_fn pack,
+                 xnn_packed_stride_weights_and_biases_fn packed_stride);
+
 #if XNN_ENABLE_ARM_SME2 || XNN_ENABLE_ARM_SME
   // PF16 packed-LHS IGEMM (weights_and_biases API + packed_stride)
   void Test_PF16(xnn_pf16_f16_packed_igemm_minmax_ukernel_fn packed_igemm,

--- a/test/packing.cc
+++ b/test/packing.cc
@@ -13,6 +13,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "src/xnnpack/buffer.h"
+#include "src/xnnpack/config.h"
+#include "src/xnnpack/gemm.h"
+#include "src/xnnpack/isa-checks.h"
 #include "src/xnnpack/math.h"
 #include "src/xnnpack/microparams.h"
 #include "src/xnnpack/microparams-init.h"
@@ -23,6 +26,90 @@ namespace {
 using testing::ElementsAreArray;
 using testing::Matcher;
 using testing::_;
+
+#if XNN_ENABLE_ARM_FP16_VECTOR && XNN_ARCH_ARM64 && XNN_ENABLE_KLEIDIAI
+TEST(PACK_KAI_F16_6X32_WEIGHTS_AND_BIASES,
+     transposed_grouped_weights_use_k_stride) {
+  TEST_REQUIRES_ARCH_FLAGS(xnn_arch_arm_neon_fp16_arith);
+
+  const struct xnn_gemm_config* gemm_config =
+      xnn_init_pf16_gemm_config();
+  if (gemm_config == nullptr ||
+      gemm_config->pack_weights_and_biases !=
+          xnn_pack_kai_f16_6x32_weights_and_biases) {
+    GTEST_SKIP() << "KleidiAI Adv SIMD PF16 GEMM is not selected";
+  }
+  ASSERT_EQ(gemm_config->nr, 32);
+  ASSERT_EQ(UINT32_C(1) << gemm_config->log2_kr, 1);
+
+  constexpr size_t k = 3;
+  constexpr size_t n = 35;
+  constexpr size_t n_tile_start = 32;
+  constexpr size_t n_tile = n - n_tile_start;
+  constexpr size_t groups = 2;
+
+  std::vector<xnn_float16> lhs(k);
+  std::vector<xnn_float16> weights(groups * k * n);
+  std::vector<xnn_float16> bias(groups * n_tile);
+  for (size_t k_index = 0; k_index < k; k_index++) {
+    lhs[k_index] = xnn_float16_from_float(float(k_index + 1));
+  }
+  for (size_t group = 0; group < groups; group++) {
+    for (size_t k_index = 0; k_index < k; k_index++) {
+      for (size_t n_index = 0; n_index < n; n_index++) {
+        weights[(group * k + k_index) * n + n_index] =
+            xnn_float16_from_float(
+                float(100 * group + 10 * k_index + n_index));
+      }
+    }
+    for (size_t n_index = 0; n_index < n_tile; n_index++) {
+      bias[group * n_tile + n_index] =
+          xnn_float16_from_float(float(10 * group + n_index));
+    }
+  }
+
+  const size_t packed_stride =
+      xnn_packed_stride_kai_f16_6x32_weights_and_biases(
+          gemm_config, k, /*block_size=*/0, /*k_stride=*/n,
+          /*extra_bytes=*/0);
+  const size_t packed_group_stride =
+      round_up(n_tile, size_t{32}) * packed_stride;
+  xnnpack::Buffer<uint8_t, XNN_ALLOCATION_ALIGNMENT> packed_weights(
+      groups * packed_group_stride);
+  xnn_pack_kai_f16_6x32_weights_and_biases(
+      XNN_FLAG_TRANSPOSE_WEIGHTS, gemm_config, k, n_tile, groups,
+      /*block_size=*/0, /*k_stride=*/n, bias.data(),
+      weights.data() + n_tile_start, /*init_extra_data0_fn=*/nullptr,
+      /*extra_data0=*/nullptr, /*extra_data0_element_size=*/0,
+      /*init_extra_data1_fn=*/nullptr, /*extra_data1=*/nullptr,
+      /*extra_data1_element_size=*/0, packed_weights.data(), /*params=*/nullptr);
+
+  struct xnn_f16_minmax_params params;
+  xnn_init_f16_minmax_scalar_params(
+      &params, xnn_float16_from_float(-INFINITY),
+      xnn_float16_from_float(INFINITY));
+
+  for (size_t group = 0; group < groups; group++) {
+    std::vector<xnn_float16> output(n_tile);
+    xnn_pf16_gemm_minmax_ukernel_6x32__kai_aarch64_neonfp16arith(
+        /*m=*/1, n_tile, k * sizeof(xnn_float16), lhs.data(),
+        packed_weights.data() + group * packed_group_stride, output.data(),
+        /*dst_stride_row=*/n_tile * sizeof(xnn_float16),
+        /*dst_stride_col=*/sizeof(xnn_float16), &params);
+
+    for (size_t n_index = 0; n_index < n_tile; n_index++) {
+      xnn_float16 expected = bias[group * n_tile + n_index];
+      for (size_t k_index = 0; k_index < k; k_index++) {
+        expected = xnn_float16(
+            expected +
+            lhs[k_index] * weights[(group * k + k_index) * n +
+                                   n_tile_start + n_index]);
+      }
+      EXPECT_EQ(output[n_index], expected);
+    }
+  }
+}
+#endif  // XNN_ENABLE_ARM_FP16_VECTOR && XNN_ARCH_ARM64 && XNN_ENABLE_KLEIDIAI
 
 // QS8-QC2W GEMM packing tests.
 

--- a/test/pf16-gemm-minmax.cc
+++ b/test/pf16-gemm-minmax.cc
@@ -242,6 +242,33 @@ std::vector<GemmTestParams> CreateTests1(
 }  // namespace
 
 
+#if XNN_ENABLE_ARM_FP16_VECTOR && XNN_ARCH_ARM64
+  #if XNN_ENABLE_KLEIDIAI
+  INSTANTIATE_TEST_SUITE_P(
+      PF16_GEMM_MINMAX_6X32__KAI_AARCH64_NEONFP16ARITH, GemmTest,
+      testing::ValuesIn(CreateTests1(
+          /*k_block=*/1,
+          /*adj_k_block=*/1,
+          /*mr=*/6, /*nr=*/32, /*kr=*/1, /*sr=*/1,
+          /*mr_packed=*/6,
+          /*is_igemm=*/false,
+          /*unsigned_inputs=*/false,
+          /*planes=*/1,
+          [](GemmMicrokernelTester& tester) {
+            tester.Test_PF16(xnn_pf16_gemm_minmax_ukernel_6x32__kai_aarch64_neonfp16arith,
+                        xnn_init_f16_minmax_scalar_params,
+                        xnn_pack_kai_f16_6x32_weights_and_biases,
+                        xnn_packed_stride_kai_f16_6x32_weights_and_biases);
+          },
+          xnn_arch_arm_neon_fp16_arith)),
+      [](const testing::TestParamInfo<GemmTest::ParamType>& info) {
+        return info.param.test_name;
+      });
+
+  #endif  // XNN_ENABLE_KLEIDIAI
+#endif  // XNN_ENABLE_ARM_FP16_VECTOR && XNN_ARCH_ARM64
+
+
 #if XNN_ENABLE_ARM_SME2 && XNN_ARCH_ARM64
   #if XNN_ENABLE_KLEIDIAI
   INSTANTIATE_TEST_SUITE_P(
@@ -284,6 +311,8 @@ std::vector<GemmTestParams> CreateTests1(
           [](GemmMicrokernelTester& tester) {
             tester.Test_PF16(xnn_pf16_gemm_minmax_ukernel_1x32c2__neonsme2,
                         xnn_init_f16_minmax_scalar_params,
+                        (xnn_pack_lh_ukernel_fn) xnn_x16_pack_lh_ukernel__neonsme2,
+                        xnn_x16_pack_lh_size__neonsme2,
                         xnn_pack_kai_f16_weights_and_biases,
                         xnn_packed_stride_kai_f16_weights_and_biases);
           },
@@ -333,6 +362,8 @@ std::vector<GemmTestParams> CreateTests1(
           [](GemmMicrokernelTester& tester) {
             tester.Test_PF16(xnn_pf16_gemm_minmax_ukernel_32x32c2__neonsme2,
                         xnn_init_f16_minmax_scalar_params,
+                        (xnn_pack_lh_ukernel_fn) xnn_x16_pack_lh_ukernel__neonsme2,
+                        xnn_x16_pack_lh_size__neonsme2,
                         xnn_pack_kai_f16_weights_and_biases,
                         xnn_packed_stride_kai_f16_weights_and_biases);
           },
@@ -387,6 +418,8 @@ std::vector<GemmTestParams> CreateTests1(
           [](GemmMicrokernelTester& tester) {
             tester.Test_PF16(xnn_pf16_gemm_minmax_ukernel_1x32c2__neonsme,
                         xnn_init_f16_minmax_scalar_params,
+                        (xnn_pack_lh_ukernel_fn) xnn_x16_pack_lh_ukernel__neonsme,
+                        xnn_x16_pack_lh_size__neonsme,
                         xnn_pack_kai_f16_weights_and_biases,
                         xnn_packed_stride_kai_f16_weights_and_biases);
           },
@@ -436,6 +469,8 @@ std::vector<GemmTestParams> CreateTests1(
           [](GemmMicrokernelTester& tester) {
             tester.Test_PF16(xnn_pf16_gemm_minmax_ukernel_32x32c2__neonsme,
                         xnn_init_f16_minmax_scalar_params,
+                        (xnn_pack_lh_ukernel_fn) xnn_x16_pack_lh_ukernel__neonsme,
+                        xnn_x16_pack_lh_size__neonsme,
                         xnn_pack_kai_f16_weights_and_biases,
                         xnn_packed_stride_kai_f16_weights_and_biases);
           },

--- a/test/pf16-gemm-minmax.yaml
+++ b/test/pf16-gemm-minmax.yaml
@@ -4,8 +4,17 @@
 # LICENSE file in the root directory of this source tree.
 
 # Arm KleidiAI kernels
+- name: xnn_pf16_gemm_minmax_ukernel_6x32__kai_aarch64_neonfp16arith
+  init: xnn_init_f16_minmax_scalar_params
+  pack: xnn_pack_kai_f16_6x32_weights_and_biases
+  packed-stride: xnn_packed_stride_kai_f16_6x32_weights_and_biases
+  cpp-check: XNN_ENABLE_KLEIDIAI
+  k-block: 1
+  mr-packed: 6
 - name: xnn_pf16_gemm_minmax_ukernel_1x32c2__neonsme2
   init: xnn_init_f16_minmax_scalar_params
+  pack-lh-fn: (xnn_pack_lh_ukernel_fn) xnn_x16_pack_lh_ukernel__neonsme2
+  pack-lh-size-fn: xnn_x16_pack_lh_size__neonsme2
   pack: xnn_pack_kai_f16_weights_and_biases
   packed-stride: xnn_packed_stride_kai_f16_weights_and_biases
   cpp-check: XNN_ENABLE_KLEIDIAI
@@ -13,6 +22,8 @@
   mr-packed: 1
 - name: xnn_pf16_gemm_minmax_ukernel_32x32c2__neonsme2
   init: xnn_init_f16_minmax_scalar_params
+  pack-lh-fn: (xnn_pack_lh_ukernel_fn) xnn_x16_pack_lh_ukernel__neonsme2
+  pack-lh-size-fn: xnn_x16_pack_lh_size__neonsme2
   pack: xnn_pack_kai_f16_weights_and_biases
   packed-stride: xnn_packed_stride_kai_f16_weights_and_biases
   cpp-check: XNN_ENABLE_KLEIDIAI
@@ -20,6 +31,8 @@
   mr-packed: 32
 - name: xnn_pf16_gemm_minmax_ukernel_1x32c2__neonsme
   init: xnn_init_f16_minmax_scalar_params
+  pack-lh-fn: (xnn_pack_lh_ukernel_fn) xnn_x16_pack_lh_ukernel__neonsme
+  pack-lh-size-fn: xnn_x16_pack_lh_size__neonsme
   pack: xnn_pack_kai_f16_weights_and_biases
   packed-stride: xnn_packed_stride_kai_f16_weights_and_biases
   cpp-check: XNN_ENABLE_KLEIDIAI
@@ -27,6 +40,8 @@
   mr-packed: 1
 - name: xnn_pf16_gemm_minmax_ukernel_32x32c2__neonsme
   init: xnn_init_f16_minmax_scalar_params
+  pack-lh-fn: (xnn_pack_lh_ukernel_fn) xnn_x16_pack_lh_ukernel__neonsme
+  pack-lh-size-fn: xnn_x16_pack_lh_size__neonsme
   pack: xnn_pack_kai_f16_weights_and_biases
   packed-stride: xnn_packed_stride_kai_f16_weights_and_biases
   cpp-check: XNN_ENABLE_KLEIDIAI

--- a/test/subgraph/subgraph-fp16.cc
+++ b/test/subgraph/subgraph-fp16.cc
@@ -18,6 +18,7 @@
 #include "include/xnnpack.h"
 #include "src/xnnpack/allocation-type.h"
 #include "src/xnnpack/buffer.h"
+#include "src/xnnpack/config.h"
 #include "src/xnnpack/hardware-config.h"
 #include "src/xnnpack/math.h"
 #include "src/xnnpack/node-type.h"
@@ -1250,6 +1251,49 @@ TEST(SUBGRAPH_FP16_DUPLICATE_INPUTS, converted_only_once) {
 }
 
 #if XNN_ARCH_ARM64 && XNN_ENABLE_KLEIDIAI
+TEST(SUBGRAPH_FP16_CONVOLUTION, no_inline_lhs_without_igemm) {
+  const struct xnn_gemm_config* pf16_config =
+      xnn_init_pf16_gemm_config();
+  // This test executes only on Arm64 KleidiAI builds where PF16 GEMM is
+  // available without an IGEMM weight packer, such as Adv SIMD builds with
+  // SME and SME2 disabled. Other build and hardware combinations skip it.
+  if (pf16_config == nullptr || pf16_config->pack_igemm_goki != nullptr) {
+    GTEST_SKIP() << "PF16 without an IGEMM packer is not selected";
+  }
+
+  constexpr uint32_t input_id = 0;
+  constexpr uint32_t filter_id = 1;
+  constexpr uint32_t bias_id = 2;
+  constexpr uint32_t output_id = 3;
+  const uint32_t runtime_flags =
+      xnn_test_runtime_flags() & ~XNN_FLAG_NO_INLINED_LHS_PACKING;
+
+  SubgraphTester tester(/*external_value_ids=*/4);
+  tester.AddInputTensorF32({1, 8, 8, 32}, input_id)
+      .AddStaticTensorF32({64, 3, 3, 32}, TensorType::kDense, filter_id)
+      .AddStaticTensorF32({64}, TensorType::kDense, bias_id)
+      .AddOutputTensorF32({1, 8, 8, 64}, output_id)
+      .AddConvolution2D(
+          ConvolutionParams{
+              Padding{1, 1, 1, 1}, Kernel{3, 3}, Subsampling{1, 1},
+              Dilation{1, 1}, /*groups=*/1, /*group_input_channels=*/32,
+              /*group_output_channels=*/64, /*output_min=*/-INFINITY,
+              /*output_max=*/INFINITY},
+          input_id, filter_id, bias_id, output_id, /*flags=*/0)
+      .RewriteForFp16()
+      .Optimize(runtime_flags);
+
+  bool found_convolution = false;
+  for (uint32_t i = 0; i < tester.NumNodes(); i++) {
+    const xnn_node* node = tester.Node(i);
+    if (node->type == xnn_node_type_convolution_2d) {
+      found_convolution = true;
+      EXPECT_EQ(node->flags & XNN_FLAG_INLINE_LHS_PACKING, 0);
+    }
+  }
+  EXPECT_TRUE(found_convolution);
+}
+
 // This test targets the failure where pf16 packed-LHS iGEMM kernels were
 // accidentally invoked through the non-packed iGEMM call path. The packed-LHS
 // kernels have a different function signature, so the runtime ended up passing
@@ -1257,12 +1301,11 @@ TEST(SUBGRAPH_FP16_DUPLICATE_INPUTS, converted_only_once) {
 // causing a crash. In this test we build a Conv2D that forces the pf16 iGEMM path with
 // inline LHS packing enabled
 TEST(SUBGRAPH_FP16_CONVOLUTION, inline_lhs_packing_pf16) {
-
-    const auto* hw = xnn_init_hardware_config();
-    if (!hw || (hw->arch_flags & xnn_arch_arm_sme2) == 0
-            || (hw->arch_flags & xnn_arch_arm_sme ) == 0) {
-      GTEST_SKIP() << "PF16/SME(2) path not available on this target";
-    }
+  const struct xnn_gemm_config* pf16_config =
+      xnn_init_pf16_gemm_config();
+  if (pf16_config == nullptr || pf16_config->pack_igemm_goki == nullptr) {
+    GTEST_SKIP() << "PF16 IGEMM path not available on this target";
+  }
 
   // Construct an NHWC Conv that triggers iGEMM path
   // Shapes: N=1, H=W=8 => output_size=64; Cin=32, Cout=64.

--- a/third_party/kleidiai/BUILD.gn
+++ b/third_party/kleidiai/BUILD.gn
@@ -439,6 +439,9 @@ source_set("matmul") {
     "src/kai/ukernels/matmul/pack/kai_rhs_pack_nxk_x16p2vlx2b_x16_x16_sme.c",
     "src/kai/ukernels/matmul/pack/kai_rhs_pack_nxk_x16p2vlx2b_x16_x16_sme.h",
     "src/kai/ukernels/matmul/pack/kai_rhs_pack_nxk_x16p2vlx2b_x16_x16_sme_asm.S",
+    "src/kai/ukernels/matmul/pack/kai_rhs_pack_nxk_x16p32x1bx16_x16_x16_neon.c",
+    "src/kai/ukernels/matmul/pack/kai_rhs_pack_nxk_x16p32x1bx16_x16_x16_neon.h",
+    "src/kai/ukernels/matmul/pack/kai_rhs_pack_nxk_x16p32x1bx16_x16_x16_neon_asm.S",
     "src/kai/ukernels/matmul/pack/kai_rhs_quant_pack_kxn_bf16p12x4biasf32_f32_neon.c",
     "src/kai/ukernels/matmul/pack/kai_rhs_quant_pack_kxn_bf16p12x4biasf32_f32_neon.h",
   ]


### PR DESCRIPTION
### Summary
This change adds the KleidiAI Advanced SIMD (Arm® Neon™) PF16 6×32 GEMM kernels and selects it for packed FP16 GEMM when SME or SME2 kernels are not available. Two kernels are added. A general advanced SIMD and one targeting Arm(R) Cortex(TM)-A55.

The existing conventional PF16 6×16 kernels remain available for operations that cannot use the packed PF16 path, including convolution/IGEMM and cases where packed-LHS optimization is disabled.

This change also updates KleidiAI to version 1.28.

### Stack / Dependencies
The 6×32 kernel exists in KleidiAI 1.25, but this integration also requires the NXK RHS packer, which was part of 1.26.

DEPS now references the official GitHub repository using the v1.28.0 tag. Bazel and CMake use the corresponding immutable archive commit and SHA-256. This is in line with an earlier PR: https://github.com/google/XNNPACK/pull/7941

