### PR TITLE
litert/xnnpack: guard against empty axis buffer in SplitOperation::ToXnnpack()

### DIFF
--- a/litert/tensor/backends/xnnpack/arithmetic.cc
+++ b/litert/tensor/backends/xnnpack/arithmetic.cc
@@ -1815,6 +1815,10 @@ absl::Status OpMixin<SplitOperation, XnnpackMixinTag>::ToXnnpack(
         absl::StrFormat("%s: axis must be a constant tensor", op_name));
   }
   auto locked_axis = axis_info.buffer->Lock().As<const int32_t>();
+  if (locked_axis.size() == 0) {
+    return absl::InvalidArgumentError(
+        absl::StrFormat("%s: axis tensor buffer must not be empty", op_name));
+  }
   int real_axis = locked_axis.data()[0];
 
   LRT_TENSOR_ASSIGN_OR_RETURN(const auto& input_info, graph::GetInfo(input));


### PR DESCRIPTION
`axis_info.buffer != nullptr` only verifies that the Buffer object exists, not that it contains data. A TFLite flatbuffer can declare a constant tensor with a non-null Buffer entry but zero bytes — valid per the schema. `buffer->Lock().As<const int32_t>()` then returns a `LockedBufferSpan` with a null data pointer (`LockedBufferSpan::Empty()` in `litert/tensor/buffer.h:72` explicitly sets `data = nullptr` when byte count is zero), and `locked_axis.data()[0]` dereferences null → SIGSEGV during XNNPACK subgraph compilation at model load time.

`ExpandDimsOperation::ToXnnpack()` (lines 1203–1208) in the same file performs the identical buffer lock and already includes the missing guard:

```cpp
if (locked_axis.size() == 0) {
    return absl::InvalidArgumentError(...);
}
```

Fix: add the same `locked_axis.size() == 0` check to `SplitOperation::ToXnnpack()` immediately after the buffer lock.