### PR TITLE
Reject deconvolution reshape with zero output dimensions

### DIFF
--- a/src/operators/deconvolution-nhwc.c
+++ b/src/operators/deconvolution-nhwc.c
@@ -2367,6 +2367,17 @@ static enum xnn_status reshape_deconvolution2d_nhwc(
           deconvolution_op->convolution_op->dilation_width,
           deconvolution_op->convolution_op->stride_width);
 
+  if (deconvolution_op->convolution_op->output_height == 0 ||
+      deconvolution_op->convolution_op->output_width == 0) {
+    xnn_log_error(
+        "failed to reshape %s operator: computed output dimensions %zux%zu, "
+        "dimensions must be non-zero",
+        xnn_operator_type_to_string_v2(deconvolution_op),
+        deconvolution_op->convolution_op->output_height,
+        deconvolution_op->convolution_op->output_width);
+    return xnn_status_invalid_parameter;
+  }
+
   if (output_height_out != NULL) {
     *output_height_out = deconvolution_op->convolution_op->output_height;
   }


### PR DESCRIPTION
xnn_reshape_deconvolution2d_nhwc_* computes the output dimensions with xnn_compute_deconvolution_output_dimension() and never validates the result. When the padding is large enough relative to the kernel, input size, stride and adjustment (e.g. a 4x4 kernel with 3 pixels of padding on a 2x2 input at stride 1), the computed output dimension saturates to zero. reshape_igemm_path() then calls xnn_indirection_init_deconv2d(), which divides by the zero output width:

  clamp_oy = (output_size - 1) / output_width;   // output_width == 0

causing a SIGFPE (integer division by zero) instead of returning an error. The crash is reachable through the public operator API and affects every deconvolution data type (F32/F16/QS8/QU8), which all share reshape_deconvolution2d_nhwc().

ASAN dump, in case useful:

```
create: 0
AddressSanitizer:DEADLYSIGNAL
=================================================================
==660670==ERROR: AddressSanitizer: FPE on unknown address 0x5581a3970f10 (pc 0x5581a3970f10 bp 0x000000000000 sp 0x7ffc7dbe7d08 T0)
    #0 0x5581a3970f10 in xnn_indirection_init_deconv2d (/home/kjc/XNNPACK/poc+0x1c5f10) (BuildId: 9271705f4c8422984162093fe3f1adaff6f9f695)
    #1 0x5581a3944871 in reshape_igemm_path deconvolution-nhwc.c
    #2 0x5581a39425b0 in reshape_deconvolution2d_nhwc deconvolution-nhwc.c
    #3 0x5581a3942911 in xnn_reshape_deconvolution2d_nhwc_f32 (/home/kjc/XNNPACK/poc+0x197911) (BuildId: 9271705f4c8422984162093fe3f1adaff6f9f695)
    #4 0x5581a393fc58 in main /home/kjc/XNNPACK/poc.cc:30:8
    #5 0x7f32dda27780 in __libc_start_call_main /usr/src/debug/glibc/glibc/csu/../sysdeps/nptl/libc_start_call_main.h:59:16
    #6 0x7f32dda278b8 in __libc_start_main /usr/src/debug/glibc/glibc/csu/../csu/libc-start.c:372:3
    #7 0x5581a37d9214 in _start (/home/kjc/XNNPACK/poc+0x2e214) (BuildId: 9271705f4c8422984162093fe3f1adaff6f9f695)

==660670==Register values:
rax = 0xffffffffffffffff  rbx = 0x000000000000000a  rcx = 0x0000000000000000  rdx = 0x0000000000000000
rdi = 0x000000000000000a  rsi = 0x00007b52dcde0010  rbp = 0x0000000000000000  rsp = 0x00007ffc7dbe7d08
 r8 = 0x00007bc2dcde0040   r9 = 0xffffffffffffffff  r10 = 0x0000000000000000  r11 = 0x00007c42dcde0540
r12 = 0x0000000000000003  r13 = 0x0000000000000003  r14 = 0x0000000000000001  r15 = 0x0000000000000001
AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: FPE (/home/kjc/XNNPACK/poc+0x1c5f10) (BuildId: 9271705f4c8422984162093fe3f1adaff6f9f695) in xnn_indirection_init_deconv2d
==660670==ABORTING
```