### PR TITLE
[Security] Fix integer overflow in slice-nd reshape strides

### DIFF
--- a/src/operators/slice-nd.c
+++ b/src/operators/slice-nd.c
@@ -16,6 +16,7 @@
 #include "src/xnnpack/config-types.h"
 #include "src/xnnpack/config.h"
 #include "src/xnnpack/log.h"
+#include "src/xnnpack/math.h"
 #include "src/xnnpack/normalization.h"
 #include "src/xnnpack/operator-type.h"
 #include "src/xnnpack/operator-utils.h"
@@ -213,8 +214,18 @@ static enum xnn_status reshape_slice_nd(
   for (size_t i = 1; i < XNN_MAX_TENSOR_DIMS; i++) {
     slice_op->context.slice.input_stride[i - 1] = input_stride << log2_element_size;
     slice_op->context.slice.output_stride[i - 1] = output_stride << log2_element_size;
-    input_stride *= normalized_input_shape[XNN_MAX_TENSOR_DIMS - 1 - i];
-    output_stride *= normalized_output_shape[XNN_MAX_TENSOR_DIMS - 1 - i];
+    if (!xnn_safe_mul(input_stride, normalized_input_shape[XNN_MAX_TENSOR_DIMS - 1 - i], &input_stride)) {
+      xnn_log_error(
+        "failed to reshape %s operator: input stride overflow at dimension %zu",
+        xnn_operator_type_to_string_v2(slice_op), i);
+      return xnn_status_invalid_parameter;
+    }
+    if (!xnn_safe_mul(output_stride, normalized_output_shape[XNN_MAX_TENSOR_DIMS - 1 - i], &output_stride)) {
+      xnn_log_error(
+        "failed to reshape %s operator: output stride overflow at dimension %zu",
+        xnn_operator_type_to_string_v2(slice_op), i);
+      return xnn_status_invalid_parameter;
+    }
   }
   slice_op->context.slice.contiguous_size = normalized_output_shape[XNN_MAX_TENSOR_DIMS - 1] << log2_element_size;
 


### PR DESCRIPTION
`reshape_slice_nd()` builds input/output strides with unguarded `size_t` multiplies. On overflow the stored strides wrap, so setup can advance the input pointer past a buffer sized from the wrapping product of the same dims.

This applies `xnn_safe_mul()` and returns `xnn_status_invalid_parameter` on overflow, matching the depth-to-space hardening in PR #10990.

Reported privately via Google OSS VRP; opening this PR at the program's request so the merged-patch acceptance criterion can be met.