### PR TITLE
Check xnn_allocate_zero_memory return value in profiling end_ts loop

### DIFF
--- a/src/runtime.c
+++ b/src/runtime.c
@@ -677,6 +677,11 @@ enum xnn_status xnn_create_runtime_v4(
   if (runtime->profiling) {
     for (size_t i = 0; i < subgraph->num_nodes; i++) {
       runtime->opdata[i].end_ts = xnn_allocate_zero_memory(sizeof(xnn_timestamp) * XNN_MAX_OPERATOR_OBJECTS);
+      if (runtime->opdata[i].end_ts == NULL) {
+        xnn_log_error("failed to allocate %zu bytes for profiling timestamps",
+          sizeof(xnn_timestamp) * XNN_MAX_OPERATOR_OBJECTS);
+        goto error;
+      }
     }
   }
 


### PR DESCRIPTION
When `XNN_FLAG_BASIC_PROFILING` is set, `xnn_create_runtime_v4` allocates per-node `end_ts` timestamp arrays in a loop but never checks whether each allocation succeeded. If any `xnn_allocate_zero_memory` call returns NULL, `runtime->profiling` remains `true` and the next call to `xnn_invoke_runtime` or `xnn_get_runtime_profiling_info` writes or reads through the NULL pointer, causing a SIGSEGV.

Add a NULL check after each allocation and jump to the existing `error` label on failure, consistent with how every other allocation in the runtime is handled.