### PR TITLE
litert/tensor: guard FullyConnected, EmbeddingLookup, GatherNd against rank-0 input tensors

### DIFF
--- a/litert/tensor/arithmetic.h
+++ b/litert/tensor/arithmetic.h
@@ -1149,6 +1149,14 @@ Tensor<Mixins...> FullyConnected(
   const graph::TensorInformation& input_info = *GetInfo(input.GetRaw());
   const graph::TensorInformation& weights_info = *GetInfo(weights.GetRaw());
   graph::TensorInformation& output_info = *GetInfo(output.GetRaw());
+  if (input_info.shape.empty()) {
+    return Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
+        "FullyConnected input must have rank >= 1.")));
+  }
+  if (weights_info.shape.empty()) {
+    return Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
+        "FullyConnected weights must have rank >= 1.")));
+  }
   if (keep_num_dims) {
     output_info.shape = input_info.shape;
     output_info.shape.back() = weights_info.shape[0];
@@ -1966,6 +1974,10 @@ Tensor<Mixins...> EmbeddingLookup(
 
   output_info.type = output_type;
 
+  if (value_info.shape.empty()) {
+    return Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
+        "EmbeddingLookup value must have rank >= 1.")));
+  }
   output_info.shape = ids_info.shape;
   output_info.shape.push_back(value_info.shape.back());
 
@@ -2311,7 +2323,15 @@ Tensor<Mixins...> GatherNd(Tensor<Mixins...> input, Tensor<Mixins...> indices,
 
   int indices_ndims = indices_info.shape.size();
   int input_ndims = input_info.shape.size();
+  if (indices_info.shape.empty()) {
+    return Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
+        "GatherNd indices must have rank >= 1.")));
+  }
   int index_depth = indices_info.shape.back();
+  if (index_depth < 0 || index_depth > input_ndims) {
+    return Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
+        "GatherNd index depth is out of range.")));
+  }
   int outer_dims = indices_ndims - 1;
 
   for (int i = 0; i < outer_dims; ++i) {


### PR DESCRIPTION
## Problem

Three shape-inference functions in `litert/tensor/arithmetic.h` call `.back()` on `std::vector<int>` shape vectors, or use `size() - 1` as a `size_t`, without first verifying the vector is non-empty. A crafted model that supplies a rank-0 (scalar) tensor to any of these operators causes undefined behaviour at graph-construction time, before inference runs.

### FullyConnected (`lines 1152–1160`)

```cpp
if (keep_num_dims) {
  output_info.shape = input_info.shape;        // empty if input is rank-0
  output_info.shape.back() = ...;              // UB: back() on empty vector
} else {
  for (size_t i = 0; i < input_info.shape.size() - 1; ++i) {  // size_t wraps to SIZE_MAX
    batch *= input_info.shape[i];              // OOB read → SIGSEGV
  }
}
```

### EmbeddingLookup (`line 1970`)

```cpp
output_info.shape.push_back(value_info.shape.back());  // UB if value is rank-0
```

### GatherNd (`lines 2314, 2320–2321`)

```cpp
int index_depth = indices_info.shape.back();   // UB if indices is rank-0
// ...
for (int i = index_depth; i < input_ndims; ++i) {
  output_info.shape.push_back(input_info.shape[i]);  // OOB if index_depth < 0
}
```

The same class of bug was fixed for six other operators in PRs #10464 and #10702.

## Fix

Add rank guards before each unsafe access:

- **FullyConnected**: reject rank-0 `input` or `weights` with `InvalidArgumentError`
- **EmbeddingLookup**: reject rank-0 `value` with `InvalidArgumentError`
- **GatherNd**: reject rank-0 `indices` and reject `index_depth < 0 || index_depth > input_ndims`