### PR TITLE
Fix integer overflow in convolution conversion buffer sizing

### DIFF
--- a/src/operators/convolution-nhwc.c
+++ b/src/operators/convolution-nhwc.c
@@ -2306,8 +2306,16 @@ enum xnn_status xnn_create_convolution2d_nhwc_f16(
   const void* bias_to_use = bias;
   void* allocated_bias = NULL;
   if (bias != NULL && (flags & XNN_FLAG_FP32_STATIC_BIASES)) {
-    const size_t bias_size = groups * group_output_channels;
-    allocated_bias = xnn_allocate_memory(bias_size * sizeof(xnn_float16));
+    size_t bias_size;
+    size_t bias_bytes;
+    if (!xnn_safe_mul(groups, group_output_channels, &bias_size) ||
+        !xnn_safe_mul(bias_size, sizeof(xnn_float16), &bias_bytes)) {
+      xnn_log_error(
+          "failed to create %s operator: bias size overflows size_t",
+          xnn_operator_type_to_string(xnn_operator_type_convolution_nhwc_f16));
+      return xnn_status_invalid_parameter;
+    }
+    allocated_bias = xnn_allocate_memory(bias_bytes);
     if (allocated_bias == NULL) {
       return xnn_status_out_of_memory;
     }
@@ -2405,8 +2413,16 @@ enum xnn_status xnn_create_convolution2d_nhwc_pf16(
   const void* bias_to_use = bias;
   void* allocated_bias = NULL;
   if (bias != NULL && (flags & XNN_FLAG_FP32_STATIC_BIASES)) {
-    const size_t bias_size = groups * group_output_channels;
-    allocated_bias = xnn_allocate_memory(bias_size * sizeof(xnn_float16));
+    size_t bias_size;
+    size_t bias_bytes;
+    if (!xnn_safe_mul(groups, group_output_channels, &bias_size) ||
+        !xnn_safe_mul(bias_size, sizeof(xnn_float16), &bias_bytes)) {
+      xnn_log_error(
+          "failed to create %s operator: bias size overflows size_t",
+          xnn_operator_type_to_string(xnn_operator_type_convolution_nhwc_pf16));
+      return xnn_status_invalid_parameter;
+    }
+    allocated_bias = xnn_allocate_memory(bias_bytes);
     if (allocated_bias == NULL) {
       return xnn_status_out_of_memory;
     }
@@ -2510,11 +2526,20 @@ enum xnn_status xnn_create_convolution2d_nhwc_f32_f16(
     float output_min, float output_max, uint32_t flags,
     xnn_weights_cache_t weights_cache, xnn_operator_t* convolution_op_out) {
   // Convert the `f16` kernel and bias to `f32` in temporary buffers.
-  const size_t num_kernel_entries = groups * group_input_channels *
-                                    group_output_channels * kernel_width *
-                                    kernel_height;
-  float* fp32_kernel_buffer =
-      (float*)xnn_allocate_memory(num_kernel_entries * sizeof(float));
+  size_t num_kernel_entries;
+  size_t kernel_bytes;
+  if (!xnn_safe_mul(groups, group_input_channels, &num_kernel_entries) ||
+      !xnn_safe_mul(num_kernel_entries, group_output_channels,
+                    &num_kernel_entries) ||
+      !xnn_safe_mul(num_kernel_entries, kernel_width, &num_kernel_entries) ||
+      !xnn_safe_mul(num_kernel_entries, kernel_height, &num_kernel_entries) ||
+      !xnn_safe_mul(num_kernel_entries, sizeof(float), &kernel_bytes)) {
+    xnn_log_error(
+        "failed to create %s operator: kernel size overflows size_t",
+        xnn_operator_type_to_string(xnn_operator_type_convolution_nhwc_f32));
+    return xnn_status_invalid_parameter;
+  }
+  float* fp32_kernel_buffer = (float*)xnn_allocate_memory(kernel_bytes);
   if (fp32_kernel_buffer == NULL) {
     return xnn_status_out_of_memory;
   }
@@ -2526,14 +2551,23 @@ enum xnn_status xnn_create_convolution2d_nhwc_f32_f16(
     fp32_kernel_buffer[i] = xnn_float16_to_float(f16_kernel[i]);
   }
   if (bias && !(flags & XNN_FLAG_FP32_STATIC_BIASES)) {
-    fp32_bias_buffer = (float*)xnn_allocate_memory(
-        groups * group_output_channels * sizeof(float));
+    size_t bias_size;
+    size_t bias_bytes;
+    if (!xnn_safe_mul(groups, group_output_channels, &bias_size) ||
+        !xnn_safe_mul(bias_size, sizeof(float), &bias_bytes)) {
+      xnn_log_error(
+          "failed to create %s operator: bias size overflows size_t",
+          xnn_operator_type_to_string(xnn_operator_type_convolution_nhwc_f32));
+      xnn_release_memory(fp32_kernel_buffer);
+      return xnn_status_invalid_parameter;
+    }
+    fp32_bias_buffer = (float*)xnn_allocate_memory(bias_bytes);
     if (fp32_bias_buffer == NULL) {
       xnn_release_memory(fp32_kernel_buffer);
       return xnn_status_out_of_memory;
     }
     bias_buffer = fp32_bias_buffer;
-    for (size_t i = 0; i < groups * group_output_channels; ++i) {
+    for (size_t i = 0; i < bias_size; ++i) {
       fp32_bias_buffer[i] = xnn_float16_to_float(f16_bias[i]);
     }
   } else {
@@ -2596,11 +2630,20 @@ enum xnn_status xnn_create_convolution2d_nhwc_pf32_f16(
   }
 
   // Convert the `f16` kernel and bias to `f32` in temporary buffers.
-  const size_t num_kernel_entries = groups * group_input_channels *
-                                    group_output_channels * kernel_width *
-                                    kernel_height;
-  float* fp32_kernel_buffer =
-      (float*)xnn_allocate_memory(num_kernel_entries * sizeof(float));
+  size_t num_kernel_entries;
+  size_t kernel_bytes;
+  if (!xnn_safe_mul(groups, group_input_channels, &num_kernel_entries) ||
+      !xnn_safe_mul(num_kernel_entries, group_output_channels,
+                    &num_kernel_entries) ||
+      !xnn_safe_mul(num_kernel_entries, kernel_width, &num_kernel_entries) ||
+      !xnn_safe_mul(num_kernel_entries, kernel_height, &num_kernel_entries) ||
+      !xnn_safe_mul(num_kernel_entries, sizeof(float), &kernel_bytes)) {
+    xnn_log_error(
+        "failed to create %s operator: kernel size overflows size_t",
+        xnn_operator_type_to_string(xnn_operator_type_convolution_nhwc_pf32));
+    return xnn_status_invalid_parameter;
+  }
+  float* fp32_kernel_buffer = (float*)xnn_allocate_memory(kernel_bytes);
   if (fp32_kernel_buffer == NULL) {
     return xnn_status_out_of_memory;
   }
@@ -2612,14 +2655,23 @@ enum xnn_status xnn_create_convolution2d_nhwc_pf32_f16(
     fp32_kernel_buffer[i] = xnn_float16_to_float(f16_kernel[i]);
   }
   if (bias && !(flags & XNN_FLAG_FP32_STATIC_BIASES)) {
-    fp32_bias_buffer = (float*)xnn_allocate_memory(
-        groups * group_output_channels * sizeof(float));
+    size_t bias_size;
+    size_t bias_bytes;
+    if (!xnn_safe_mul(groups, group_output_channels, &bias_size) ||
+        !xnn_safe_mul(bias_size, sizeof(float), &bias_bytes)) {
+      xnn_log_error(
+          "failed to create %s operator: bias size overflows size_t",
+          xnn_operator_type_to_string(xnn_operator_type_convolution_nhwc_pf32));
+      xnn_release_memory(fp32_kernel_buffer);
+      return xnn_status_invalid_parameter;
+    }
+    fp32_bias_buffer = (float*)xnn_allocate_memory(bias_bytes);
     if (fp32_bias_buffer == NULL) {
       xnn_release_memory(fp32_kernel_buffer);
       return xnn_status_out_of_memory;
     }
     bias_buffer = fp32_bias_buffer;
-    for (size_t i = 0; i < groups * group_output_channels; ++i) {
+    for (size_t i = 0; i < bias_size; ++i) {
       fp32_bias_buffer[i] = xnn_float16_to_float(f16_bias[i]);
     }
   } else {

--- a/src/operators/deconvolution-nhwc.c
+++ b/src/operators/deconvolution-nhwc.c
@@ -1724,11 +1724,20 @@ enum xnn_status xnn_create_deconvolution2d_nhwc_f32_f16(
     const void* bias, float output_min, float output_max, uint32_t flags,
     xnn_weights_cache_t weights_cache, xnn_operator_t* deconvolution_op_out) {
   // Convert the `f16` kernel and bias to `f32` in temporary buffers.
-  const size_t num_kernel_entries = groups * group_input_channels *
-                                    group_output_channels * kernel_width *
-                                    kernel_height;
-  float* fp32_kernel_buffer =
-      (float*)xnn_allocate_memory(num_kernel_entries * sizeof(float));
+  size_t num_kernel_entries;
+  size_t kernel_bytes;
+  if (!xnn_safe_mul(groups, group_input_channels, &num_kernel_entries) ||
+      !xnn_safe_mul(num_kernel_entries, group_output_channels,
+                    &num_kernel_entries) ||
+      !xnn_safe_mul(num_kernel_entries, kernel_width, &num_kernel_entries) ||
+      !xnn_safe_mul(num_kernel_entries, kernel_height, &num_kernel_entries) ||
+      !xnn_safe_mul(num_kernel_entries, sizeof(float), &kernel_bytes)) {
+    xnn_log_error(
+        "failed to create %s operator: kernel size overflows size_t",
+        xnn_operator_type_to_string(xnn_operator_type_deconvolution_nhwc_f32));
+    return xnn_status_invalid_parameter;
+  }
+  float* fp32_kernel_buffer = (float*)xnn_allocate_memory(kernel_bytes);
   if (fp32_kernel_buffer == NULL) {
     return xnn_status_out_of_memory;
   }
@@ -1739,13 +1748,22 @@ enum xnn_status xnn_create_deconvolution2d_nhwc_f32_f16(
     fp32_kernel_buffer[i] = xnn_float16_to_float(f16_kernel[i]);
   }
   if (bias && !(flags & XNN_FLAG_FP32_STATIC_BIASES)) {
-    fp32_bias_buffer = (float*)xnn_allocate_memory(
-        groups * group_output_channels * sizeof(float));
+    size_t bias_size;
+    size_t bias_bytes;
+    if (!xnn_safe_mul(groups, group_output_channels, &bias_size) ||
+        !xnn_safe_mul(bias_size, sizeof(float), &bias_bytes)) {
+      xnn_log_error("failed to create %s operator: bias size overflows size_t",
+                    xnn_operator_type_to_string(
+                        xnn_operator_type_deconvolution_nhwc_f32));
+      xnn_release_memory(fp32_kernel_buffer);
+      return xnn_status_invalid_parameter;
+    }
+    fp32_bias_buffer = (float*)xnn_allocate_memory(bias_bytes);
     if (fp32_bias_buffer == NULL) {
       xnn_release_memory(fp32_kernel_buffer);
       return xnn_status_out_of_memory;
     }
-    for (size_t i = 0; i < groups * group_output_channels; ++i) {
+    for (size_t i = 0; i < bias_size; ++i) {
       fp32_bias_buffer[i] = xnn_float16_to_float(f16_bias[i]);
     }
     bias = fp32_bias_buffer;

--- a/test/operators/convolution-nhwc.cc
+++ b/test/operators/convolution-nhwc.cc
@@ -6,6 +6,9 @@
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
 
+#include <array>
+#include <cstdint>
+#include <limits>
 #include <utility>
 #include <vector>
 
@@ -1107,6 +1110,46 @@ CREATE_CONVOLUTION_SETUP_TESTS(CONVOLUTION_NHWC_F32, TestSetupNHWCxF32)
 
 CREATE_CONVOLUTION_TESTS(CONVOLUTION_NHWC_F16, TestNHWCxF16)
 CREATE_CONVOLUTION_SETUP_TESTS(CONVOLUTION_NHWC_F16, TestSetupNHWCxF16)
+
+TEST(CONVOLUTION_NHWC, conversion_buffer_size_overflow) {
+  ASSERT_EQ(xnn_status_success, xnn_initialize(nullptr /* allocator */));
+
+  constexpr size_t group_input_channels =
+      std::numeric_limits<size_t>::max() / sizeof(float) + 17;
+  constexpr size_t group_output_channels = 1;
+  const std::array<uint16_t, 17> kernel{};
+  xnn_operator_t convolution_op = nullptr;
+
+  EXPECT_EQ(
+      xnn_status_invalid_parameter,
+      xnn_create_convolution2d_nhwc_f32_f16(
+          0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, group_input_channels,
+          group_output_channels, group_input_channels, group_output_channels,
+          kernel.data(), nullptr, -std::numeric_limits<float>::infinity(),
+          std::numeric_limits<float>::infinity(), 0, nullptr, &convolution_op));
+  EXPECT_EQ(nullptr, convolution_op);
+}
+
+TEST(CONVOLUTION_NHWC, fp32_static_bias_size_overflow) {
+  ASSERT_EQ(xnn_status_success, xnn_initialize(nullptr /* allocator */));
+
+  constexpr size_t group_input_channels = 1;
+  constexpr size_t group_output_channels =
+      std::numeric_limits<size_t>::max() / sizeof(uint16_t) + 9;
+  const std::array<uint16_t, 1> kernel{};
+  const std::array<float, 17> bias{};
+  xnn_operator_t convolution_op = nullptr;
+
+  EXPECT_EQ(
+      xnn_status_invalid_parameter,
+      xnn_create_convolution2d_nhwc_f16(
+          0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, group_input_channels,
+          group_output_channels, group_input_channels, group_output_channels,
+          kernel.data(), bias.data(), -std::numeric_limits<float>::infinity(),
+          std::numeric_limits<float>::infinity(), XNN_FLAG_FP32_STATIC_BIASES,
+          nullptr, &convolution_op));
+  EXPECT_EQ(nullptr, convolution_op);
+}
 
 TEST(CONVOLUTION_NHWC_F32, unioutput_1x1) {
   ConvolutionOperatorTester()

--- a/test/operators/deconvolution-nhwc.cc
+++ b/test/operators/deconvolution-nhwc.cc
@@ -3,7 +3,10 @@
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
 
+#include <array>
 #include <cstddef>
+#include <cstdint>
+#include <limits>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -3385,3 +3388,23 @@ CREATE_DECONVOLUTION_SETUP_TESTS(DECONVOLUTION_NHWC_F16, TestSetupF16)
 CREATE_DECONVOLUTION_TESTS(DECONVOLUTION_NHWC_F32, xnn_init_f32_igemm_config(),
                            TestF32)
 CREATE_DECONVOLUTION_SETUP_TESTS(DECONVOLUTION_NHWC_F32, TestSetupF32)
+
+TEST(DECONVOLUTION_NHWC, conversion_buffer_size_overflow) {
+  ASSERT_EQ(xnn_status_success, xnn_initialize(nullptr /* allocator */));
+
+  constexpr size_t group_input_channels =
+      std::numeric_limits<size_t>::max() / sizeof(float) + 17;
+  constexpr size_t group_output_channels = 1;
+  const std::array<uint16_t, 17> kernel{};
+  xnn_operator_t deconvolution_op = nullptr;
+
+  EXPECT_EQ(
+      xnn_status_invalid_parameter,
+      xnn_create_deconvolution2d_nhwc_f32_f16(
+          0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, group_input_channels,
+          group_output_channels, group_input_channels, group_output_channels,
+          kernel.data(), nullptr, -std::numeric_limits<float>::infinity(),
+          std::numeric_limits<float>::infinity(), 0, nullptr,
+          &deconvolution_op));
+  EXPECT_EQ(nullptr, deconvolution_op);
+}


### PR DESCRIPTION
## Summary

Several public convolution and deconvolution constructors convert FP16 kernels
or biases into temporary buffers. They multiply caller-controlled dimensions to
compute the allocation size, then use the unwrapped element count in the
conversion loop.

The unchecked products can wrap `size_t`. The allocation can then be smaller
than the conversion loop, which causes a heap-buffer-overflow.

Affected paths:

- `xnn_create_convolution2d_nhwc_f16`
- `xnn_create_convolution2d_nhwc_pf16`
- `xnn_create_convolution2d_nhwc_f32_f16`
- `xnn_create_convolution2d_nhwc_pf32_f16`
- `xnn_create_deconvolution2d_nhwc_f32_f16`

## Fix

Use `xnn_safe_mul` for each element-count and byte-size product. Return
`xnn_status_invalid_parameter` before allocation or conversion when a product
does not fit in `size_t`. Release the temporary kernel buffer when a later bias
size check fails.

## Tests

- Added regression tests for kernel-conversion and FP32-static-bias overflow in
  the convolution and deconvolution operator tests.
- Built the two test binaries with CMake and Ninja.
- Ran all 20 convolution and deconvolution test shards with CTest. All passed.
- The same overflow inputs reproduce heap-buffer-overflow under ASan on the
  base revision and return `xnn_status_invalid_parameter` on this branch.
