### PR TITLE
litert/xnnpack: guard against 0D scalar axes/begin tensor in MeanOperation and SliceOperation ToXnnpack()

### DIFF
--- a/litert/tensor/backends/xnnpack/arithmetic.cc
+++ b/litert/tensor/backends/xnnpack/arithmetic.cc
@@ -1025,6 +1025,10 @@ absl::Status OpMixin<MeanOperation, XnnpackMixinTag>::ToXnnpack(
   }
   LockedBufferSpan<const int32_t> axes_data =
       axes_info.buffer->Lock().As<const int32_t>();
+  if (axes_info.shape.empty()) {
+    return absl::InvalidArgumentError(
+        absl::StrFormat("%s: axes tensor must not be a 0D scalar", op_name));
+  }
   const size_t num_axes = axes_info.shape[0];
   const std::vector<int64_t> axes(axes_data.begin(), axes_data.end());
   // Set XNN_FLAG_KEEP_DIMS if keep_dims is true
@@ -1069,6 +1073,10 @@ absl::Status OpMixin<SliceOperation, XnnpackMixinTag>::ToXnnpack(
   auto begin_locked = begin_info.buffer->Lock();
   const int32_t* begin_data =
       reinterpret_cast<const int32_t*>(begin_locked.data());
+  if (begin_info.shape.empty()) {
+    return absl::InvalidArgumentError(
+        absl::StrFormat("%s: begin tensor must not be a 0D scalar", op_name));
+  }
   size_t num_dims = begin_info.shape[0];
 
   // Get sizes from const tensor


### PR DESCRIPTION
`MeanOperation::ToXnnpack()` accesses `axes_info.shape[0]` and `SliceOperation::ToXnnpack()` accesses `begin_info.shape[0]` without checking whether the shape vector is empty. A crafted TFLite model that declares either tensor as a 0D scalar produces an empty `std::vector<int>`; `operator[](0)` on an empty vector dereferences null → SIGSEGV during XNNPACK subgraph compilation at model load time, before any inference runs.

`ExpandDimsOperation::ToXnnpack()` in the same file performs the identical buffer-lock pattern and already includes `if (locked_axis.size() == 0)` before accessing element 0. The `keep_dims == true` branch of `Mean()` in `litert/tensor/arithmetic.h` (lines 947–980) guards `if (b_info.shape.empty())` before accessing `b_info.shape[0]`. Neither MeanOperation nor SliceOperation in the ToXnnpack path received an equivalent guard.

Fix: add `shape.empty()` checks in both functions before the `shape[0]` access.