### PR TITLE
fully-connected: guard f16→f32 kernel buffer size against integer overflow

### DIFF
--- a/src/operators/fully-connected-nc.c
+++ b/src/operators/fully-connected-nc.c
@@ -2513,8 +2513,17 @@ enum xnn_status xnn_create_fully_connected_nc_f32_f16(
     size_t output_stride, const void* kernel, const void* bias,
     float output_min, float output_max, uint32_t flags,
     xnn_weights_cache_t weights_cache, xnn_operator_t* fully_connected_op_out) {
-  float* fp32_kernel_buffer = (float*)xnn_allocate_memory(
-      input_channels * output_channels * sizeof(float));
+  size_t fp32_kernel_size = 0;
+  if (!xnn_safe_mul(input_channels, output_channels, &fp32_kernel_size) ||
+      !xnn_safe_mul(fp32_kernel_size, sizeof(float), &fp32_kernel_size)) {
+    xnn_log_error(
+        "failed to create %s operator with %zu input channels and %zu output "
+        "channels: kernel buffer size overflows size_t",
+        xnn_operator_type_to_string(xnn_operator_type_fully_connected_nc_f32),
+        input_channels, output_channels);
+    return xnn_status_invalid_parameter;
+  }
+  float* fp32_kernel_buffer = (float*)xnn_allocate_memory(fp32_kernel_size);
   if (fp32_kernel_buffer == NULL) {
     return xnn_status_out_of_memory;
   }
@@ -2568,8 +2577,17 @@ enum xnn_status xnn_create_fully_connected_nc_pf32_f16(
     size_t output_stride, const void* kernel, const void* bias,
     float output_min, float output_max, uint32_t flags,
     xnn_weights_cache_t weights_cache, xnn_operator_t* fully_connected_op_out) {
-  float* fp32_kernel_buffer = (float*)xnn_allocate_memory(
-      input_channels * output_channels * sizeof(float));
+  size_t fp32_kernel_size = 0;
+  if (!xnn_safe_mul(input_channels, output_channels, &fp32_kernel_size) ||
+      !xnn_safe_mul(fp32_kernel_size, sizeof(float), &fp32_kernel_size)) {
+    xnn_log_error(
+        "failed to create %s operator with %zu input channels and %zu output "
+        "channels: kernel buffer size overflows size_t",
+        xnn_operator_type_to_string(xnn_operator_type_fully_connected_nc_pf32),
+        input_channels, output_channels);
+    return xnn_status_invalid_parameter;
+  }
+  float* fp32_kernel_buffer = (float*)xnn_allocate_memory(fp32_kernel_size);
   if (fp32_kernel_buffer == NULL) {
     return xnn_status_out_of_memory;
   }


### PR DESCRIPTION
## Problem

`xnn_create_fully_connected_nc_f32_f16` and `xnn_create_fully_connected_nc_pf32_f16` allocate a temporary fp32 kernel conversion buffer with an unguarded three-factor multiplication:

```c
float* fp32_kernel_buffer = (float*)xnn_allocate_memory(
    input_channels * output_channels * sizeof(float));  // no overflow check
```

On 32-bit `size_t` targets (ARM32, WASM32), with `input_channels = output_channels = 32768`:

```
32768 × 32768         = 2^30   (fits in 32-bit — no overflow)
2^30  × sizeof(float) = 2^32  ≡ 0  (mod 2^32 — wraps to zero)
```

`xnn_allocate_memory(0)` returns a non-NULL minimum-size chunk on bionic/glibc, so the NULL check added by `f6c4a0d` does not fire. The subsequent conversion loop writes past the allocation, corrupting adjacent heap memory.

## Fix

Add `xnn_safe_mul` guards matching the pattern already applied to scale buffer allocations in this file (lines 1971–1972, 2249–2250, 2319–2320, 2388–2389) and analogous conversion buffer allocations in `convolution-nhwc.c` and `convolution-nchw.c`.