### PR TITLE
subgraph: reject zero axes_count in fuse_dims (out-of-bounds shape write)

### DIFF
--- a/src/subgraph/copy.c
+++ b/src/subgraph/copy.c
@@ -572,6 +572,13 @@ enum xnn_status xnn_define_static_expand_dims(
 enum xnn_status xnn_define_fuse_dims(
     xnn_subgraph_t subgraph, size_t axis, size_t axes_count,
     uint32_t input_id, uint32_t output_id, uint32_t flags) {
+  if (axes_count == 0) {
+    xnn_log_error(
+        "failed to define %s operator with %zu axes_count: axes_count must "
+        "be non-zero",
+        xnn_node_type_to_string(xnn_node_type_fuse_dims), axes_count);
+    return xnn_status_invalid_parameter;
+  }
   if (axis > XNN_MAX_TENSOR_DIMS || axes_count > XNN_MAX_TENSOR_DIMS ||
       axis + axes_count > XNN_MAX_TENSOR_DIMS) {
     xnn_log_error(
@@ -596,6 +603,13 @@ enum xnn_status xnn_define_split_dim(xnn_subgraph_t subgraph,
                                              uint32_t input_id,
                                              uint32_t output_id,
                                              uint32_t flags) {
+  if (num_splits == 0) {
+    xnn_log_error(
+        "failed to define %s operator with %zu num_splits: num_splits must "
+        "be non-zero",
+        xnn_node_type_to_string(xnn_node_type_split_dims), num_splits);
+    return xnn_status_invalid_parameter;
+  }
   if (axis > XNN_MAX_TENSOR_DIMS || num_splits > XNN_MAX_TENSOR_DIMS ||
       axis + num_splits > XNN_MAX_TENSOR_DIMS) {
     xnn_log_error(


### PR DESCRIPTION
### Summary
`xnn_define_fuse_dims()` validated `axis` / `axes_count` against `XNN_MAX_TENSOR_DIMS` but never rejected `axes_count == 0`, unlike its siblings `xnn_define_static_reduce` (rejects `num_reduction_axes == 0`) and `xnn_define_static_transpose` (rejects `num_dims == 0`).

### Bug
With `axes_count == 0` and a rank-`XNN_MAX_TENSOR_DIMS` (6) input, `resize_fuse_dims_output_tensor()` in `src/subgraph/copy.c` runs

```c
output_shape->dim[k - num_dims + 1] = input_shape->dim[k];
```

with `num_dims == 0`, so at `k == 5` it writes `output->shape.dim[6]` — one past the 6-element `dim[]` array (a heap out-of-bounds write) — and then sets `num_dims = 6 - 0 + 1 = 7` (`> 6`), driving further out-of-bounds reads.

### Fix
Add the same non-zero guard (`xnn_log_error` + `xnn_status_invalid_parameter`) the reduce / transpose siblings already use to `xnn_define_fuse_dims`. I also added the analogous `num_splits == 0` guard to `xnn_define_split_dim`, which was missing the same check — there it yields an incorrect result rather than an OOB write.

### Verification
A full XNNPACK build was not possible in my environment (RAM-constrained), so I did **not** run the full test suite. What I did verify:
- The added guards match the `xnn_define_static_reduce` / `xnn_define_static_transpose` pattern (same log message shape + `xnn_status_invalid_parameter` return).
- An isolated AddressSanitizer harness that replicates only the `resize_fuse_dims_output_tensor` shape arithmetic on a heap-allocated rank-6 `xnn_shape`: with `axes_count == 0` the pre-fix arithmetic reports `heap-buffer-overflow` **WRITE** "0 bytes after 56-byte region" at the `output->dim[k - num_dims + 1]` store (i.e. `dim[6]`), while the added define-time guard returns `xnn_status_invalid_parameter` so that arithmetic is never reached.

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
