### PR TITLE
subgraph: fix two constant-propagation miscompilations (reciprocal_square_root, modulus)

### DIFF
--- a/src/subgraph.c
+++ b/src/subgraph.c
@@ -3350,6 +3350,13 @@ static void propagate_constants(xnn_subgraph_t subgraph, uint32_t node_id) {
           break;
 
         case xnn_binary_modulus:
+          // fmod(0, b) == 0, but fmod(1, b) is not 1 in general (e.g. fmod(1,1)==0),
+          // so modulus preserves only zeros, unlike prelu below.
+          if (a_is_zero) {
+            output_value->flags |= XNN_VALUE_FLAG_IS_ZERO;
+          }
+          break;
+
         case xnn_binary_prelu:
           if (a_is_zero) {
             output_value->flags |= XNN_VALUE_FLAG_IS_ZERO;

--- a/src/subgraph.c
+++ b/src/subgraph.c
@@ -3210,7 +3210,7 @@ static void propagate_constants(xnn_subgraph_t subgraph, uint32_t node_id) {
 
         // The following ops preserve only ones.
         case xnn_unary_reciprocal_square_root:
-          output_value->flags |= (input_value->flags & XNN_VALUE_FLAG_IS_ZERO);
+          output_value->flags |= (input_value->flags & XNN_VALUE_FLAG_IS_ONE);
           break;
 
         // The following ops flip zeros to ones.


### PR DESCRIPTION
## Problem

In `propagate_constants()` (`src/subgraph.c`), `reciprocal_square_root` sits under the comment **"The following ops preserve only ones"**, but the code copies the input's `XNN_VALUE_FLAG_IS_ZERO` onto the output:

```c
// The following ops preserve only ones.
case xnn_unary_reciprocal_square_root:
  output_value->flags |= (input_value->flags & XNN_VALUE_FLAG_IS_ZERO);
  break;
```

This is inverted. `rsqrt(1) = 1` (one-preserving), and `rsqrt(0) = 1/sqrt(0)` is **not** zero — yet the output of `rsqrt` applied to a constant `0.0` is flagged `IS_ZERO`. Since `xnn_value_is_const()` treats `IS_ZERO` as a constant scalar `0`, `optimize_common_subgraphs_min_max_to_clamp()` then reads that operand as `0.0f` and rewrites `maximum(x, rsqrt(0))` into `clamp(x, [0, +inf)) = relu(x)` — a silent miscompilation of a legal graph. The false flag also propagates through `mul`/`add` constant-folding. The pass is on by default (`xnn_create_runtime`, unless `XNN_FLAG_SLOW_CONSISTENT_ARITHMETIC` / `XNN_FLAG_NO_OPERATOR_FUSION` is set).

## Fix

Mask `XNN_VALUE_FLAG_IS_ONE`, matching the comment (`rsqrt` is one-preserving, not zero-preserving).

## Testing

Built `libXNNPACK` and ran a subgraph `out = maximum(x, reciprocal_square_root(z))` with `z` a static constant `0.0` and `x = {-3, -1, 0, 2, 5}`:

- **Before:** `out = {0, 0, 0, 2, 5}` — the optimizer folded `maximum(x, rsqrt(0))` into `relu(x)`, silently dropping the `rsqrt` operand.
- **After:** the incorrect fold no longer happens (`min_max_to_clamp` no longer sees the `rsqrt` output as a constant zero), so the runtime evaluates the actual graph.

`rsqrt(0.0) = +inf`, `rsqrt(1.0) = 1.0` (confirmed numerically), so the operand is one-preserving; the fold to `relu(x)` was the miscompilation.

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
