### PR TITLE
litert/xnnpack: add rank guards to AveragePool2D, MaxPool2D, Conv2D, DepthwiseConv2D, and TransposeConv2D ToXnnpack() before shape subscripts

### DIFF
--- a/litert/tensor/backends/xnnpack/arithmetic.cc
+++ b/litert/tensor/backends/xnnpack/arithmetic.cc
@@ -621,6 +621,11 @@ absl::Status OpMixin<AveragePool2DOperation, XnnpackMixinTag>::ToXnnpack(
 
   LRT_TENSOR_ASSIGN_OR_RETURN(const auto& input_info, graph::GetInfo(input));
 
+  if (input_info.shape.size() < 3) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "%s: input tensor must be at least rank 3. Got rank %d", op_name,
+        input_info.shape.size()));
+  }
   const int input_h = input_info.shape[1];
   const int input_w = input_info.shape[2];
   const int filter_h = op_data.filter_height;
@@ -666,6 +671,11 @@ absl::Status OpMixin<MaxPool2DOperation, XnnpackMixinTag>::ToXnnpack(
 
   LRT_TENSOR_ASSIGN_OR_RETURN(const auto& input_info, graph::GetInfo(input));
 
+  if (input_info.shape.size() < 3) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "%s: input tensor must be at least rank 3. Got rank %d", op_name,
+        input_info.shape.size()));
+  }
   const int input_h = input_info.shape[1];
   const int input_w = input_info.shape[2];
   const int filter_h = op_data.filter_height;
@@ -719,6 +729,12 @@ absl::Status OpMixin<Conv2DOperation, XnnpackMixinTag>::ToXnnpack(
   LRT_TENSOR_ASSIGN_OR_RETURN(const auto& input_info, graph::GetInfo(input));
   LRT_TENSOR_ASSIGN_OR_RETURN(const auto& filter_info, graph::GetInfo(filter));
 
+  if (input_info.shape.size() != 4 || filter_info.shape.size() != 4) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "%s: input and filter tensors must be rank 4. Got input rank %d, "
+        "filter rank %d",
+        op_name, input_info.shape.size(), filter_info.shape.size()));
+  }
   // The 0th dimension is always the batch dimension in the tensor API (BHWC).
   const int input_h = input_info.shape[1];
   const int input_w = input_info.shape[2];
@@ -780,6 +796,12 @@ absl::Status OpMixin<DepthwiseConv2DOperation, XnnpackMixinTag>::ToXnnpack(
   LRT_TENSOR_ASSIGN_OR_RETURN(const auto& input_info, graph::GetInfo(input));
   LRT_TENSOR_ASSIGN_OR_RETURN(const auto& filter_info, graph::GetInfo(filter));
 
+  if (input_info.shape.size() != 4 || filter_info.shape.size() != 4) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "%s: input and filter tensors must be rank 4. Got input rank %d, "
+        "filter rank %d",
+        op_name, input_info.shape.size(), filter_info.shape.size()));
+  }
   const int input_h = input_info.shape[1];
   const int input_w = input_info.shape[2];
   const int filter_h = filter_info.shape[1];
@@ -1747,6 +1769,14 @@ absl::Status OpMixin<TransposeConv2DOperation, XnnpackMixinTag>::ToXnnpack(
   LRT_TENSOR_ASSIGN_OR_RETURN(uint32_t output_id, ctx.DefineValue(output));
   LRT_TENSOR_ASSIGN_OR_RETURN(const auto& output_info, graph::GetInfo(output));
 
+  if (input_info.shape.size() != 4 || filter_info.shape.size() != 4 ||
+      output_info.shape.size() != 4) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "%s: input, filter, and output tensors must be rank 4. Got input "
+        "rank %d, filter rank %d, output rank %d",
+        op_name, input_info.shape.size(), filter_info.shape.size(),
+        output_info.shape.size()));
+  }
   const size_t output_channels = filter_info.shape[0];
   const size_t input_channels = filter_info.shape[3];
 


### PR DESCRIPTION
Five `ToXnnpack()` implementations access fixed shape indices (`shape[1]`, `shape[2]`, `shape[3]`) on input, filter, and output tensor shape vectors without first validating that the vector has enough elements. A crafted TFLite model that declares a wrong-rank tensor for any of these operations triggers a null pointer dereference during XNNPACK subgraph compilation at model load time, before any inference runs.

`TransposeConvOperation::ToXnnpack()` (lines 1649–1653) performs the same shape subscripts and already includes the explicit rank guard that the five affected functions are missing:

```cpp
if (input_info.shape.size() != 4 || filter_info.shape.size() != 4 ||
    output_info.shape.size() != 4) {
    return absl::InvalidArgumentError(...);
}
```

Fix: add equivalent rank size checks before the first shape subscript in each affected function — `size() < 3` for AveragePool2D and MaxPool2D (which only need indices 1 and 2), `size() != 4` for Conv2D and DepthwiseConv2D (input + filter), and `size() != 4` for all three tensors in TransposeConv2D.