### PR TITLE
litert/xnnpack: validate scale array size against channel/block count in DefineValue()

### DIFF
--- a/litert/tensor/backends/xnnpack/conversion.cc
+++ b/litert/tensor/backends/xnnpack/conversion.cc
@@ -505,6 +505,10 @@ absl::StatusOr<uint32_t> XnnpackBuildContext::DefineValue(
           info.name,
           ": blockwise quantized tensor requires at least 2 dimensions"));
     }
+    if (bwq.block_size == 0) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          info.name, ": blockwise quantized tensor block_size must be > 0"));
+    }
     const size_t expected_block_count =
         dims[0] * dims[1] / bwq.block_size;
     if (bwq.scales.size() < expected_block_count) {

--- a/litert/tensor/backends/xnnpack/conversion.cc
+++ b/litert/tensor/backends/xnnpack/conversion.cc
@@ -478,12 +478,14 @@ absl::StatusOr<uint32_t> XnnpackBuildContext::DefineValue(
             value.flags, &value.id))
             << "Could not define a new tensor value after dequantization.";
       } else {
-        if (pcq.quantized_dimension >= dims.size() ||
+        if (pcq.quantized_dimension < 0 ||
+            static_cast<size_t>(pcq.quantized_dimension) >= dims.size() ||
             pcq.scales.size() < dims[pcq.quantized_dimension]) {
           return absl::InvalidArgumentError(absl::StrCat(
               info.name, ": per-channel scale count (", pcq.scales.size(),
               ") is smaller than the channel dimension size (",
-              pcq.quantized_dimension < dims.size()
+              pcq.quantized_dimension >= 0 &&
+                      static_cast<size_t>(pcq.quantized_dimension) < dims.size()
                   ? dims[pcq.quantized_dimension]
                   : static_cast<size_t>(0),
               ")"));

--- a/litert/tensor/backends/xnnpack/conversion.cc
+++ b/litert/tensor/backends/xnnpack/conversion.cc
@@ -478,6 +478,16 @@ absl::StatusOr<uint32_t> XnnpackBuildContext::DefineValue(
             value.flags, &value.id))
             << "Could not define a new tensor value after dequantization.";
       } else {
+        if (pcq.quantized_dimension >= dims.size() ||
+            pcq.scales.size() < dims[pcq.quantized_dimension]) {
+          return absl::InvalidArgumentError(absl::StrCat(
+              info.name, ": per-channel scale count (", pcq.scales.size(),
+              ") is smaller than the channel dimension size (",
+              pcq.quantized_dimension < dims.size()
+                  ? dims[pcq.quantized_dimension]
+                  : static_cast<size_t>(0),
+              ")"));
+        }
         LRT_TENSOR_RETURN_IF_ERROR(
             xnn_define_channelwise_quantized_tensor_value_v3(
                 subgraph_, GetXnnpackType(value), /*zero_point=*/0,
@@ -490,6 +500,18 @@ absl::StatusOr<uint32_t> XnnpackBuildContext::DefineValue(
   } else if (auto maybe_bwq = info.quantization->As<BlockwiseQuantization>();
              maybe_bwq.ok()) {
     const auto& bwq = maybe_bwq.value();
+    if (dims.size() < 2) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          info.name,
+          ": blockwise quantized tensor requires at least 2 dimensions"));
+    }
+    const size_t expected_block_count =
+        dims[0] * dims[1] / bwq.block_size;
+    if (bwq.scales.size() < expected_block_count) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          info.name, ": blockwise scale count (", bwq.scales.size(),
+          ") is smaller than block_count (", expected_block_count, ")"));
+    }
     fp16_buffers_.emplace_back(bwq.scales.begin(), bwq.scales.end());
     const void* scale_ptr = fp16_buffers_.back().data();
     int32_t zero_point = bwq.zero_points.empty() ? 0 : bwq.zero_points[0];


### PR DESCRIPTION
`DefineValue()` in `litert/tensor/backends/xnnpack/conversion.cc` passes caller-supplied scale arrays to XNNPACK without checking that the array is large enough for the tensor's channel or block count.

**Channelwise path**: `pcq.scales.size()` was never checked against `dims[pcq.quantized_dimension]`. `xnn_validate_channelwise_quantized_tensor` then loops `dims[channel_dim]` times reading `scale[channel]`, causing an
out-of-bounds heap read when the scale array is shorter than the channel dimension - reachable from a crafted flatbuffer at model-load time.

**Blockwise path**: `bwq.scales.size()` was never checked against `dims[0] * dims[1] / block_size`. `xnn_define_blockwise_quantized_tensor_value_v2` loops `block_count` times reading the fp16 scale array, causing an
out-of-bounds heap read when the scale array is shorter than `block_count` - also reachable from a crafted flatbuffer at model-load time.

Fix: add explicit size checks before both calls and return `InvalidArgumentError` on mismatch.