### PR TITLE
Fix PowerPC hardware detection on FreeBSD

### DIFF
--- a/src/configs/hardware-config.c
+++ b/src/configs/hardware-config.c
@@ -47,6 +47,10 @@
 
 #if XNN_ARCH_PPC64
   #include <sys/auxv.h>
+  #if defined(__FreeBSD__)
+    #include <machine/cpu.h>
+  #endif
+
 #endif
 
 #if XNN_ARCH_WASM || XNN_ARCH_WASMSIMD || XNN_ARCH_WASMRELAXEDSIMD
@@ -357,8 +361,15 @@ static void init_hardware_config(void) {
   #endif
 
   #if XNN_ARCH_PPC64
-    const unsigned long HWCAPs = getauxval(AT_HWCAP);
-    const unsigned long HWCAPs_2 = getauxval(AT_HWCAP2);
+    #if defined(__FreeBSD__)
+      unsigned long HWCAPs = 0, HWCAPs_2 = 0;
+      elf_aux_info(AT_HWCAP, &HWCAPs, sizeof(HWCAPs));
+      elf_aux_info(AT_HWCAP2, &HWCAPs_2, sizeof(HWCAPs_2));
+    #else
+      const unsigned long HWCAPs = getauxval(AT_HWCAP);
+      const unsigned long HWCAPs_2 = getauxval(AT_HWCAP2);
+    #endif
+
     if (HWCAPs & PPC_FEATURE_HAS_VSX) {
       set_arch_flag(xnn_arch_vsx, 1);
     }


### PR DESCRIPTION
The XNN_ARCH_PPC64 branch of xnn_init_hardware_config() uses getauxval() and the PPC_FEATURE_* constants, both of which are Linux-only spellings.

FreeBSD has no getauxval(); the equivalent is elf_aux_info(), declared in the <sys/auxv.h> that is already included here.  The PPC_FEATURE_HAS_VSX, PPC_FEATURE2_ARCH_3_1 and PPC_FEATURE2_MMA constants live in <machine/cpu.h> rather than in <sys/auxv.h>.

Without this, a FreeBSD/powerpc64 build fails with

  error: use of undeclared identifier 'PPC_FEATURE_HAS_VSX'

and, less visibly, a call to an undeclared getauxval() that would only have surfaced as an undefined symbol at link time.

Found while building TensorFlow on FreeBSD/powerpc64le.