### PR TITLE
litert/tensor/arithmetic.h: bounds-check Split axis against input rank

### DIFF
--- a/litert/tensor/arithmetic.h
+++ b/litert/tensor/arithmetic.h
@@ -1554,6 +1554,11 @@ std::vector<Tensor<Mixins...>> Split(
     axis_val += input_info.shape.size();
   }
 
+  if (axis_val < 0 || static_cast<size_t>(axis_val) >= input_info.shape.size()) {
+    return {Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
+        "The Split axis is out of range.")))};
+  }
+
   if (input_info.shape[axis_val] % num_splits != 0) {
     return {Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
         "Number of splits must evenly divide the dimension.")))};


### PR DESCRIPTION
After negative-axis normalisation, `axis_val` was used directly as a subscript into `input_info.shape` (OOB read at line 1557) and `output_shape` (OOB write at line 1563) without checking that it is within `[0, input rank)`.

A model that supplies an axis value ≥ input rank triggers `std::vector::operator[]` past the end of the heap-allocated shape vector. The read returns undefined data; the write corrupts heap memory at an attacker-controlled offset before any crash occurs.

The sibling `ExpandDims()` already guards its axis with the equivalent check (line 662), and `SplitOperation::ToXnnpack()` in `arithmetic.cc` validates `real_axis` before passing it to `xnn_define_even_split()` (lines 1825–1827). This aligns `Split()` to the same pattern.