### PR TITLE
Guard scale_params size against integer overflow in setup_packing_params_qs8

### DIFF
--- a/src/operators/batch-matrix-multiply-nc.c
+++ b/src/operators/batch-matrix-multiply-nc.c
@@ -312,8 +312,15 @@ static enum xnn_status setup_packing_params_qs8(
 
     context->packing_params_.qs8 = (struct xnn_qs8_packing_params){
         .input_zero_point = context->input_zero_point};
-    const size_t scale_params_size =
-        sizeof(float) * context->batch_size_b * context->n;
+    size_t scale_params_count;
+    size_t scale_params_size;
+    if (!xnn_safe_mul(context->batch_size_b, context->n, &scale_params_count) ||
+        !xnn_safe_mul(scale_params_count, sizeof(float), &scale_params_size)) {
+      xnn_log_error(
+          "failed to create %s operator: scale params size overflows size_t",
+          xnn_operator_type_to_string(context->operator_type));
+      return xnn_status_invalid_parameter;
+    }
     float* scale_params = xnn_allocate_zero_memory(scale_params_size);
     context->scales_params_to_cleanup = scale_params;
     if (scale_params == NULL) {
@@ -322,7 +329,7 @@ static enum xnn_status setup_packing_params_qs8(
                     xnn_operator_type_to_string(context->operator_type));
       return xnn_status_out_of_memory;
     }
-    for (size_t i = 0; i < context->batch_size_b * context->n; ++i) {
+    for (size_t i = 0; i < scale_params_count; ++i) {
       scale_params[i] = context->requantization_scale;
     }
     context->packing_params = &context->packing_params_;


### PR DESCRIPTION
`setup_packing_params_qs8` computes the requantization scale buffer size as a bare three-factor product with no overflow guard:

    const size_t scale_params_size =
        sizeof(float) * context->batch_size_b * context->n;

On 32-bit targets (ARM32, WASM32), with `batch_size_b = 2^28` and `n = 4`, the product wraps to zero. `xnn_allocate_zero_memory(0)` returns a non-NULL pointer, the NULL check passes, and the write loop then iterates `2^30` times into a zero-byte buffer - a heap buffer overflow.

PR #10842 already applied `xnn_safe_mul` to the `packed_size` allocation in the same file (`create_batch_matrix_multiply_nc_const_weights`), but the `scale_params_size` calculation in `setup_packing_params_qs8` was not included in that fix. This patch applies the same pattern here, and also reuses the checked `scale_params_count` in the write loop to avoid computing `batch_size_b * context->n` a second time.