### PR TITLE
packing: fix NULL deref in KleidiAI QS4 bias-substitute allocation

### DIFF
--- a/src/reference/packing.cc
+++ b/src/reference/packing.cc
@@ -2550,6 +2550,13 @@ void xnn_pack_kai_qs4_weights_and_biases_sme(
   bool free_accumulator_init = false;
   if (extra_data0 == nullptr) {
     extra_data0 = calloc(output_channels, sizeof(float));
+    if (extra_data0 == nullptr) {
+      xnn_log_error(
+          "failed to allocate %zu bytes for KleidiAI QS4 bias substitute buffer",
+          output_channels * sizeof(float));
+      assert(false);
+      return;
+    }
     free_accumulator_init = true;
   }
   kai_run_rhs_pack_nxk_qsi4cxps1s0_qsu4cxs1s0_neon(


### PR DESCRIPTION
## Problem

`xnn_pack_kai_qs4_weights_and_biases_sme` in `src/reference/packing.cc` allocates a zero-initialized bias substitute when `extra_data0` is `nullptr`, but does not check whether `calloc` succeeded:

```cpp
if (extra_data0 == nullptr) {
    extra_data0 = calloc(output_channels, sizeof(float));  // unchecked
    free_accumulator_init = true;
}
kai_run_rhs_pack_nxk_qsi4cxps1s0_qsu4cxs1s0_neon(
    ...,
    /*bias=*/reinterpret_cast<const float*>(extra_data0),  // NULL on OOM → SIGSEGV
    ...);
```

If `calloc` returns NULL, the pointer is forwarded directly as `bias` to the KleidiAI NEON kernel, which unconditionally dereferences it. The crash site is clean — there is exactly one allocation between function entry and the `kai_run_` call, so the NULL deref is unconditional once `calloc` fails.

The call path is normal operation: `operator-run.c:275` explicitly passes `/*extra_data0=*/NULL`, and the function is registered as `qp8_f32_qc4w_gemm_config.pack_weights_and_biases` on SME-capable hardware (`src/configs/gemm-config.c:2908`).

## Fix

Add the same NULL check and `assert(false)`/`return` pattern used in the three sibling sites fixed in PR #10947.

## Changes

- `src/reference/packing.cc`: add NULL check after `calloc` in `xnn_pack_kai_qs4_weights_and_biases_sme`