### PR TITLE
Fix -Wundef error and dead Hexagon guard in xnnpack.h

### DIFF
--- a/include/xnnpack.h
+++ b/include/xnnpack.h
@@ -21,6 +21,18 @@
 extern "C" {
 #endif
 
+// XNN_ARCH_HEXAGON is also defined by src/xnnpack/common.h, but that is an
+// internal header and is not installed. Define it here as well, deriving it from the same compiler builtin
+// so both expansions are identical. If common.h is included first this block is
+// skipped. Keep the two in sync.
+#ifndef XNN_ARCH_HEXAGON
+#if defined(__hexagon__)
+#define XNN_ARCH_HEXAGON 1
+#else
+#define XNN_ARCH_HEXAGON 0
+#endif
+#endif  // XNN_ARCH_HEXAGON
+
 /// The number of bytes XNNPACK may read beyond array bounds.
 /// The caller must allocate at least this many extra bytes after the tensor data passed to XNNPACK.
 ///


### PR DESCRIPTION
Consumers compiling the public header with -Wundef -Werror fail on any architecture:

  error: 'XNN_ARCH_HEXAGON' is not defined, evaluates to 0
  [-Werror,-Wundef]  #if XNN_ARCH_HEXAGON

XNN_ARCH_HEXAGON is defined only in src/xnnpack/common.h, an internal header xnnpack.h cannot include, so the guard tested an undefined macro and the 128-byte value never took effect. HVX vectors are 1024-bit: a full-width load can read up to 128 bytes past a tensor callers padded by 16.

Deriving from __hexagon__ keeps the internal header internal, and both definitions expand identically so neither redefinition warns.