### PR TITLE
litert/xnnpack: reject negative begin-tensor shape dimension in SliceOperation::ToXnnpack()

### DIFF
--- a/litert/tensor/backends/xnnpack/arithmetic.cc
+++ b/litert/tensor/backends/xnnpack/arithmetic.cc
@@ -924,9 +924,11 @@ absl::Status OpMixin<SliceOperation, XnnpackMixinTag>::ToXnnpack(
   auto begin_locked = begin_info.buffer->Lock();
   const int32_t* begin_data =
       reinterpret_cast<const int32_t*>(begin_locked.data());
-  if (begin_info.shape.empty()) {
-    return absl::InvalidArgumentError(
-        absl::StrFormat("%s: begin tensor must not be a 0D scalar", op_name));
+  if (begin_info.shape.empty() || begin_info.shape[0] <= 0) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "%s: begin tensor must be a 1D tensor with a positive dimension; "
+        "got shape[0] = %d",
+        op_name, begin_info.shape.empty() ? 0 : begin_info.shape[0]));
   }
   size_t num_dims = begin_info.shape[0];
 


### PR DESCRIPTION
## Problem

PR #11056 added a guard for the 0D scalar case (`begin_info.shape.empty()`). A 1D begin tensor whose sole dimension is **negative** (e.g. `-1`, valid in the flatbuffer format as a dynamic/unknown size marker) bypasses that guard:

```cpp
if (begin_info.shape.empty()) { ... }   // shape = [-1] → NOT empty, bypassed
size_t num_dims = begin_info.shape[0];  // -1 (int32_t) → SIZE_MAX (size_t)

std::vector<size_t> offsets(num_dims); // requests SIZE_MAX elements → abort
std::vector<size_t> sizes(num_dims);   // same
```

`shape[0] = -1` wraps to `SIZE_MAX` on the implicit `int32_t → size_t` conversion. Both vector constructors then request `SIZE_MAX` elements, exceeding `max_size()` and causing an unconditional abort at model-load time - before any inference occurs.

## Fix

Extend the existing guard to also reject `shape[0] <= 0`:

```cpp
if (begin_info.shape.empty() || begin_info.shape[0] <= 0) {
  return absl::InvalidArgumentError(...);
}
```