### PR TITLE
litert/tensor: guard TopK() against rank-0 input to prevent heap OOB write

### DIFF
--- a/litert/tensor/arithmetic.h
+++ b/litert/tensor/arithmetic.h
@@ -2134,6 +2134,11 @@ std::vector<Tensor<Mixins...>> TopK(
   graph::TensorInformation& values_info = *GetInfo(values.GetRaw());
   values_info.type = input_info.type;
   values_info.shape = input_info.shape;
+  if (values_info.shape.empty()) {
+    auto error = absl::InvalidArgumentError("TopK input must have rank >= 1.");
+    return {Tensor<Mixins...>(graph::ErrorTensor(error)),
+            Tensor<Mixins...>(graph::ErrorTensor(error))};
+  }
   if (GetInfo(k.GetRaw())->buffer == nullptr) {
     auto error = absl::InvalidArgumentError(
         "TopK k tensor must have a buffer.");


### PR DESCRIPTION
## Problem

`TopK()` in `litert/tensor/arithmetic.h` copies `input_info.shape` into `values_info.shape` and `indices_info.shape`, then calls `back()` on both to write the user-supplied `k` value as the last dimension:

```cpp
values_info.shape = input_info.shape;   // empty {} when input is rank-0
// ...
values_info.shape.back() = k_val;       // UB: back() on empty vector
// ...
indices_info.shape = input_info.shape;  // also empty
indices_info.shape.back() = k_val;      // UB again
```

When the input tensor has rank 0 (scalar), both shape vectors are empty. `std::vector::back()` on an empty vector is undefined behaviour: the implementation returns `*(data() - 1)`, one `sizeof(int)` before the heap allocation. The two assignments write an attacker-controlled `int32_t` value to those out-of-bounds addresses, corrupting heap metadata.

The bug is reachable at model-load / graph-construction time with a crafted `.tflite` flatbuffer - no inference step is required.

## Fix

Add a rank guard immediately after copying the input shape, before either `back()` call. This mirrors the guard added for `EmbeddingLookup` at line 1994 of the same file:

```cpp
values_info.shape = input_info.shape;
if (values_info.shape.empty()) {
  auto error = absl::InvalidArgumentError("TopK input must have rank >= 1.");
  return {Tensor<Mixins...>(graph::ErrorTensor(error)),
          Tensor<Mixins...>(graph::ErrorTensor(error))};
}
```