### PR TITLE
Fix overflow in qb4w f16 scale buffer sizing

### DIFF
--- a/src/operators/fully-connected-nc.c
+++ b/src/operators/fully-connected-nc.c
@@ -1946,13 +1946,27 @@ enum xnn_status xnn_create_fully_connected_nc_qd8_f16_qb4w_f16_scales(
     float output_min, float output_max, uint32_t flags,
     xnn_weights_cache_t weights_cache, xnn_operator_t* fully_connected_op_out) {
   enum xnn_status status = xnn_status_success;
-  const size_t num_blocks =
-      (input_channels + block_size - 1) / block_size * output_channels;
-  xnn_bfloat16* bf16_scale_buffer =
-      (xnn_bfloat16*)xnn_allocate_memory(num_blocks * sizeof(xnn_bfloat16));
-  if (bf16_scale_buffer == NULL) {
-    return xnn_status_out_of_memory;
+  if (block_size == 0) {
+    xnn_log_error("failed to create %s operator: block size must be non-zero",
+                  xnn_operator_type_to_string(
+                      xnn_operator_type_fully_connected_nc_qd8_f16_qb4w));
+    return xnn_status_invalid_parameter;
   }
+  const size_t blocks_per_output = divide_round_up(input_channels, block_size);
+  size_t num_blocks = 0;
+  size_t scale_buffer_size = 0;
+  if (!xnn_safe_mul(blocks_per_output, output_channels, &num_blocks) ||
+      !xnn_safe_mul(num_blocks, sizeof(xnn_bfloat16), &scale_buffer_size)) {
+    xnn_log_error(
+        "failed to create %s operator with %zu input channels, %zu output "
+        "channels, and block size %zu: scale buffer size overflows size_t",
+        xnn_operator_type_to_string(
+            xnn_operator_type_fully_connected_nc_qd8_f16_qb4w),
+        input_channels, output_channels, block_size);
+    return xnn_status_invalid_parameter;
+  }
+  xnn_bfloat16* bf16_scale_buffer =
+      (xnn_bfloat16*)xnn_allocate_memory(scale_buffer_size);
   for (size_t i = 0; i < num_blocks; ++i) {
     bf16_scale_buffer[i] = xnn_bfloat16_from_float(
         xnn_float16_to_float(((const xnn_float16*)kernel_scale)[i]));
@@ -2180,10 +2194,27 @@ enum xnn_status xnn_create_fully_connected_nc_qp8_f32_qb4w_f16_scales(
     float output_min, float output_max, uint32_t flags,
     xnn_weights_cache_t weights_cache, xnn_operator_t* fully_connected_op_out) {
   enum xnn_status status = xnn_status_success;
-  const size_t num_blocks =
-      (input_channels + block_size - 1) / block_size * output_channels;
+  if (block_size == 0) {
+    xnn_log_error("failed to create %s operator: block size must be non-zero",
+                  xnn_operator_type_to_string(
+                      xnn_operator_type_fully_connected_nc_qp8_f32_qb4w));
+    return xnn_status_invalid_parameter;
+  }
+  const size_t blocks_per_output = divide_round_up(input_channels, block_size);
+  size_t num_blocks = 0;
+  size_t scale_buffer_size = 0;
+  if (!xnn_safe_mul(blocks_per_output, output_channels, &num_blocks) ||
+      !xnn_safe_mul(num_blocks, sizeof(xnn_bfloat16), &scale_buffer_size)) {
+    xnn_log_error(
+        "failed to create %s operator with %zu input channels, %zu output "
+        "channels, and block size %zu: scale buffer size overflows size_t",
+        xnn_operator_type_to_string(
+            xnn_operator_type_fully_connected_nc_qp8_f32_qb4w),
+        input_channels, output_channels, block_size);
+    return xnn_status_invalid_parameter;
+  }
   xnn_bfloat16* bf16_scale_buffer =
-      (xnn_bfloat16*)xnn_allocate_memory(num_blocks * sizeof(xnn_bfloat16));
+      (xnn_bfloat16*)xnn_allocate_memory(scale_buffer_size);
   for (size_t i = 0; i < num_blocks; ++i) {
     bf16_scale_buffer[i] = xnn_bfloat16_from_float(
         xnn_float16_to_float(((const xnn_float16*)kernel_scale)[i]));
@@ -2230,10 +2261,27 @@ enum xnn_status xnn_create_fully_connected_nc_qd8_f32_qb4w_f16_scales(
     const xnn_float16* kernel_scale, const void* kernel, const float* bias,
     float output_min, float output_max, uint32_t flags,
     xnn_weights_cache_t weights_cache, xnn_operator_t* fully_connected_op_out) {
-  const size_t num_blocks =
-      (input_channels + block_size - 1) / block_size * output_channels;
+  if (block_size == 0) {
+    xnn_log_error("failed to create %s operator: block size must be non-zero",
+                  xnn_operator_type_to_string(
+                      xnn_operator_type_fully_connected_nc_qd8_f32_qb4w));
+    return xnn_status_invalid_parameter;
+  }
+  const size_t blocks_per_output = divide_round_up(input_channels, block_size);
+  size_t num_blocks = 0;
+  size_t scale_buffer_size = 0;
+  if (!xnn_safe_mul(blocks_per_output, output_channels, &num_blocks) ||
+      !xnn_safe_mul(num_blocks, sizeof(xnn_bfloat16), &scale_buffer_size)) {
+    xnn_log_error(
+        "failed to create %s operator with %zu input channels, %zu output "
+        "channels, and block size %zu: scale buffer size overflows size_t",
+        xnn_operator_type_to_string(
+            xnn_operator_type_fully_connected_nc_qd8_f32_qb4w),
+        input_channels, output_channels, block_size);
+    return xnn_status_invalid_parameter;
+  }
   xnn_bfloat16* bf16_scale_buffer =
-      (xnn_bfloat16*)xnn_allocate_memory(num_blocks * sizeof(xnn_bfloat16));
+      (xnn_bfloat16*)xnn_allocate_memory(scale_buffer_size);
   for (size_t i = 0; i < num_blocks; ++i) {
     bf16_scale_buffer[i] =
         xnn_bfloat16_from_float(xnn_float16_to_float(kernel_scale[i]));
@@ -2279,10 +2327,30 @@ enum xnn_status xnn_create_fully_connected_nc_qdu8_f32_qb4w_f16_scales(
     const xnn_float16* kernel_scale, const void* kernel, const float* bias,
     float output_min, float output_max, uint32_t flags,
     xnn_weights_cache_t weights_cache, xnn_operator_t* fully_connected_op_out) {
-  const size_t num_blocks =
-      (input_channels + block_size - 1) / block_size * output_channels;
+  if (block_size == 0) {
+    xnn_log_error("failed to create %s operator: block size must be non-zero",
+                  xnn_operator_type_to_string(
+                      xnn_operator_type_fully_connected_nc_qdu8_f32_qb4w));
+    return xnn_status_invalid_parameter;
+  }
+  const size_t blocks_per_output = divide_round_up(input_channels, block_size);
+  size_t num_blocks = 0;
+  size_t scale_buffer_size = 0;
+  if (!xnn_safe_mul(blocks_per_output, output_channels, &num_blocks) ||
+      !xnn_safe_mul(num_blocks, sizeof(xnn_bfloat16), &scale_buffer_size)) {
+    xnn_log_error(
+        "failed to create %s operator with %zu input channels, %zu output "
+        "channels, and block size %zu: scale buffer size overflows size_t",
+        xnn_operator_type_to_string(
+            xnn_operator_type_fully_connected_nc_qdu8_f32_qb4w),
+        input_channels, output_channels, block_size);
+    return xnn_status_invalid_parameter;
+  }
   xnn_bfloat16* bf16_scale_buffer =
-      (xnn_bfloat16*)xnn_allocate_memory(num_blocks * sizeof(xnn_bfloat16));
+      (xnn_bfloat16*)xnn_allocate_memory(scale_buffer_size);
+  if (bf16_scale_buffer == NULL) {
+    return xnn_status_out_of_memory;
+  }
   for (size_t i = 0; i < num_blocks; ++i) {
     bf16_scale_buffer[i] =
         xnn_bfloat16_from_float(xnn_float16_to_float(kernel_scale[i]));

--- a/test/operators/fully-connected-nc.cc
+++ b/test/operators/fully-connected-nc.cc
@@ -6,10 +6,15 @@
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
 
+#include <array>
 #include <cstdint>
+#include <limits>
 
 #include <gtest/gtest.h>
+#include "include/xnnpack.h"
 #include "src/xnnpack/common.h"
+#include "src/xnnpack/internal.h"
+#include "src/xnnpack/math.h"
 #include "test/operators/fully-connected-operator-tester.h"
 
 TEST(FULLY_CONNECTED_NC_QS8, unit_batch) {
@@ -2634,6 +2639,63 @@ TEST(FULLY_CONNECTED_NC_QD8_F16_QB4W, bl) {
           .TestQD8F16QB4W();
     }
   }
+}
+
+TEST(FULLY_CONNECTED_NC_QB4W_F16_SCALES, scale_buffer_size_overflow) {
+  ASSERT_EQ(xnn_status_success, xnn_initialize(nullptr /* allocator */));
+
+  constexpr size_t input_channels = 32;
+  constexpr size_t block_size = 32;
+  constexpr size_t num_scale_elements = 33;
+  // The byte-size multiplication wraps to a 64-byte allocation, while the
+  // conversion loop still attempts to process output_channels scale values.
+  constexpr size_t output_channels =
+      std::numeric_limits<size_t>::max() / sizeof(xnn_bfloat16) +
+      num_scale_elements;
+  const std::array<uint16_t, num_scale_elements> f16_scales{};
+  const std::array<xnn_float16, num_scale_elements> typed_f16_scales{};
+  const uint8_t kernel = 0;
+  xnn_operator_t fully_connected_op = nullptr;
+
+  EXPECT_EQ(
+      xnn_status_invalid_parameter,
+      xnn_create_fully_connected_nc_qd8_f16_qb4w_f16_scales(
+          input_channels, output_channels, input_channels, output_channels,
+          block_size, /*kernel_zero_point=*/8, f16_scales.data(), &kernel,
+          /*bias=*/nullptr, -std::numeric_limits<float>::infinity(),
+          std::numeric_limits<float>::infinity(), /*flags=*/0,
+          /*weights_cache=*/nullptr, &fully_connected_op));
+  EXPECT_EQ(nullptr, fully_connected_op);
+
+  EXPECT_EQ(
+      xnn_status_invalid_parameter,
+      xnn_create_fully_connected_nc_qp8_f32_qb4w_f16_scales(
+          input_channels, output_channels, input_channels, output_channels,
+          block_size, /*kernel_zero_point=*/8, f16_scales.data(), &kernel,
+          /*bias=*/nullptr, -std::numeric_limits<float>::infinity(),
+          std::numeric_limits<float>::infinity(), /*flags=*/0,
+          /*weights_cache=*/nullptr, &fully_connected_op));
+  EXPECT_EQ(nullptr, fully_connected_op);
+
+  EXPECT_EQ(
+      xnn_status_invalid_parameter,
+      xnn_create_fully_connected_nc_qd8_f32_qb4w_f16_scales(
+          input_channels, output_channels, input_channels, output_channels,
+          block_size, /*kernel_zero_point=*/8, typed_f16_scales.data(), &kernel,
+          /*bias=*/nullptr, -std::numeric_limits<float>::infinity(),
+          std::numeric_limits<float>::infinity(), /*flags=*/0,
+          /*weights_cache=*/nullptr, &fully_connected_op));
+  EXPECT_EQ(nullptr, fully_connected_op);
+
+  EXPECT_EQ(
+      xnn_status_invalid_parameter,
+      xnn_create_fully_connected_nc_qdu8_f32_qb4w_f16_scales(
+          input_channels, output_channels, input_channels, output_channels,
+          block_size, /*kernel_zero_point=*/8, typed_f16_scales.data(), &kernel,
+          /*bias=*/nullptr, -std::numeric_limits<float>::infinity(),
+          std::numeric_limits<float>::infinity(), /*flags=*/0,
+          /*weights_cache=*/nullptr, &fully_connected_op));
+  EXPECT_EQ(nullptr, fully_connected_op);
 }
 
 TEST(FULLY_CONNECTED_NC_QD8_F16_QC2W, unit_batch) {


### PR DESCRIPTION
## Summary

Four `*_qb4w_f16_scales` fully-connected creation wrappers calculate a
temporary BF16 scale-buffer size from caller-supplied dimensions before the
shared parameter validation runs. Both the scale-count multiplication and the
subsequent byte-size multiplication were unchecked.

With `input_channels = block_size = 32` and
`output_channels = SIZE_MAX / sizeof(xnn_bfloat16) + 33`, the byte-size
calculation wraps to 64 bytes while the conversion loop retains the large
unwrapped element count. ASan reports a two-byte heap-buffer-overflow on the
first write past that allocation.

## Fix

- Reject a zero block size before performing the ceiling division.
- Use the existing overflow-safe `divide_round_up` and `xnn_safe_mul` helpers
  to calculate both the scale count and allocation size.
- Allocate and iterate using the checked results.
- Apply the same guard to the QD8/F16, QP8/F32, QD8/F32, and QDU8/F32 QB4W
  wrappers.

This follows the checked-allocation pattern already used in
`create_fully_connected_nc` and the overflow hardening merged in #10606. It is
separate from #10934 and #10935, which protect different buffers, and from
#10940, which adds allocation-failure checks after these three sibling
allocations.

## Test

Added a regression test that calls all four affected wrappers with the
overflowing dimensions and verifies that they return
`xnn_status_invalid_parameter` without creating an operator.

Before the fix, the focused test fails under ASan with:

```text
ERROR: AddressSanitizer: heap-buffer-overflow
WRITE of size 2
0 bytes after 64-byte region
xnn_create_fully_connected_nc_qd8_f16_qb4w_f16_scales
```

After the fix:

```sh
cmake -S . -B build/asan -G Ninja \
  -DCMAKE_BUILD_TYPE=Debug \
  -DXNNPACK_BUILD_TESTS=ON \
  -DXNNPACK_BUILD_BENCHMARKS=OFF \
  -DXNNPACK_LIBRARY_TYPE=static \
  '-DCMAKE_C_FLAGS=-fsanitize=address,undefined -fno-omit-frame-pointer -g' \
  '-DCMAKE_CXX_FLAGS=-fsanitize=address,undefined -fno-omit-frame-pointer -g' \
  '-DCMAKE_EXE_LINKER_FLAGS=-fsanitize=address,undefined'
cmake --build build/asan --target fully-connected-nc-test -- -j4
ASAN_OPTIONS=abort_on_error=1:detect_leaks=0 \
  ctest --test-dir build/asan --output-on-failure --parallel 4 \
  -R '^fully-connected-nc-test'
```

All 10 fully-connected test shards pass under ASan/UBSan.

Authored with OpenAI Codex.
