### PR TITLE
depth-to-space: guard block_size² against uint32_t overflow → divide-by-zero

### DIFF
--- a/src/operators/transpose-nd.c
+++ b/src/operators/transpose-nd.c
@@ -826,16 +826,24 @@ enum xnn_status reshape_depth_to_space_nchw2nhwc(
   }
 
   const uint32_t block_size = depth_to_space_op->depth_to_space.block_size;
-  if (input_channels % (block_size * block_size) != 0) {
+  size_t block_size_sq = 0;
+  if (!xnn_safe_mul((size_t)block_size, (size_t)block_size, &block_size_sq)) {
     xnn_log_error(
-        "failed to reshape %s operator with %zu input_channels and %zu "
-        "block_sizex: input channels must be divisible by block_size * "
+        "failed to reshape %s operator with %u block size: "
+        "block_size * block_size overflows size_t",
+        xnn_operator_type_to_string(operator_type), block_size);
+    return xnn_status_invalid_parameter;
+  }
+  if (input_channels % block_size_sq != 0) {
+    xnn_log_error(
+        "failed to reshape %s operator with %zu input channels and %u "
+        "block_size: input channels must be divisible by block_size * "
         "block_size",
-        xnn_operator_type_to_string(operator_type), input_width, input_height);
+        xnn_operator_type_to_string(operator_type), input_channels, block_size);
     return xnn_status_invalid_parameter;
   }
 
-  const size_t output_channels = input_channels / block_size / block_size;
+  const size_t output_channels = input_channels / block_size_sq;
 
   if (batch_size == 0) {
     depth_to_space_op->state = xnn_run_state_skip;
@@ -1119,9 +1127,17 @@ static enum xnn_status reshape_depth_to_space_nhwc(
   }
 
   const uint32_t block_size = depth_to_space_op->depth_to_space.block_size;
-  if (input_channels % (block_size * block_size) != 0) {
+  size_t block_size_sq = 0;
+  if (!xnn_safe_mul((size_t)block_size, (size_t)block_size, &block_size_sq)) {
     xnn_log_error(
-        "failed to reshape %s operator with %zu input_channels and %u "
+        "failed to reshape %s operator with %u block size: "
+        "block_size * block_size overflows size_t",
+        xnn_operator_type_to_string(expected_operator_type), block_size);
+    return xnn_status_invalid_parameter;
+  }
+  if (input_channels % block_size_sq != 0) {
+    xnn_log_error(
+        "failed to reshape %s operator with %zu input channels and %u "
         "block_size: input channels must be divisible by block_size * "
         "block_size",
         xnn_operator_type_to_string(expected_operator_type), input_channels,
@@ -1129,7 +1145,7 @@ static enum xnn_status reshape_depth_to_space_nhwc(
     return xnn_status_invalid_parameter;
   }
 
-  const size_t output_channels = input_channels / block_size / block_size;
+  const size_t output_channels = input_channels / block_size_sq;
 
   if (batch_size == 0) {
     depth_to_space_op->state = xnn_run_state_skip;


### PR DESCRIPTION
## Problem

`reshape_depth_to_space_nchw2nhwc` and `reshape_depth_to_space_nhwc` compute `block_size * block_size` in `uint32_t` arithmetic and use the result directly as the divisor in a modulo expression:

```c
const uint32_t block_size = depth_to_space_op->depth_to_space.block_size;
if (input_channels % (block_size * block_size) != 0) {  // ← crash if block_size >= 65536
```

When `block_size >= 65536` (= 2¹⁶), the product wraps to 0 in `uint32_t`. The zero is promoted to `size_t` for the `%` operator, causing:
- **x86 / x86-64**: `DIV` with divisor 0 → `#DE` → `SIGFPE` → process crash
- **ARM32**: `UDIV` with divisor 0 → division-by-zero trap → `SIGFPE` → process crash
- **WASM32**: `i32.rem_u` with divisor 0 → WebAssembly trap → module terminates

The create-time check only rejects `block_size <= 1`, so `block_size = 65536` is accepted without error and the fault fires on the first reshape call with any non-zero `input_channels`. No large input is required — a single-element tensor suffices.

## Fix

Replace the bare `block_size * block_size` expression with an `xnn_safe_mul` guard that returns `xnn_status_invalid_parameter` on overflow, matching the pattern used in the space-to-depth direction (`reshape_space_to_depth_nhwc`, lines 1420–1421) and throughout the rest of the codebase. Also use the pre-computed `block_size_sq` for the subsequent `output_channels` division, and fix a pre-existing typo in the `nchw2nhwc` error message that printed `input_width`/`input_height` instead of `input_channels`/`block_size`.