### PR TITLE
packing: fix NULL deref in KleidiAI SME bias-substitute allocation

### DIFF
--- a/src/reference/packing.cc
+++ b/src/reference/packing.cc
@@ -2675,6 +2675,7 @@ void xnn_pack_kai_qs8_qc8w_weights_and_biases_sme(
       xnn_log_error(
           "failed to allocate %zu bytes for KleidiAI SME bias substitute buffer",
           output_channels * sizeof(int32_t));
+      assert(false);
       return;
     }
     free_accumulator_init = true;
@@ -2838,6 +2839,7 @@ void xnn_pack_kai_f16_weights_and_biases(
       xnn_log_error(
           "failed to allocate %zu bytes for KleidiAI SME bias substitute buffer",
           output_channels * sizeof(float));
+      assert(false);
       return;
     }
     free_accumulator_init = true;
@@ -2924,6 +2926,7 @@ void xnn_pack_kai_f32_weights_and_biases(
       xnn_log_error(
           "failed to allocate %zu bytes for KleidiAI SME bias substitute buffer",
           output_channels * sizeof(float));
+      assert(false);
       return;
     }
     free_accumulator_init = true;

--- a/src/reference/packing.cc
+++ b/src/reference/packing.cc
@@ -2671,6 +2671,12 @@ void xnn_pack_kai_qs8_qc8w_weights_and_biases_sme(
   bool free_accumulator_init = false;
   if (accumulator_init == NULL) {
     accumulator_init = calloc(output_channels, sizeof(int32_t));
+    if (accumulator_init == NULL) {
+      xnn_log_error(
+          "failed to allocate %zu bytes for KleidiAI SME bias substitute buffer",
+          output_channels * sizeof(int32_t));
+      return;
+    }
     free_accumulator_init = true;
   }
   const struct xnn_qs8_packing_params* xnn_params =
@@ -2828,6 +2834,12 @@ void xnn_pack_kai_f16_weights_and_biases(
   bool free_accumulator_init = false;
   if (accumulator_init == NULL) {
     accumulator_init = calloc(output_channels, sizeof(float));
+    if (accumulator_init == NULL) {
+      xnn_log_error(
+          "failed to allocate %zu bytes for KleidiAI SME bias substitute buffer",
+          output_channels * sizeof(float));
+      return;
+    }
     free_accumulator_init = true;
   }
 
@@ -2908,6 +2920,12 @@ void xnn_pack_kai_f32_weights_and_biases(
   bool free_accumulator_init = false;
   if (accumulator_init == NULL) {
     accumulator_init = calloc(output_channels, sizeof(float));
+    if (accumulator_init == NULL) {
+      xnn_log_error(
+          "failed to allocate %zu bytes for KleidiAI SME bias substitute buffer",
+          output_channels * sizeof(float));
+      return;
+    }
     free_accumulator_init = true;
   }
 


### PR DESCRIPTION
`calloc` returns NULL on OOM. Three KleidiAI SME weight-packing functions allocate a zero-initialized bias substitute when the caller passes NULL bias (a standard configuration for bias-free FC layers), but none check the `calloc` return value. On failure the NULL pointer is passed directly to `kai_run_*` as the bias argument - no intervening allocation, no early-return path - and the kernel dereferences it → SIGSEGV.

XNNPACK's own comment at each site documents why the substitute is needed:

```
// Some packing kernels assume that the bias is non-null. Allocate a zero
// initialized array as a workaround if bias is null.
```

**Affected functions:**
- `xnn_pack_kai_qs8_qc8w_weights_and_biases_sme` (src/reference/packing.cc ~line 2665)
- `xnn_pack_kai_f16_weights_and_biases` (src/reference/packing.cc ~line 2821)
- `xnn_pack_kai_f32_weights_and_biases` (src/reference/packing.cc ~line 2901)

**Fix:** add a NULL guard after each `calloc`. On OOM, log the error and return early before the kernel call.

Note: this is independent of #10942, which guards `tmp_data` transpose buffer allocations in a different set of functions.