### PR TITLE
Operators: error out when packed weights cannot be inserted into a finalized weights cache

### DIFF
--- a/src/operators/batch-matrix-multiply-nc.c
+++ b/src/operators/batch-matrix-multiply-nc.c
@@ -521,6 +521,14 @@ XNN_NO_SANITIZE_FUNCTION enum xnn_status create_batch_matrix_multiply_nc_const_w
           xnn_look_up_or_insert_weights_cache(
               batch_matrix_multiply_op->weights_cache, &cache_key, packed_data,
               aligned_size);
+      if (batch_matrix_multiply_op->packed_weights.offset ==
+          XNN_CACHE_NOT_FOUND) {
+        xnn_log_error(
+            "failed to create %s operator: packed weights were not inserted "
+            "into the weights cache",
+            xnn_operator_type_to_string_v2(batch_matrix_multiply_op));
+        return xnn_status_invalid_parameter;
+      }
     }
 
   } else {

--- a/src/operators/convolution-nchw.c
+++ b/src/operators/convolution-nchw.c
@@ -256,6 +256,13 @@ static XNN_NO_SANITIZE_FUNCTION enum xnn_status create_conv2d_hwc2chw_path(
     if (use_weights_cache(convolution_op)) {
       convolution_op->packed_weights.offset = xnn_look_up_or_insert_weights_cache(
           convolution_op->weights_cache, &cache_key, weights_ptr, aligned_total_weights_size);
+      if (convolution_op->packed_weights.offset == XNN_CACHE_NOT_FOUND) {
+        xnn_log_error(
+            "failed to create %s operator: packed weights were not inserted "
+            "into the weights cache",
+            xnn_operator_type_to_string_v2(convolution_op));
+        return xnn_status_invalid_parameter;
+      }
     }
   }
 
@@ -324,6 +331,13 @@ static XNN_NO_SANITIZE_FUNCTION enum xnn_status create_dwconv_path(
     if (use_weights_cache(convolution_op)) {
       convolution_op->packed_weights.offset = xnn_look_up_or_insert_weights_cache(
           convolution_op->weights_cache, &cache_key, weights_ptr, aligned_total_weights_size);
+      if (convolution_op->packed_weights.offset == XNN_CACHE_NOT_FOUND) {
+        xnn_log_error(
+            "failed to create %s operator: packed weights were not inserted "
+            "into the weights cache",
+            xnn_operator_type_to_string_v2(convolution_op));
+        return xnn_status_invalid_parameter;
+      }
     }
   }
 

--- a/src/operators/convolution-nhwc.c
+++ b/src/operators/convolution-nhwc.c
@@ -221,6 +221,14 @@ static XNN_NO_SANITIZE_FUNCTION enum xnn_status create_vmulcaddc_path(
       convolution_op->packed_weights.offset = xnn_look_up_or_insert_weights_cache(
           convolution_op->weights_cache, &cache_key, weights_ptr,
           aligned_total_weights_size);
+      if (convolution_op->packed_weights.offset == XNN_CACHE_NOT_FOUND) {
+        xnn_log_error(
+            "failed to create %s operator: packed weights were not inserted "
+            "into the weights cache",
+            xnn_operator_type_to_string_v2(convolution_op));
+        status = xnn_status_invalid_parameter;
+        goto error;
+      }
     }
   }
 
@@ -336,6 +344,14 @@ static XNN_NO_SANITIZE_FUNCTION enum xnn_status create_dwconv_path(
       convolution_op->packed_weights.offset = xnn_look_up_or_insert_weights_cache(
           convolution_op->weights_cache, &cache_key, weights_ptr,
           aligned_total_weights_size);
+      if (convolution_op->packed_weights.offset == XNN_CACHE_NOT_FOUND) {
+        xnn_log_error(
+            "failed to create %s operator: packed weights were not inserted "
+            "into the weights cache",
+            xnn_operator_type_to_string_v2(convolution_op));
+        status = xnn_status_invalid_parameter;
+        goto error;
+      }
     }
   }
 
@@ -522,6 +538,14 @@ static XNN_NO_SANITIZE_FUNCTION enum xnn_status create_igemm(
       convolution_op->packed_weights.offset = xnn_look_up_or_insert_weights_cache(
           convolution_op->weights_cache, &cache_key, weights_ptr,
           aligned_total_weights_size);
+      if (convolution_op->packed_weights.offset == XNN_CACHE_NOT_FOUND) {
+        xnn_log_error(
+            "failed to create %s operator: packed weights were not inserted "
+            "into the weights cache",
+            xnn_operator_type_to_string_v2(convolution_op));
+        status = xnn_status_invalid_parameter;
+        goto error;
+      }
     }
   }
 

