### PR TITLE
guard NCHW FP16 conversion buffer sizes

### DIFF
--- a/src/operators/convolution-nchw.c
+++ b/src/operators/convolution-nchw.c
@@ -1238,32 +1238,12 @@ enum xnn_status xnn_create_convolution2d_nchw_f32_f16(
   const void* kernel_for_cache_key = kernel;
   size_t num_kernel_entries;
   size_t kernel_bytes;
-  if (!xnn_safe_mul(groups, group_input_channels, &num_kernel_entries)) {
-    xnn_log_error(
-        "failed to create %s operator: kernel size overflows size_t",
-        xnn_operator_type_to_string(xnn_operator_type_convolution_nchw_f32));
-    return xnn_status_invalid_parameter;
-  }
-  if (!xnn_safe_mul(num_kernel_entries, group_output_channels,
-                    &num_kernel_entries)) {
-    xnn_log_error(
-        "failed to create %s operator: kernel size overflows size_t",
-        xnn_operator_type_to_string(xnn_operator_type_convolution_nchw_f32));
-    return xnn_status_invalid_parameter;
-  }
-  if (!xnn_safe_mul(num_kernel_entries, kernel_width, &num_kernel_entries)) {
-    xnn_log_error(
-        "failed to create %s operator: kernel size overflows size_t",
-        xnn_operator_type_to_string(xnn_operator_type_convolution_nchw_f32));
-    return xnn_status_invalid_parameter;
-  }
-  if (!xnn_safe_mul(num_kernel_entries, kernel_height, &num_kernel_entries)) {
-    xnn_log_error(
-        "failed to create %s operator: kernel size overflows size_t",
-        xnn_operator_type_to_string(xnn_operator_type_convolution_nchw_f32));
-    return xnn_status_invalid_parameter;
-  }
-  if (!xnn_safe_mul(num_kernel_entries, sizeof(float), &kernel_bytes)) {
+  if (!xnn_safe_mul(groups, group_input_channels, &num_kernel_entries) ||
+      !xnn_safe_mul(num_kernel_entries, group_output_channels,
+                    &num_kernel_entries) ||
+      !xnn_safe_mul(num_kernel_entries, kernel_width, &num_kernel_entries) ||
+      !xnn_safe_mul(num_kernel_entries, kernel_height, &num_kernel_entries) ||
+      !xnn_safe_mul(num_kernel_entries, sizeof(float), &kernel_bytes)) {
     xnn_log_error(
         "failed to create %s operator: kernel size overflows size_t",
         xnn_operator_type_to_string(xnn_operator_type_convolution_nchw_f32));
@@ -1282,14 +1262,8 @@ enum xnn_status xnn_create_convolution2d_nchw_f32_f16(
   if (bias && !(flags & XNN_FLAG_FP32_STATIC_BIASES)) {
     size_t bias_size;
     size_t bias_bytes;
-    if (!xnn_safe_mul(groups, group_output_channels, &bias_size)) {
-      xnn_log_error(
-          "failed to create %s operator: bias size overflows size_t",
-          xnn_operator_type_to_string(xnn_operator_type_convolution_nchw_f32));
-      xnn_release_memory(fp32_kernel_buffer);
-      return xnn_status_invalid_parameter;
-    }
-    if (!xnn_safe_mul(bias_size, sizeof(float), &bias_bytes)) {
+    if (!xnn_safe_mul(groups, group_output_channels, &bias_size) ||
+        !xnn_safe_mul(bias_size, sizeof(float), &bias_bytes)) {
       xnn_log_error(
           "failed to create %s operator: bias size overflows size_t",
           xnn_operator_type_to_string(xnn_operator_type_convolution_nchw_f32));

--- a/src/operators/convolution-nchw.c
+++ b/src/operators/convolution-nchw.c
@@ -1236,11 +1236,40 @@ enum xnn_status xnn_create_convolution2d_nchw_f32_f16(
   // Convert the `f16` kernel and bias to `f32` in temporary buffers.
   const void* bias_for_cache_key = bias;
   const void* kernel_for_cache_key = kernel;
-  const size_t num_kernel_entries = groups * group_input_channels *
-                                    group_output_channels * kernel_width *
-                                    kernel_height;
-  float* fp32_kernel_buffer =
-      (float*)xnn_allocate_memory(num_kernel_entries * sizeof(float));
+  size_t num_kernel_entries;
+  size_t kernel_bytes;
+  if (!xnn_safe_mul(groups, group_input_channels, &num_kernel_entries)) {
+    xnn_log_error(
+        "failed to create %s operator: kernel size overflows size_t",
+        xnn_operator_type_to_string(xnn_operator_type_convolution_nchw_f32));
+    return xnn_status_invalid_parameter;
+  }
+  if (!xnn_safe_mul(num_kernel_entries, group_output_channels,
+                    &num_kernel_entries)) {
+    xnn_log_error(
+        "failed to create %s operator: kernel size overflows size_t",
+        xnn_operator_type_to_string(xnn_operator_type_convolution_nchw_f32));
+    return xnn_status_invalid_parameter;
+  }
+  if (!xnn_safe_mul(num_kernel_entries, kernel_width, &num_kernel_entries)) {
+    xnn_log_error(
+        "failed to create %s operator: kernel size overflows size_t",
+        xnn_operator_type_to_string(xnn_operator_type_convolution_nchw_f32));
+    return xnn_status_invalid_parameter;
+  }
+  if (!xnn_safe_mul(num_kernel_entries, kernel_height, &num_kernel_entries)) {
+    xnn_log_error(
+        "failed to create %s operator: kernel size overflows size_t",
+        xnn_operator_type_to_string(xnn_operator_type_convolution_nchw_f32));
+    return xnn_status_invalid_parameter;
+  }
+  if (!xnn_safe_mul(num_kernel_entries, sizeof(float), &kernel_bytes)) {
+    xnn_log_error(
+        "failed to create %s operator: kernel size overflows size_t",
+        xnn_operator_type_to_string(xnn_operator_type_convolution_nchw_f32));
+    return xnn_status_invalid_parameter;
+  }
+  float* fp32_kernel_buffer = (float*)xnn_allocate_memory(kernel_bytes);
   if (fp32_kernel_buffer == NULL) {
     return xnn_status_out_of_memory;
   }
@@ -1251,13 +1280,28 @@ enum xnn_status xnn_create_convolution2d_nchw_f32_f16(
     fp32_kernel_buffer[i] = xnn_float16_to_float(f16_kernel[i]);
   }
   if (bias && !(flags & XNN_FLAG_FP32_STATIC_BIASES)) {
-    fp32_bias_buffer = (float*)xnn_allocate_memory(
-        groups * group_output_channels * sizeof(float));
+    size_t bias_size;
+    size_t bias_bytes;
+    if (!xnn_safe_mul(groups, group_output_channels, &bias_size)) {
+      xnn_log_error(
+          "failed to create %s operator: bias size overflows size_t",
+          xnn_operator_type_to_string(xnn_operator_type_convolution_nchw_f32));
+      xnn_release_memory(fp32_kernel_buffer);
+      return xnn_status_invalid_parameter;
+    }
+    if (!xnn_safe_mul(bias_size, sizeof(float), &bias_bytes)) {
+      xnn_log_error(
+          "failed to create %s operator: bias size overflows size_t",
+          xnn_operator_type_to_string(xnn_operator_type_convolution_nchw_f32));
+      xnn_release_memory(fp32_kernel_buffer);
+      return xnn_status_invalid_parameter;
+    }
+    fp32_bias_buffer = (float*)xnn_allocate_memory(bias_bytes);
     if (fp32_bias_buffer == NULL) {
       xnn_release_memory(fp32_kernel_buffer);
       return xnn_status_out_of_memory;
     }
-    for (size_t i = 0; i < groups * group_output_channels; ++i) {
+    for (size_t i = 0; i != bias_size; ++i) {
       fp32_bias_buffer[i] = xnn_float16_to_float(f16_bias[i]);
     }
     bias = fp32_bias_buffer;

--- a/test/operators/convolution-nchw.cc
+++ b/test/operators/convolution-nchw.cc
@@ -142,13 +142,14 @@ TEST(CONVOLUTION_NCHW, bias_conversion) {
   std::array<float, 1> output{{0.0f}};
   xnn_operator_t convolution_op = nullptr;
 
-  EXPECT_EQ(
-      xnn_status_success,
-      xnn_create_convolution2d_nchw_f32_f16(
-          0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, kernel.data(),
-          bias.data(), -std::numeric_limits<float>::infinity(),
-          std::numeric_limits<float>::infinity(), 0, nullptr,
-          &convolution_op));
+  const xnn_status status = xnn_create_convolution2d_nchw_f32_f16(
+      0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, kernel.data(),
+      bias.data(), -std::numeric_limits<float>::infinity(),
+      std::numeric_limits<float>::infinity(), 0, nullptr, &convolution_op);
+  if (status == xnn_status_unsupported_hardware) {
+    GTEST_SKIP();
+  }
+  EXPECT_EQ(xnn_status_success, status);
   ASSERT_NE(nullptr, convolution_op);
   size_t output_height = 0;
   size_t output_width = 0;

--- a/test/operators/convolution-nchw.cc
+++ b/test/operators/convolution-nchw.cc
@@ -3,11 +3,188 @@
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
 
+#include <array>
 #include <cstddef>
+#include <cstdint>
+#include <limits>
 
 #include <gtest/gtest.h>
 #include "include/xnnpack.h"
+#include "src/xnnpack/internal.h"
 #include "test/operators/convolution-operator-tester.h"
+
+/**************************** Input validation ****************************/
+
+TEST(CONVOLUTION_NCHW, conversion_buffer_size_overflow) {
+  ASSERT_EQ(xnn_status_success, xnn_initialize(nullptr /* allocator */));
+
+  constexpr size_t group_input_channels =
+      std::numeric_limits<size_t>::max() / sizeof(float) + 17;
+  constexpr size_t group_output_channels = 1;
+  const std::array<uint16_t, 17> kernel{};
+  xnn_operator_t convolution_op = nullptr;
+
+  EXPECT_EQ(
+      xnn_status_invalid_parameter,
+      xnn_create_convolution2d_nchw_f32_f16(
+          0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, group_input_channels,
+          group_output_channels, group_input_channels, group_output_channels,
+          kernel.data(), nullptr, -std::numeric_limits<float>::infinity(),
+          std::numeric_limits<float>::infinity(), 0, nullptr,
+          &convolution_op));
+  EXPECT_EQ(nullptr, convolution_op);
+}
+
+TEST(CONVOLUTION_NCHW, kernel_element_count_overflow_at_groups) {
+  ASSERT_EQ(xnn_status_success, xnn_initialize(nullptr /* allocator */));
+
+  constexpr uint32_t groups = std::numeric_limits<uint32_t>::max();
+  constexpr size_t group_input_channels =
+      std::numeric_limits<size_t>::max() / groups + 1;
+  const std::array<uint16_t, 1> kernel{{0x3c00}};
+  xnn_operator_t convolution_op = nullptr;
+
+  EXPECT_EQ(
+      xnn_status_invalid_parameter,
+      xnn_create_convolution2d_nchw_f32_f16(
+          0, 0, 0, 0, 1, 1, 1, 1, 1, 1, groups, group_input_channels, 1,
+          group_input_channels, 1, kernel.data(), nullptr,
+          -std::numeric_limits<float>::infinity(),
+          std::numeric_limits<float>::infinity(), 0, nullptr,
+          &convolution_op));
+  EXPECT_EQ(nullptr, convolution_op);
+}
+
+TEST(CONVOLUTION_NCHW, kernel_element_count_overflow_at_channels) {
+  ASSERT_EQ(xnn_status_success, xnn_initialize(nullptr /* allocator */));
+
+  constexpr size_t group_input_channels =
+      std::numeric_limits<size_t>::max() / 2 + 1;
+  const std::array<uint16_t, 1> kernel{};
+  xnn_operator_t convolution_op = nullptr;
+
+  EXPECT_EQ(
+      xnn_status_invalid_parameter,
+      xnn_create_convolution2d_nchw_f32_f16(
+          0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, group_input_channels, 2,
+          group_input_channels, 2, kernel.data(), nullptr,
+          -std::numeric_limits<float>::infinity(),
+          std::numeric_limits<float>::infinity(), 0, nullptr,
+          &convolution_op));
+  EXPECT_EQ(nullptr, convolution_op);
+}
+
+TEST(CONVOLUTION_NCHW, kernel_element_count_overflow_at_width) {
+  ASSERT_EQ(xnn_status_success, xnn_initialize(nullptr /* allocator */));
+
+  constexpr size_t group_input_channels =
+      std::numeric_limits<size_t>::max() / 2 + 1;
+  const std::array<uint16_t, 1> kernel{};
+  xnn_operator_t convolution_op = nullptr;
+
+  EXPECT_EQ(
+      xnn_status_invalid_parameter,
+      xnn_create_convolution2d_nchw_f32_f16(
+          0, 0, 0, 0, 1, 2, 1, 1, 1, 1, 1, group_input_channels, 1,
+          group_input_channels, 1, kernel.data(), nullptr,
+          -std::numeric_limits<float>::infinity(),
+          std::numeric_limits<float>::infinity(), 0, nullptr,
+          &convolution_op));
+  EXPECT_EQ(nullptr, convolution_op);
+}
+
+TEST(CONVOLUTION_NCHW, kernel_element_count_overflow_at_height) {
+  ASSERT_EQ(xnn_status_success, xnn_initialize(nullptr /* allocator */));
+
+  constexpr size_t group_input_channels =
+      std::numeric_limits<size_t>::max() / 2 + 1;
+  const std::array<uint16_t, 1> kernel{};
+  xnn_operator_t convolution_op = nullptr;
+
+  EXPECT_EQ(
+      xnn_status_invalid_parameter,
+      xnn_create_convolution2d_nchw_f32_f16(
+          0, 0, 0, 0, 2, 1, 1, 1, 1, 1, 1, group_input_channels, 1,
+          group_input_channels, 1, kernel.data(), nullptr,
+          -std::numeric_limits<float>::infinity(),
+          std::numeric_limits<float>::infinity(), 0, nullptr,
+          &convolution_op));
+  EXPECT_EQ(nullptr, convolution_op);
+}
+
+TEST(CONVOLUTION_NCHW, bias_element_count_overflow) {
+  ASSERT_EQ(xnn_status_success, xnn_initialize(nullptr /* allocator */));
+
+  constexpr uint32_t groups = std::numeric_limits<uint32_t>::max();
+  constexpr size_t group_output_channels =
+      std::numeric_limits<size_t>::max() / groups + 1;
+  const std::array<uint16_t, 1> kernel{};
+  const std::array<uint16_t, 1> bias{};
+  xnn_operator_t convolution_op = nullptr;
+
+  EXPECT_EQ(
+      xnn_status_invalid_parameter,
+      xnn_create_convolution2d_nchw_f32_f16(
+          0, 0, 0, 0, 1, 0, 1, 1, 1, 1, groups, 0,
+          group_output_channels, 0, group_output_channels, kernel.data(),
+          bias.data(), -std::numeric_limits<float>::infinity(),
+          std::numeric_limits<float>::infinity(), 0, nullptr,
+          &convolution_op));
+  EXPECT_EQ(nullptr, convolution_op);
+}
+
+TEST(CONVOLUTION_NCHW, bias_conversion) {
+  ASSERT_EQ(xnn_status_success, xnn_initialize(nullptr /* allocator */));
+
+  const std::array<uint16_t, 1> kernel{{0x3c00}};
+  const std::array<uint16_t, 1> bias{{0x3c00}};
+  const std::array<float, 1> input{{2.0f}};
+  std::array<float, 1> output{{0.0f}};
+  xnn_operator_t convolution_op = nullptr;
+
+  EXPECT_EQ(
+      xnn_status_success,
+      xnn_create_convolution2d_nchw_f32_f16(
+          0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, kernel.data(),
+          bias.data(), -std::numeric_limits<float>::infinity(),
+          std::numeric_limits<float>::infinity(), 0, nullptr,
+          &convolution_op));
+  ASSERT_NE(nullptr, convolution_op);
+  size_t output_height = 0;
+  size_t output_width = 0;
+  ASSERT_EQ(xnn_status_success,
+            xnn_reshape_convolution2d_nchw_f32(
+                convolution_op, 1, 1, 1, &output_height, &output_width,
+                nullptr));
+  ASSERT_EQ(xnn_status_success,
+            xnn_setup_convolution2d_nchw_f32(convolution_op, input.data(),
+                                              output.data()));
+  ASSERT_EQ(xnn_status_success,
+            xnn_run_operator(convolution_op, nullptr /* threadpool */));
+  EXPECT_FLOAT_EQ(3.0f, output[0]);
+  xnn_delete_operator(convolution_op);
+}
+
+TEST(CONVOLUTION_NCHW, bias_conversion_size_overflow) {
+  ASSERT_EQ(xnn_status_success, xnn_initialize(nullptr /* allocator */));
+
+  constexpr size_t group_input_channels = 1;
+  constexpr size_t group_output_channels =
+      std::numeric_limits<size_t>::max() / sizeof(float) + 17;
+  const std::array<uint16_t, 1> kernel{};
+  const std::array<uint16_t, 17> bias{};
+  xnn_operator_t convolution_op = nullptr;
+
+  EXPECT_EQ(
+      xnn_status_invalid_parameter,
+      xnn_create_convolution2d_nchw_f32_f16(
+          0, 0, 0, 0, 1, 0, 1, 1, 1, 1, 1, group_input_channels,
+          group_output_channels, group_input_channels, group_output_channels,
+          kernel.data(), bias.data(), -std::numeric_limits<float>::infinity(),
+          std::numeric_limits<float>::infinity(), 0, nullptr,
+          &convolution_op));
+  EXPECT_EQ(nullptr, convolution_op);
+}
 
 /**************************** SPMM path ****************************/
 


### PR DESCRIPTION
## Summary

Guard the temporary FP32 buffers used by the NCHW FP16 convolution constructor.

## Problem

The constructor multiplied the group, channel, and kernel dimensions without checking for `size_t` overflow. It then allocated the wrapped byte count but converted the full logical element count. The same issue affected the temporary bias buffer. A caller that supplies dimensions near the `size_t` limit could therefore trigger a heap buffer overflow during weight conversion.

## Fix

Use `xnn_safe_mul` for each kernel and bias element-count product and for each byte-count conversion. Return `xnn_status_invalid_parameter` before allocation when a count is not representable. Use the checked counts for both allocation and conversion loops.

## Tests

- Added focused NCHW constructor tests for overflow at every kernel product stage and for both bias overflow stages.
- Added a normal-size bias conversion test.
- Ran the affected `CONVOLUTION_NCHW.*` tests under AddressSanitizer and UndefinedBehaviorSanitizer. The base revision reproduces the heap-buffer overflow; this change returns `xnn_status_invalid_parameter`.
- Built the test target and ran CTest. 495 of 496 tests passed; the only failure was the existing Apple scalar tolerance failure in `f32-vgelu-test`.

The paired constructor check produced these results:

```text
base: AddressSanitizer: heap-buffer-overflow in xnn_create_convolution2d_nchw_f32_f16
head: overflow status=2 op=0x0; exit_code=0
```

Review history: https://gist.github.com/8d068e7e6647a814d5898654c55b8f52
