### PR TITLE
litert/tensor: guard AveragePool2D/MaxPool2D/Conv2D/DepthwiseConv2D against zero stride in arithmetic.h

### DIFF
--- a/litert/tensor/arithmetic.h
+++ b/litert/tensor/arithmetic.h
@@ -1217,6 +1217,10 @@ Tensor<Mixins...> AveragePool2D(
   graph::TensorInformation& output_info = *GetInfo(output.GetRaw());
   output_info.type = input_info.type;
 
+  if (stride_h <= 0 || stride_w <= 0) {
+    return Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
+        "AveragePool2D strides must be greater than zero.")));
+  }
   const int input_h = input_info.shape[1];
   const int input_w = input_info.shape[2];
 
@@ -1257,6 +1261,10 @@ Tensor<Mixins...> MaxPool2D(Tensor<Mixins...> input, int filter_height,
   graph::TensorInformation& output_info = *GetInfo(output.GetRaw());
   output_info.type = input_info.type;
 
+  if (stride_h <= 0 || stride_w <= 0) {
+    return Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
+        "MaxPool2D strides must be greater than zero.")));
+  }
   const int input_h = input_info.shape[1];
   const int input_w = input_info.shape[2];
 
@@ -1302,6 +1310,10 @@ TensorHandle Conv2DImpl(Tensor<Mixins...> input, Tensor<Mixins...> filter,
   graph::TensorInformation& output_info = *GetInfo(output.GetRaw());
   output_info.type = input_info.type;
 
+  if (stride_h <= 0 || stride_w <= 0) {
+    return TensorHandle(graph::ErrorTensor(absl::InvalidArgumentError(
+        "Conv2D strides must be greater than zero.")));
+  }
   const int input_h = input_info.shape[1];
   const int input_w = input_info.shape[2];
   const int filter_h = filter_info.shape[1];
@@ -1376,6 +1388,10 @@ Tensor<Mixins...> DepthwiseConv2DImpl(
   graph::TensorInformation& output_info = *GetInfo(output.GetRaw());
   output_info.type = input_info.type;
 
+  if (stride_h <= 0 || stride_w <= 0) {
+    return Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
+        "DepthwiseConv2D strides must be greater than zero.")));
+  }
   const int input_h = input_info.shape[1];
   const int input_w = input_info.shape[2];
   const int filter_h = filter_info.shape[1];


### PR DESCRIPTION
AveragePool2D, MaxPool2D, Conv2DImpl, and DepthwiseConv2DImpl all divide by `stride_h` and `stride_w` to compute output spatial dimensions without first checking that either value is non-zero. On x86-64 and ARM, integer division by zero raises SIGFPE, crashing the process at graph-construction time before any inference runs.

Add a `stride > 0` guard in each function immediately before the shape reads, consistent with the validation pattern already used in `ComputeTransposeConvPadding` in `arithmetic.cc`.

**Affected functions:**
- `AveragePool2D` - lines 1226–1230
- `MaxPool2D` - lines 1266–1270
- `Conv2DImpl` - lines 1314–1320
- `DepthwiseConv2DImpl` - lines 1388–1394