### PR TITLE
litert/xnnpack: guard against 0D scalar weights tensor in RopeOperation::ToXnnpack()

### DIFF
--- a/litert/tensor/backends/xnnpack/arithmetic.cc
+++ b/litert/tensor/backends/xnnpack/arithmetic.cc
@@ -1854,6 +1854,10 @@ absl::Status OpMixin<RopeOperation, XnnpackMixinTag>::ToXnnpack(
 
   LRT_TENSOR_ASSIGN_OR_RETURN(const auto& weights_info,
                               graph::GetInfo(op.inputs[1]));
+  if (weights_info.shape.empty()) {
+    return absl::InvalidArgumentError(
+        absl::StrFormat("%s: weights tensor must not be a 0D scalar", op_name));
+  }
   size_t max_tokens = weights_info.shape[0];
   LRT_TENSOR_RETURN_IF_ERROR(xnn_define_rope(ctx.subgraph(), max_tokens,
                                              input_id, weights_id, output_id,


### PR DESCRIPTION
## Problem

`RopeOperation::ToXnnpack()` in `litert/tensor/backends/xnnpack/arithmetic.cc` reads `weights_info.shape[0]` without checking whether the shape vector is empty:

```cpp
LRT_TENSOR_ASSIGN_OR_RETURN(const auto& weights_info,
                            graph::GetInfo(op.inputs[1]));
size_t max_tokens = weights_info.shape[0];   // crash if weights is 0D scalar
```

A crafted TFLite model that declares the Rope weights tensor as a 0D scalar (shape `[]`) produces an empty `std::vector<int32_t>`. `operator[](0)` on an empty vector dereferences the vector's null internal pointer → SIGSEGV during XNNPACK subgraph compilation at model load time, before any inference runs.

## Fix

Add an explicit `shape.empty()` guard before the `shape[0]` access, matching the pattern already used in `ExpandDimsOperation::ToXnnpack()` and the `keep_dims == true` branch of `Mean()` in `litert/tensor/arithmetic.h`.

```cpp
if (weights_info.shape.empty()) {
  return absl::InvalidArgumentError(
      absl::StrFormat("%s: weights tensor must not be a 0D scalar", op_name));
}
size_t max_tokens = weights_info.shape[0];
```