### PR TITLE
litert/xnnpack: guard against zero input dimension in ResizeNearestNeighborOperation::ToXnnpack()

### DIFF
--- a/litert/tensor/backends/xnnpack/arithmetic.cc
+++ b/litert/tensor/backends/xnnpack/arithmetic.cc
@@ -1338,6 +1338,11 @@ OpMixin<ResizeNearestNeighborOperation, XnnpackMixinTag>::ToXnnpack(
   const int input_w = input_info.shape[2];
   const int channels = input_info.shape[3];
 
+  if (input_h == 0 || input_w == 0) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "%s: input spatial dimensions must be non-zero. Got %dx%d", op_name,
+        input_h, input_w));
+  }
   if (new_height % input_h != 0 || new_width % input_w != 0) {
     return absl::UnimplementedError(absl::StrFormat(
         "%s: only integer scaling supported. Input %dx%d, output %dx%d",


### PR DESCRIPTION
`ResizeNearestNeighborOperation::ToXnnpack()` reads `input_h` and `input_w` directly from the flatbuffer shape field and uses them as integer divisors in modulo and division operations (lines 1483–1489) without checking for zero. A crafted model with an input tensor whose height or width is 0 triggers SIGFPE during XNNPACK subgraph compilation at model load time - before any inference runs.

The sibling `ResizeBilinearOperation::ToXnnpack()` passes dimensions directly to `xnn_define_static_resize_bilinear_2d` without any division and is not affected. This function uniquely computes an integer scale factor via division and had no guard for a zero divisor.

Fix: add an explicit non-zero check for `input_h` and `input_w` immediately after they are read, before the first modulo operation.