### PR TITLE
litert/tensor/arithmetic.h: guard Select() against null deref when a/b are rank-0

### DIFF
--- a/litert/tensor/arithmetic.h
+++ b/litert/tensor/arithmetic.h
@@ -1856,6 +1856,7 @@ Tensor<Mixins...> Select(Tensor<Mixins...> condition, Tensor<Mixins...> a,
   // first dimension of the inputs, or match the inputs completely.
   if (condition_info.shape != a_info.shape) {
     if (condition_info.shape.size() != 1 ||
+        a_info.shape.empty() ||
         condition_info.shape[0] != a_info.shape[0]) {
       return Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
           absl::StrCat("Shape of condition must match a and b or be 1D with "


### PR DESCRIPTION
## Problem

`Select()` in `litert/tensor/arithmetic.h` accesses `a_info.shape[0]` without checking whether `a_info.shape` is empty. When a model provides rank-0 (scalar) `a` and `b` tensors alongside a 1-D `condition` tensor, the check at line 1858:

```cpp
if (condition_info.shape.size() != 1 ||
    condition_info.shape[0] != a_info.shape[0]) {
```

evaluates the right-hand operand with `a_info.shape` empty. On libstdc++ and libc++, `std::vector<int>{}.data()` is null; `operator[](0)` dereferences it → **SIGSEGV at graph-build time**.

Trigger:
- `condition` shape = `[N]` (1-D)
- `a` and `b` shapes = `[]` (rank-0 scalar)

Line 1849 passes (both `[]` match). Line 1857 enters the branch (`[N] != []`). Line 1858: `size() != 1` is false → right-hand side evaluated → crash.

## Fix

Add `a_info.shape.empty()` guard before the subscript:

```cpp
if (condition_info.shape.size() != 1 ||
    a_info.shape.empty() ||
    condition_info.shape[0] != a_info.shape[0]) {
```

This matches the existing pattern used in `RopeOperation::ToXnnpack()` and other sites that guard against rank-0 tensors before shape subscripting.