--- a/src/operators/deconvolution-nhwc.c
+++ b/src/operators/deconvolution-nhwc.c
@@ -523,6 +523,14 @@ static XNN_NO_SANITIZE_FUNCTION enum xnn_status create_deconvolution2d_nhwc(
         xnn_look_up_or_insert_weights_cache(deconvolution_op->weights_cache,
                                             &cache_key, weights_ptr,
                                             aligned_total_weights_size);
+    if (deconvolution_op->packed_weights.offset == XNN_CACHE_NOT_FOUND) {
+      xnn_log_error(
+          "failed to create %s operator: packed weights were not inserted "
+          "into the weights cache",
+          xnn_operator_type_to_string(operator_type));
+      status = xnn_status_invalid_parameter;
+      goto error;
+    }
   }
 
   const size_t zero_size =

--- a/src/operators/fully-connected-nc.c
+++ b/src/operators/fully-connected-nc.c
@@ -403,6 +403,14 @@ static XNN_NO_SANITIZE_FUNCTION enum xnn_status create_fully_connected_nc(
           xnn_look_up_or_insert_weights_cache(fully_connected_op->weights_cache,
                                               &cache_key, weights_ptr,
                                               aligned_total_weights_size);
+      if (fully_connected_op->packed_weights.offset == XNN_CACHE_NOT_FOUND) {
+        xnn_log_error(
+            "failed to create %s operator: packed weights were not inserted "
+            "into the weights cache",
+            xnn_operator_type_to_string_v2(fully_connected_op));
+        status = xnn_status_invalid_parameter;
+        goto error;
+      }
     }
   } else {
     fully_connected_op->packed_weights.offset = cache_offset;


### PR DESCRIPTION
## Summary

When a weights cache has been finalized (`xnn_finalize_weights_cache` with
either `hard` or `soft` kind), inserting packed weights that are **not
already present** in the cache is rejected by the cache layer:
`xnn_look_up_or_insert_weights_cache` logs "packed weights not found in
finalized weights cache" and returns `XNN_CACHE_NOT_FOUND`
(`src/cache.c`). The documented contract (`include/xnnpack.h`,
`xnn_weights_cache_finalization_kind_soft`) is that creation of an operator
whose weights are not already cached **errors**.

However, every operator `create` path that caches packed weights ignored the
`XNN_CACHE_NOT_FOUND` result and returned success, leaving
`packed_weights.offset = XNN_CACHE_NOT_FOUND` (`SIZE_MAX`) on the operator.
A subsequent `xnn_run_operator()` then resolved the packed-weights pointer as
`cache_base + SIZE_MAX` and the kernels performed a wild-pointer read,
crashing with SEGV (or, worse, reading arbitrary memory) instead of the
creation call failing.

Affected create paths (all callers of `xnn_look_up_or_insert_weights_cache`):
- `convolution-nhwc.c`: igemm, dwconv, vmulcaddc paths
- `convolution-nchw.c`: hwc2chw/dwconv paths
- `deconvolution-nhwc.c`
- `fully-connected-nc.c`
- `batch-matrix-multiply-nc.c`

## Repro (deterministic, release + debug, ASAN)

```c
xnn_weights_cache_t cache;
xnn_create_weights_cache(&cache);

// Op 1: inserts packed weights into the (unfinalized) cache.
xnn_create_convolution2d_nhwc_f32(..., /*weights_cache=*/cache, &op1);
xnn_finalize_weights_cache(cache, xnn_weights_cache_finalization_kind_soft);

// Op 2: DIFFERENT geometry -> would need to insert new weights, which the
// finalized cache refuses. Documented: this must error. Actual behavior:
// returns success with packed_weights.offset == XNN_CACHE_NOT_FOUND.
xnn_create_convolution2d_nhwc_f32(..., /*different params..., */ cache, &op2);

// Crashes: kernels read packed weights at cache_base + SIZE_MAX.
xnn_setup_convolution2d_nhwc_f32(op2, ...);
xnn_run_operator(op2, nullptr);
```

ASAN (unpatched master, x86-64):
```
ERROR: AddressSanitizer: SEGV on unknown address
#0 xnn_f32_igemm_minmax_ukernel_5x16__fma3_broadcast_prfm
#1 xnn_compute_hmp_igemm operator-run.c
#2 xnn_run_operator_with_index operator-run.c
```
Same for `qd8_f32_qc8w` conv, fully-connected, deconvolution, BMM.

Note: creating an op whose weights **are** already cached after finalization
is unaffected and keeps working (look-up hit).

## Fix

Check the return of `xnn_look_up_or_insert_weights_cache` in each create path
and fail operator creation (log + error status) when it reports
`XNN_CACHE_NOT_FOUND`, mirroring the documented soft/hard finalize contract.