### PR TITLE
Check xnn_allocate_memory return value in xnn_create_threadpool_v2

### DIFF
--- a/src/runtime.c
+++ b/src/runtime.c
@@ -786,6 +786,11 @@ enum xnn_status xnn_create_threadpool_v2(struct xnn_scheduler_v2 scheduler,
                                          uint32_t flags,
                                          xnn_threadpool_t* threadpool_out) {
   *threadpool_out = xnn_allocate_memory(sizeof(struct xnn_threadpool));
+  if (*threadpool_out == NULL) {
+    xnn_log_error("failed to allocate %zu bytes for threadpool descriptor",
+                  sizeof(struct xnn_threadpool));
+    return xnn_status_out_of_memory;
+  }
   (*threadpool_out)->scheduler = scheduler;
   (*threadpool_out)->scheduler_context = scheduler_context;
   return xnn_status_success;


### PR DESCRIPTION
`xnn_create_threadpool_v2` in `src/runtime.c` calls `xnn_allocate_memory` but does not check the return value before immediately writing through the pointer. 
If the allocation fails, `*threadpool_out` is NULL and the next line (`(*threadpool_out)->scheduler = scheduler`) is a guaranteed NULL dereference. The function also unconditionally returns `xnn_status_success`, so the caller has no way to detect the failure.

Add a NULL check after the allocation and return `xnn_status_out_of_memory` on failure, consistent with how every other allocation in the runtime is handled.