### PR TITLE
subgraph: validate filter shape dims[1..3] in conv/deconv/depthwise-conv

### DIFF
--- a/src/subgraph/convolution-2d.c
+++ b/src/subgraph/convolution-2d.c
@@ -1295,14 +1295,21 @@ enum xnn_status xnn_define_convolution_2d(
     return status;
   }
 
-  if (filter_value->shape.dim[0] != group_output_channels * groups) {
+  if (filter_value->shape.num_dims != 4 ||
+      filter_value->shape.dim[0] != group_output_channels * groups ||
+      filter_value->shape.dim[1] != kernel_height ||
+      filter_value->shape.dim[2] != kernel_width ||
+      filter_value->shape.dim[3] != group_input_channels) {
     xnn_log_error(
-        "failed to define %s operator with filter output channels %zu, groups "
-        "#%" PRIu32
-        " and group_output_channels %zu:mismatching shapes, filter output "
-        "channels must be equal to groups * group_output_channels.",
-        xnn_node_type_to_string(xnn_node_type_convolution_2d),
-        filter_value->shape.dim[0], groups, group_output_channels);
+        "failed to define %s operator with filter ID #%" PRIu32
+        ": filter shape must be [groups * group_output_channels=%zu, "
+        "kernel_height=%" PRIu32 ", kernel_width=%" PRIu32
+        ", group_input_channels=%zu], but got shape [%zu, %zu, %zu, %zu]",
+        xnn_node_type_to_string(xnn_node_type_convolution_2d), filter_id,
+        group_output_channels * groups, kernel_height, kernel_width,
+        group_input_channels, filter_value->shape.dim[0],
+        filter_value->shape.dim[1], filter_value->shape.dim[2],
+        filter_value->shape.dim[3]);
     return xnn_status_invalid_parameter;
   }
 

--- a/src/subgraph/deconvolution-2d.c
+++ b/src/subgraph/deconvolution-2d.c
@@ -971,6 +971,24 @@ enum xnn_status xnn_define_deconvolution_2d(
     }
   }
 
+  if (filter_value->shape.num_dims != 4 ||
+      filter_value->shape.dim[0] != group_output_channels * groups ||
+      filter_value->shape.dim[1] != kernel_height ||
+      filter_value->shape.dim[2] != kernel_width ||
+      filter_value->shape.dim[3] != group_input_channels) {
+    xnn_log_error(
+        "failed to define %s operator with filter ID #%" PRIu32
+        ": filter shape must be [groups * group_output_channels=%zu, "
+        "kernel_height=%" PRIu32 ", kernel_width=%" PRIu32
+        ", group_input_channels=%zu], but got shape [%zu, %zu, %zu, %zu]",
+        xnn_node_type_to_string(xnn_node_type_deconvolution_2d), filter_id,
+        group_output_channels * groups, kernel_height, kernel_width,
+        group_input_channels, filter_value->shape.dim[0],
+        filter_value->shape.dim[1], filter_value->shape.dim[2],
+        filter_value->shape.dim[3]);
+    return xnn_status_invalid_parameter;
+  }
+
   struct xnn_node* node = xnn_subgraph_new_node(subgraph);
   if (node == NULL) {
     return xnn_status_out_of_memory;

--- a/src/subgraph/depthwise-convolution-2d.c
+++ b/src/subgraph/depthwise-convolution-2d.c
@@ -1011,6 +1011,25 @@ enum xnn_status xnn_define_depthwise_convolution_2d(
     }
   }
 
