### PR TITLE
litert/tensor: guard AveragePool2D/MaxPool2D/Conv2D/DepthwiseConv2D against under-rank input in arithmetic.h

### DIFF
--- a/litert/tensor/arithmetic.h
+++ b/litert/tensor/arithmetic.h
@@ -1217,6 +1217,10 @@ Tensor<Mixins...> AveragePool2D(
   graph::TensorInformation& output_info = *GetInfo(output.GetRaw());
   output_info.type = input_info.type;
 
+  if (input_info.shape.size() < 4) {
+    return Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
+        "AveragePool2D input must be rank 4 (NHWC).")));
+  }
   const int input_h = input_info.shape[1];
   const int input_w = input_info.shape[2];
 
@@ -1257,6 +1261,10 @@ Tensor<Mixins...> MaxPool2D(Tensor<Mixins...> input, int filter_height,
   graph::TensorInformation& output_info = *GetInfo(output.GetRaw());
   output_info.type = input_info.type;
 
+  if (input_info.shape.size() < 4) {
+    return Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
+        "MaxPool2D input must be rank 4 (NHWC).")));
+  }
   const int input_h = input_info.shape[1];
   const int input_w = input_info.shape[2];
 
@@ -1302,6 +1310,10 @@ TensorHandle Conv2DImpl(Tensor<Mixins...> input, Tensor<Mixins...> filter,
   graph::TensorInformation& output_info = *GetInfo(output.GetRaw());
   output_info.type = input_info.type;
 
+  if (input_info.shape.size() < 4 || filter_info.shape.size() < 4) {
+    return TensorHandle(graph::ErrorTensor(absl::InvalidArgumentError(
+        "Conv2D input and filter must be rank 4 (NHWC).")));
+  }
   const int input_h = input_info.shape[1];
   const int input_w = input_info.shape[2];
   const int filter_h = filter_info.shape[1];
@@ -1376,6 +1388,10 @@ Tensor<Mixins...> DepthwiseConv2DImpl(
   graph::TensorInformation& output_info = *GetInfo(output.GetRaw());
   output_info.type = input_info.type;
 
+  if (input_info.shape.size() < 4 || filter_info.shape.size() < 4) {
+    return Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
+        "DepthwiseConv2D input and filter must be rank 4 (NHWC).")));
+  }
   const int input_h = input_info.shape[1];
   const int input_w = input_info.shape[2];
   const int filter_h = filter_info.shape[1];


### PR DESCRIPTION
## Problem

`AveragePool2D()`, `MaxPool2D()`, `Conv2DImpl()`, and `DepthwiseConv2DImpl()` in `litert/tensor/arithmetic.h` subscript fixed shape indices (1, 2, 3) without first checking that the input/filter shape vectors are large enough. A crafted TFLite model with a rank-0 or rank-1 tensor on any of these operators causes an out-of-bounds `std::vector::operator[]` access during graph construction (model-load time), before inference begins, resulting in SIGSEGV.

## Fix

Add `shape.size() < 4` checks before the first shape subscript in each of the four functions, returning an `InvalidArgumentError` on violation — consistent with the pattern used in FullyConnected, EmbeddingLookup, and GatherNd.

## Affected functions

| Function | File | First crash line |
|---|---|---|
| `AveragePool2D` | `arithmetic.h:1220` | `shape[1]` on rank-0 input |
| `MaxPool2D` | `arithmetic.h:1260` | `shape[1]` on rank-0 input |
| `Conv2DImpl` | `arithmetic.h:1305` | `shape[1]` on rank-0 input or filter |
| `DepthwiseConv2DImpl` | `arithmetic.h:1379` | `shape[1]` on rank-0 input or filter |