### PR TITLE
Guard convolution/deconvolution packed weights size against integer overflow

### DIFF
--- a/src/operators/convolution-nhwc.c
+++ b/src/operators/convolution-nhwc.c
@@ -382,6 +382,34 @@ static XNN_NO_SANITIZE_FUNCTION enum xnn_status create_igemm(
   const size_t n_stride = round_up(group_output_channels, nr);
   const size_t k_stride = round_up_po2(group_input_channels, kr * sr);
 
+  size_t packed_group_weights_size = 0;
+  if (!xnn_safe_mul(kernel_size, k_stride, &packed_group_weights_size) ||
+      !xnn_safe_mul(packed_group_weights_size,
+                    (size_t)1 << log2_filter_element_size,
+                    &packed_group_weights_size) ||
+      !xnn_safe_add(packed_group_weights_size, bias_element_size,
+                    &packed_group_weights_size) ||
+      !xnn_safe_add(packed_group_weights_size, extra_weights_bytes,
+                    &packed_group_weights_size) ||
+      !xnn_safe_mul(packed_group_weights_size, n_stride,
+                    &packed_group_weights_size)) {
+    xnn_log_error(
+        "failed to create %s operator: packed weights size overflows size_t "
+        "(kernel_size=%zu, k_stride=%zu, n_stride=%zu)",
+        xnn_operator_type_to_string(operator_type), kernel_size, k_stride,
+        n_stride);
+    goto error;
+  }
+  size_t total_weights_size = 0;
+  if (!xnn_safe_mul(packed_group_weights_size, groups, &total_weights_size)) {
+    xnn_log_error(
+        "failed to create %s operator: total packed weights size overflows "
+        "size_t (packed_group_weights_size=%zu, groups=%zu)",
+        xnn_operator_type_to_string(operator_type), packed_group_weights_size,
+        (size_t)groups);
+    goto error;
+  }
+
   const uint32_t cache_seed = groups ^ group_input_channels ^
                               group_output_channels ^ nr ^ kr ^ sr ^
                               ukernel_type ^ flags;
@@ -400,12 +428,8 @@ static XNN_NO_SANITIZE_FUNCTION enum xnn_status create_igemm(
   const bool weights_already_cached =
       convolution_op->packed_weights.offset != XNN_CACHE_NOT_FOUND;
 
-  const size_t packed_group_weights_size =
-      ((kernel_size * k_stride << log2_filter_element_size) +
-       bias_element_size + extra_weights_bytes) *
-      n_stride;
-  const size_t aligned_total_weights_size = round_up_po2(
-      packed_group_weights_size * groups, XNN_ALLOCATION_ALIGNMENT);
+  const size_t aligned_total_weights_size =
+      round_up_po2(total_weights_size, XNN_ALLOCATION_ALIGNMENT);
   void* weights_ptr = NULL;
 
   if (!weights_already_cached) {

--- a/src/operators/deconvolution-nhwc.c
+++ b/src/operators/deconvolution-nhwc.c
@@ -288,16 +288,48 @@ static XNN_NO_SANITIZE_FUNCTION enum xnn_status create_deconvolution2d_nhwc(
     return xnn_status_out_of_memory;
   }
   enum xnn_microkernel_type ukernel_type = xnn_microkernel_type_igemm;
-  size_t packed_group_weights_size =
-      ((kernel_size * k_stride << log2_filter_element_size) +
-       bias_element_size + extra_weights_bytes) *
-      n_stride;
+  size_t packed_group_weights_size = 0;
+  if (!xnn_safe_mul(kernel_size, k_stride, &packed_group_weights_size) ||
+      !xnn_safe_mul(packed_group_weights_size,
+                    (size_t)1 << log2_filter_element_size,
+                    &packed_group_weights_size) ||
+      !xnn_safe_add(packed_group_weights_size, bias_element_size,
+                    &packed_group_weights_size) ||
+      !xnn_safe_add(packed_group_weights_size, extra_weights_bytes,
+                    &packed_group_weights_size) ||
+      !xnn_safe_mul(packed_group_weights_size, n_stride,
+                    &packed_group_weights_size)) {
+    xnn_log_error(
+        "failed to create %s operator: packed weights size overflows size_t "
+        "(kernel_size=%zu, k_stride=%zu, n_stride=%zu)",
+        xnn_operator_type_to_string(operator_type), kernel_size, k_stride,
+        n_stride);
+    goto error;
+  }
   if (is_subconv2d(context)) {
     ukernel_type = xnn_microkernel_type_subconv2d;
     const size_t subkernels = stride_height * stride_width;
-    packed_group_weights_size =
-        n_stride * (((kernel_size * k_stride) << log2_filter_element_size) +
-                    (bias_element_size + extra_weights_bytes) * subkernels);
+    size_t subconv_kernel_weights_size = 0;
+    size_t subconv_bias_weights_size = 0;
+    if (!xnn_safe_mul(kernel_size, k_stride, &subconv_kernel_weights_size) ||
+        !xnn_safe_mul(subconv_kernel_weights_size,
+                      (size_t)1 << log2_filter_element_size,
+                      &subconv_kernel_weights_size) ||
+        !xnn_safe_add(bias_element_size, extra_weights_bytes,
+                      &subconv_bias_weights_size) ||
+        !xnn_safe_mul(subconv_bias_weights_size, subkernels,
+                      &subconv_bias_weights_size) ||
+        !xnn_safe_add(subconv_kernel_weights_size, subconv_bias_weights_size,
+                      &packed_group_weights_size) ||
+        !xnn_safe_mul(packed_group_weights_size, n_stride,
+                      &packed_group_weights_size)) {
+      xnn_log_error(
+          "failed to create %s operator: packed weights size overflows size_t "
+          "(kernel_size=%zu, k_stride=%zu, n_stride=%zu, subkernels=%zu)",
+          xnn_operator_type_to_string(operator_type), kernel_size, k_stride,
+          n_stride, subkernels);
+      goto error;
+    }
     const size_t subconvolution_buffer_size =
         sizeof(struct subconvolution_params) * subkernels;
     deconvolution_op->convolution_op->subconvolution_buffer =
@@ -319,8 +351,17 @@ static XNN_NO_SANITIZE_FUNCTION enum xnn_status create_deconvolution2d_nhwc(
       goto error;
     }
   }
-  const size_t aligned_total_weights_size = round_up_po2(
-      packed_group_weights_size * groups, XNN_ALLOCATION_ALIGNMENT);
+  size_t total_weights_size = 0;
+  if (!xnn_safe_mul(packed_group_weights_size, groups, &total_weights_size)) {
+    xnn_log_error(
+        "failed to create %s operator: total packed weights size overflows "
+        "size_t (packed_group_weights_size=%zu, groups=%zu)",
+        xnn_operator_type_to_string(operator_type), packed_group_weights_size,
+        (size_t)groups);
+    goto error;
+  }
+  const size_t aligned_total_weights_size =
+      round_up_po2(total_weights_size, XNN_ALLOCATION_ALIGNMENT);
   void* weights_ptr = xnn_get_pointer_to_write_weights(
       deconvolution_op, aligned_total_weights_size);
   if (weights_ptr == NULL) {


### PR DESCRIPTION
## Summary

`packed_group_weights_size` is computed from the caller-supplied
`group_input_channels` / `group_output_channels` without any overflow checks,
while only `kernel_height * kernel_width` is guarded via `xnn_safe_mul`:

```c
size_t packed_group_weights_size =
    ((kernel_size * k_stride << log2_filter_element_size) +
     bias_element_size + extra_weights_bytes) *
    n_stride;
```

When the product wraps `size_t`, `aligned_total_weights_size` is far smaller
than the amount of data the weight-packing microkernel writes into it, so
`xnn_pack_f32_conv_goki_w` writes past the end of the allocation — a heap
out-of-bounds write.

Two affected sites:

- `src/operators/convolution-nhwc.c` — `create_igemm`, reached from
  `xnn_create_convolution2d_nhwc_f32`
- `src/operators/deconvolution-nhwc.c` — `create_deconvolution2d_nhwc`,
  reached from `xnn_create_deconvolution2d_nhwc_f32` (including the
  `is_subconv2d` branch)

The entry points only reject zero-valued channel counts, so oversized values
reach the unguarded arithmetic.

## Reproduction

With `group_input_channels = 2^30`, `group_output_channels = 2^28`,
`groups = 1` and a 4x4 kernel on a 64-bit build:

```
packed_group_weights_size =
  ((16 * 2^30 << 2) + 4) * round_up(2^28, 16)
  = (2^36 + 4) * 2^28
  = 2^64 + 2^30
  -> wraps to 2^30 = 1 GiB allocation
```

The pack kernel then writes the full logical kernel size (2^64 bytes).
Under AddressSanitizer the create call reports the 1 GiB allocation and then
crashes in `xnn_pack_f32_conv_goki_w` (`src/reference/packing.cc:3995`). On
32-bit targets (Android ARM32, WASM) `group_input_channels =
group_output_channels = 32768` is enough to wrap.

## Fix

Guard every multiply and add in the size chain with
`xnn_safe_mul` / `xnn_safe_add`, and reject the operator with
`xnn_status_unsupported_parameter` when any step overflows. This mirrors the
guard already present for Fully Connected (`src/operators/fully-connected-nc.c`,
commit 3131f0daca). The f16/pf16 variants already guard the full product; the
f32 paths did not.

In the convolution path the guard is evaluated before the weights-cache
look-up so that an overflow failure cannot leave
`packed_weights.offset` set while the `packed_weights` union's `pointer`
member is still unset.

## Testing

- `convolution-nhwc-test`: 797 passed
- `deconvolution-nhwc-test`: 1079 passed
- subgraph `convolution-2d-test`: 11 passed
- subgraph `deconvolution-2d-test`: 7 passed

Both oversized inputs now fail cleanly with
`packed weights size overflows size_t` instead of corrupting the heap.