+  if (filter_value->shape.num_dims != 4 ||
+      filter_value->shape.dim[0] != 1 ||
+      filter_value->shape.dim[1] != kernel_height ||
+      filter_value->shape.dim[2] != kernel_width ||
+      filter_value->shape.dim[3] != input_channels * depth_multiplier) {
+    xnn_log_error(
+        "failed to define %s operator with filter ID #%" PRIu32
+        ": filter shape must be [1, kernel_height=%" PRIu32
+        ", kernel_width=%" PRIu32
+        ", input_channels * depth_multiplier=%zu], but got shape [%zu, %zu, "
+        "%zu, %zu]",
+        xnn_node_type_to_string(xnn_node_type_depthwise_convolution_2d),
+        filter_id, kernel_height, kernel_width,
+        input_channels * depth_multiplier, filter_value->shape.dim[0],
+        filter_value->shape.dim[1], filter_value->shape.dim[2],
+        filter_value->shape.dim[3]);
+    return xnn_status_invalid_parameter;
+  }
+
   struct xnn_node* node = xnn_subgraph_new_node(subgraph);
   if (node == NULL) {
     return xnn_status_out_of_memory;

--- a/test/subgraph/subgraph-fp16.cc
+++ b/test/subgraph/subgraph-fp16.cc
@@ -431,7 +431,7 @@ TEST(SUBGRAPH_FP16, convolution_weights_used_by_another_node) {
       .AddOutputTensorF32({1, 5, 5, 2}, convolution_out_id)
       .AddInputTensorF32({1, 4, 2, 3}, subtract_input_id)
       .AddOutputTensorF32({2, 1, 1, 3}, out_id2)
-      .AddConvolution2D(ConvolutionParams{Padding{0, 0, 0, 0}, Kernel{3, 3},
+      .AddConvolution2D(ConvolutionParams{Padding{0, 0, 0, 0}, Kernel{1, 1},
                                           Subsampling{1, 1}, Dilation{1, 1},
                                           /*groups=*/1,
                                           /*group_input_channels=*/3,
@@ -508,7 +508,7 @@ TEST(SUBGRAPH_FP16, convolution_bias_used_by_another_node) {
       .AddOutputTensorF32({1, 5, 5, 2}, convolution_out_id)
       .AddInputTensorF32({2}, subtract_input_id)
       .AddOutputTensorF32({2}, out_id2)
-      .AddConvolution2D(ConvolutionParams{Padding{0, 0, 0, 0}, Kernel{3, 3},
+      .AddConvolution2D(ConvolutionParams{Padding{0, 0, 0, 0}, Kernel{1, 1},
                                           Subsampling{1, 1}, Dilation{1, 1},
                                           /*groups=*/1,
                                           /*group_input_channels=*/3,

--- a/test/subgraph/subgraph-nchw.cc
+++ b/test/subgraph/subgraph-nchw.cc
@@ -128,7 +128,7 @@ TEST(SUBGRAPH_NCHW, bottleneck) {
       .AddStaticTensorF32({1, 3, 3, 4}, TensorType::kDense, 7)
       .AddStaticTensorF32({4}, TensorType::kDense, 8)
       .AddDynamicTensorF32({1, 128, 128, 4}, 9)
-      .AddStaticTensorF32({4, 1, 1, 4}, TensorType::kSparse, 10)
+      .AddStaticTensorF32({4, 1, 1, 8}, TensorType::kSparse, 10)
       .AddStaticTensorF32({8}, TensorType::kDense, 11)
       .AddDynamicTensorF32({1, 128, 128, 8}, 12)
       .AddDynamicTensorF32({1, 128, 128, 8}, 13)


### PR DESCRIPTION
# subgraph: validate filter shape dims[1..3] in conv/deconv/depthwise-conv

## Summary

`xnn_define_convolution_2d` validated only `filter_value->shape.dim[0]` (== `group_output_channels * groups`) but not `dim[1]`, `dim[2]`, `dim[3]` against `kernel_height`, `kernel_width`, and `group_input_channels`. When a filter tensor is declared with dims[1..3] smaller than the convolution's kernel parameters, weight packing (`xnn_pack_f32_conv_goki_w`) reads `nc * ks * kc` elements from the filter buffer — where `ks = kernel_height * kernel_width` comes from the convolution parameters, not the filter's declared shape — causing a heap out-of-bounds read during `xnn_create_runtime_v2`.

`xnn_define_deconvolution_2d` and `xnn_define_depthwise_convolution_2d` had **no filter shape validation at all** (not even dim[0]).

This PR adds full 4D filter shape validation to all three operators, rejecting mismatched shapes at define-time with `xnn_status_invalid_parameter`.

## Root Cause

Filter shape layout (NHWC convention):
- Conv/Deconv: `[groups * group_output_channels, kernel_height, kernel_width, group_input_channels]`
- Depthwise: `[1, kernel_height, kernel_width, input_channels * depth_multiplier]`

Weight packing reads `nc * ks * kc` floats from the filter buffer, where:
- `nc` = group_output_channels (from conv params)
- `ks` = kernel_height * kernel_width (from conv params)
- `kc` = group_input_channels (from conv params)

The packed-weights destination buffer is sized from convolution parameters (safe — no OOB write), but the **source** filter buffer is sized from the declared filter shape. When dims[1..3] are smaller than the conv params, the read overflows the filter buffer.

## PoC

Filter declared as `{32, 3, 3, 3}` = 864 floats. Convolution defined with `kernel_height=5, kernel_width=5, group_input_channels=3, group_output_channels=32, groups=1`. The dim[0] check passed (32 == 32 * 1). Weight packing reads `32 * 25 * 3 = 2400` floats from the 864-float buffer → **1536-float (6144-byte) heap OOB read**.

### ASan output (before fix, HEAD 6c48650)

```
==51790==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x61f000000e90
READ of size 4 at 0x61f000000e90 thread T0
    #0 __asan_memmove+0x2a4
    #1 xnn_pack_f32_conv_goki_w packing.cc:3553
    #2 create_igemm convolution-nhwc.c:452
    #3 create_convolution2d_nhwc convolution-nhwc.c:806
    #4 xnn_create_convolution2d_nhwc_pf32 convolution-nhwc.c:2559
    #5 create_convolution_operator convolution-2d.c:261
    #6 xnn_create_runtime_v4 runtime.c:727
    #7 xnn_create_runtime_v2 runtime.c:219

0x61f000000e90 is located 144 bytes after 3456-byte region [0x61f000000080,0x61f000000e00)
SUMMARY: AddressSanitizer: heap-buffer-overflow in xnn_pack_f32_conv_goki_w packing.cc:3553
```

### After fix

```
[*] calling xnn_define_convolution_2d (kernel 5x5, filter shape {32,3,3,3})...
xnn_define_convolution_2d failed: 2  (xnn_status_invalid_parameter)
```

Bug blocked at define-time, no crash at runtime.

## Testing

- `convolution-2d-test`: 11/11 PASSED
- `deconvolution-2d-test`: 8/8 PASSED
- `depthwise-convolution-2d-test`: 8/8 PASSED

Built with `-fsanitize=address -g -O1`, all tests pass under ASan.

Fixes #11118
