### PR TITLE
   Fix unguarded integer overflow in reshape_reduce_nd() workspace sizing

### DIFF
--- a/src/operators/reduce-nd.c
+++ b/src/operators/reduce-nd.c
@@ -240,7 +240,17 @@ static XNN_NO_SANITIZE_FUNCTION enum xnn_status reshape_reduce_nd(
   size_t num_reduction_elements;
   if (normalized_reduction_axes[num_reduction_axes - 1] == num_input_dims - 1) {
     if (workspace_size != NULL) {
-      const size_t num_output_elements = normalized_input_shape[0] * normalized_input_shape[2] * normalized_input_shape[4];
+      // Fix: guard against size_t overflow when multiplying tensor dimensions
+      // together to compute the workspace size (CWE-190 -> CWE-131 -> CWE-787).
+      size_t num_output_elements;
+      if (!xnn_safe_mul(normalized_input_shape[0], normalized_input_shape[2], &num_output_elements) ||
+          !xnn_safe_mul(num_output_elements, normalized_input_shape[4], &num_output_elements) ||
+          num_output_elements > (SIZE_MAX >> log2_accumulator_element_size) - XNN_EXTRA_BYTES) {
+        xnn_log_error(
+            "failed to reshape %s operator: workspace size computation overflowed",
+            xnn_operator_type_to_string_v2(reduce_op));
+        return xnn_status_unsupported_parameter;
+      }
       *workspace_size = (num_output_elements << log2_accumulator_element_size) + XNN_EXTRA_BYTES;
     }
     num_reduction_elements = normalized_input_shape[1] * normalized_input_shape[3] * normalized_input_shape[5];
@@ -282,7 +292,16 @@ static XNN_NO_SANITIZE_FUNCTION enum xnn_status reshape_reduce_nd(
     // Reduction along the non-innermost dimension
     const size_t channel_like_dim = normalized_input_shape[XNN_MAX_TENSOR_DIMS - 1];
     if (workspace_size != NULL) {
-      const size_t num_output_elements = normalized_input_shape[1] * normalized_input_shape[3] * normalized_input_shape[5];
+      // Fix: guard against size_t overflow (mirror of the branch above).
+      size_t num_output_elements;
+      if (!xnn_safe_mul(normalized_input_shape[1], normalized_input_shape[3], &num_output_elements) ||
+          !xnn_safe_mul(num_output_elements, normalized_input_shape[5], &num_output_elements) ||
+          num_output_elements > (SIZE_MAX >> log2_accumulator_element_size) - XNN_EXTRA_BYTES) {
+        xnn_log_error(
+            "failed to reshape %s operator: workspace size computation overflowed",
+            xnn_operator_type_to_string_v2(reduce_op));
+        return xnn_status_unsupported_parameter;
+      }
       *workspace_size = (num_output_elements << log2_accumulator_element_size) + XNN_EXTRA_BYTES;
     }
     num_reduction_elements = normalized_input_shape[0] * normalized_input_shape[2] * normalized_input_shape[4];
@@ -297,6 +316,13 @@ static XNN_NO_SANITIZE_FUNCTION enum xnn_status reshape_reduce_nd(
       reduce_op->reduce_config->update(&reduce_op->params.reduce, scale);
     }
     if (reduce_op->channels != channel_like_dim) {
+      // Fix: guard against size_t overflow in the zero-padding buffer size.
+      if (channel_like_dim > (SIZE_MAX >> log2_data_element_size) - XNN_EXTRA_BYTES) {
+        xnn_log_error(
+            "failed to reshape %s operator: zero buffer size computation overflowed",
+            xnn_operator_type_to_string_v2(reduce_op));
+        return xnn_status_unsupported_parameter;
+      }
       const size_t zero_size = (channel_like_dim << log2_data_element_size) + XNN_EXTRA_BYTES;
       // Note: zero buffer must be SIMD-aligned, so we can't use xnn_reallocate_memory
       xnn_release_simd_memory(reduce_op->zero_buffer);


### PR DESCRIPTION
### What

`reshape_reduce_nd()` in `src/operators/reduce-nd.c` computes the workspace
size for a reduce operator (and, in one branch, a zero-padding buffer size)
by multiplying caller-supplied tensor dimensions with no overflow check.

If the product overflows `size_t`, `*workspace_size` wraps to a value much
smaller than what's actually required. A caller allocates a buffer of that
(wrong) size, and the reduce kernel then writes based on the true,
non-overflowed per-dimension bounds — writing past the undersized buffer.

### Why this pattern specifically

13 of the 14 operator files in `src/operators/` that compute a buffer size
by multiplying tensor dimensions already guard it with the library's own
`xnn_safe_mul()` helper (`src/xnnpack/math.h`) — e.g. `argmax-pooling-nhwc.c`,
`average-pooling-nhwc.c`, `convolution-nhwc.c`, `fully-connected-nc.c`.
`reduce-nd.c` was the sole exception.

### Reachability

This is reached via the public, documented low-level operator API
(`xnn_create_reduce_nd` / `xnn_reshape_reduce_nd` / `xnn_setup_reduce_nd`),
which any embedding application can call directly with its own shape
metadata. The subgraph/model-parsing path (`xnn_define_tensor_value()` in
`src/tensor.c`) independently bounds the full tensor's element count before
any reshape happens, so callers going through that front door aren't
affected — this is specific to direct use of the low-level API with shape
data that doesn't originate from a `xnn_subgraph`.

### The fix

Applies the same `xnn_safe_mul()` pattern used everywhere else in the
codebase to both unguarded multiplications in `reshape_reduce_nd()`, plus an
explicit check that the subsequent left-shift by
`log2_accumulator_element_size` / `log2_data_element_size` doesn't itself
overflow. On overflow, returns `xnn_status_unsupported_parameter` and logs
an error, matching the convention already used by e.g.
`argmax-pooling-nhwc.c` for the identical failure mode.

No behavior change for any shape where the multiplication doesn't overflow.

