### PR TITLE
fix(subgraph): reject fully-connected tensors exceeding XNN_MAX_TENSOR_DIMS (fixes #11036)

### DIFF
--- a/src/subgraph/fully-connected.c
+++ b/src/subgraph/fully-connected.c
@@ -327,6 +327,14 @@ static enum xnn_status create_fully_connected_operator(
   assert(output_id < num_values);
   const struct xnn_runtime_value* output_value = &values[output_id];
 
+  if (filter_value->shape.num_dims < 2 || filter_value->shape.num_dims > XNN_MAX_TENSOR_DIMS) {
+    xnn_log_error("failed to create %s operator with filter ID #%" PRIu32
+                  ": number of dimensions (%zu) must be between 2 and %zu",
+                  xnn_node_type_to_string(xnn_node_type_fully_connected),
+                  filter_id, filter_value->shape.num_dims, (size_t)XNN_MAX_TENSOR_DIMS);
+    return xnn_status_unsupported_parameter;
+  }
+
   size_t output_channels, input_channels;
   if (node->flags & XNN_FLAG_TRANSPOSE_WEIGHTS) {
     input_channels = filter_value->shape.dim[0];
@@ -995,13 +1003,13 @@ enum xnn_status resize_fully_connected_output_tensor(
   const uint32_t input_id = opdata->inputs[0];
   const struct xnn_runtime_value* input = &values[input_id];
 
-  if (input->shape.num_dims == 0) {
+  if (input->shape.num_dims == 0 || input->shape.num_dims > XNN_MAX_TENSOR_DIMS) {
     xnn_log_error(
         "failed to reshape %s operator with input ID #%" PRIu32
-        ": unsupported number of dimensions %zu, must be at least 1",
+        ": unsupported number of dimensions %zu, must be between 1 and %zu",
         xnn_node_type_to_string(xnn_node_type_fully_connected),
-        input_id, input->shape.num_dims);
-    return xnn_status_invalid_parameter;
+        input_id, input->shape.num_dims, (size_t)XNN_MAX_TENSOR_DIMS);
+    return xnn_status_unsupported_parameter;
   }
 
   output->shape.num_dims = input->shape.num_dims;
@@ -1032,13 +1040,13 @@ static enum xnn_status reshape_fully_connected_operator(
   assert(input_id < num_values);
   struct xnn_runtime_value* input_value = &values[input_id];
 
-  if (input_value->shape.num_dims == 0) {
+  if (input_value->shape.num_dims == 0 || input_value->shape.num_dims > XNN_MAX_TENSOR_DIMS) {
     xnn_log_error(
         "failed to reshape %s operator with input ID #%" PRIu32
-        ": unsupported number of dimensions %zu, must be at least 1",
+        ": unsupported number of dimensions %zu, must be between 1 and %zu",
         xnn_node_type_to_string(xnn_node_type_fully_connected),
-        input_id, input_value->shape.num_dims);
-    return xnn_status_invalid_parameter;
+        input_id, input_value->shape.num_dims, (size_t)XNN_MAX_TENSOR_DIMS);
+    return xnn_status_unsupported_parameter;
   }
 
   const uint32_t output_id = opdata->outputs[0];
@@ -1049,12 +1057,12 @@ static enum xnn_status reshape_fully_connected_operator(
   assert(filter_id < num_values);
   struct xnn_runtime_value* filter_value = &values[filter_id];
 
-  if (filter_value->shape.num_dims < 2) {
+  if (filter_value->shape.num_dims < 2 || filter_value->shape.num_dims > XNN_MAX_TENSOR_DIMS) {
     xnn_log_error("failed to reshape %s operator with filter ID #%" PRIu32
-                  ": number of dimensions (%zu) must be at least 2",
+                  ": number of dimensions (%zu) must be between 2 and %zu",
                   xnn_node_type_to_string(xnn_node_type_fully_connected),
-                  filter_id, filter_value->shape.num_dims);
-    return xnn_status_invalid_parameter;
+                  filter_id, filter_value->shape.num_dims, (size_t)XNN_MAX_TENSOR_DIMS);
+    return xnn_status_unsupported_parameter;
   }
 
   if (output_value->flags & XNN_VALUE_FLAG_LAYOUT_NCHW) {
@@ -1937,6 +1945,15 @@ enum xnn_status xnn_define_fully_connected(xnn_subgraph_t subgraph,
     return status;
   }
 
+  if (input_value->shape.num_dims > XNN_MAX_TENSOR_DIMS) {
+    xnn_log_error(
+        "failed to define %s operator with input ID #%" PRIu32
+        ": unsupported number of dimensions %zu, must not exceed %zu",
+        xnn_node_type_to_string(xnn_node_type_fully_connected),
+        input_id, input_value->shape.num_dims, (size_t)XNN_MAX_TENSOR_DIMS);
+    return xnn_status_unsupported_parameter;
+  }
+
   switch (input_value->datatype) {
     case xnn_datatype_bf16:
     case xnn_datatype_fp16:
@@ -1980,6 +1997,15 @@ enum xnn_status xnn_define_fully_connected(xnn_subgraph_t subgraph,
                   xnn_node_type_to_string(xnn_node_type_fully_connected),
                   filter_id, kernel_value->type);
     return xnn_status_invalid_parameter;
+  }
+
+  if (kernel_value->shape.num_dims > XNN_MAX_TENSOR_DIMS) {
+    xnn_log_error(
+        "failed to define %s operator with filter ID #%" PRIu32
+        ": unsupported number of dimensions %zu, must not exceed %zu",
+        xnn_node_type_to_string(xnn_node_type_fully_connected),
+        filter_id, kernel_value->shape.num_dims, (size_t)XNN_MAX_TENSOR_DIMS);
+    return xnn_status_unsupported_parameter;
   }
 
   // Non-static kernel is supported, but only for some data types
@@ -2120,6 +2146,15 @@ enum xnn_status xnn_define_fully_connected(xnn_subgraph_t subgraph,
       return xnn_status_invalid_parameter;
     }
 
+    if (bias_value->shape.num_dims > XNN_MAX_TENSOR_DIMS) {
+      xnn_log_error(
+          "failed to define %s operator with bias ID #%" PRIu32
+          ": unsupported number of dimensions %zu, must not exceed %zu",
+          xnn_node_type_to_string(xnn_node_type_fully_connected),
+          bias_id, bias_value->shape.num_dims, (size_t)XNN_MAX_TENSOR_DIMS);
+      return xnn_status_unsupported_parameter;
+    }
+
     // Non-static bias is supported, but only for some data types
     switch (bias_value->datatype) {
       case xnn_datatype_fp16:
@@ -2170,6 +2205,15 @@ enum xnn_status xnn_define_fully_connected(xnn_subgraph_t subgraph,
                                                 output_id, output_value);
   if (status != xnn_status_success) {
     return status;
+  }
+
+  if (output_value->shape.num_dims > XNN_MAX_TENSOR_DIMS) {
+    xnn_log_error(
+        "failed to define %s operator with output ID #%" PRIu32
+        ": unsupported number of dimensions %zu, must not exceed %zu",
+        xnn_node_type_to_string(xnn_node_type_fully_connected),
+        output_id, output_value->shape.num_dims, (size_t)XNN_MAX_TENSOR_DIMS);
+    return xnn_status_unsupported_parameter;
   }
 
   switch (output_value->datatype) {

--- a/test/subgraph/fully-connected.cc
+++ b/test/subgraph/fully-connected.cc
@@ -1423,4 +1423,39 @@ TEST(FullyConnectedQD8F32QC8W, reshape_rejects_input_channel_mismatch) {
   ASSERT_NE(xnn_status_success, subgraph.Status());
 }
 
+// Regression test: fully-connected with tensor rank exceeding XNN_MAX_TENSOR_DIMS
+// must be rejected as unsupported parameter (fixes #11036).
+TEST(FullyConnectedF32, rank_exceeding_max_dims_rejected) {
+  ASSERT_EQ(xnn_status_success, xnn_initialize(nullptr));
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(3, 0, &subgraph));
+
+  const uint32_t input_id = 0;
+  subgraph->values[input_id].type = xnn_value_type_dense_tensor;
+  subgraph->values[input_id].datatype = xnn_datatype_fp32;
+  subgraph->values[input_id].shape.num_dims = XNN_MAX_TENSOR_DIMS + 1;
+
+  float filter = 1.0f;
+  size_t filter_dims[] = {1, 1};
+  uint32_t filter_id = XNN_INVALID_VALUE_ID;
+  ASSERT_EQ(xnn_status_success,
+            xnn_define_tensor_value(subgraph, xnn_datatype_fp32, 2,
+                                    filter_dims, &filter, XNN_INVALID_VALUE_ID,
+                                    0, &filter_id));
+
+  uint32_t output_id = XNN_INVALID_VALUE_ID;
+  ASSERT_EQ(xnn_status_success,
+            xnn_define_tensor_value(subgraph, xnn_datatype_fp32, 0, nullptr,
+                                    nullptr, 1, XNN_VALUE_FLAG_EXTERNAL_OUTPUT,
+                                    &output_id));
+
+  ASSERT_EQ(xnn_status_unsupported_parameter,
+            xnn_define_fully_connected(subgraph, -1e30f, 1e30f, input_id,
+                                       filter_id, XNN_INVALID_VALUE_ID,
+                                       output_id, 0));
+
+  xnn_delete_subgraph(subgraph);
+}
+
 }  // namespace xnnpack

--- a/test/subgraph/fully-connected.cc
+++ b/test/subgraph/fully-connected.cc
@@ -1423,8 +1423,6 @@ TEST(FullyConnectedQD8F32QC8W, reshape_rejects_input_channel_mismatch) {
   ASSERT_NE(xnn_status_success, subgraph.Status());
 }
 
-// Regression test: fully-connected with tensor rank exceeding XNN_MAX_TENSOR_DIMS
-// must be rejected as unsupported parameter (fixes #11036).
 TEST(FullyConnectedF32, rank_exceeding_max_dims_rejected) {
   ASSERT_EQ(xnn_status_success, xnn_initialize(nullptr));
 


### PR DESCRIPTION
### Problem Description

Fixes #11036

When a `FULLY_CONNECTED` operator is defined or reshaped with tensor rank exceeding `XNN_MAX_TENSOR_DIMS` (e.g. rank-7 tensors), the operator was accepted during define time without dimension checks, and subsequent prepare / reshape phases could fail or index `output->shape.dim` / `filter_value->shape.dim` out-of-bounds.

In LiteRT / TensorFlow Lite delegation, this caused the XNNPACK delegate to improperly claim rank-7 `FULLY_CONNECTED` nodes and fail during prepare/allocation, preventing clean fallback to builtin CPU kernels.

### Solution

1. In `src/subgraph/fully-connected.c`:
   - Added validation in `xnn_define_fully_connected` to reject `input_value`, `kernel_value`, `bias_value`, and `output_value` shapes with `num_dims > XNN_MAX_TENSOR_DIMS` with `xnn_status_unsupported_parameter`.
   - In `create_fully_connected_operator`, validated `filter_value->shape.num_dims` to ensure it is between 2 and `XNN_MAX_TENSOR_DIMS` before accessing `filter_value->shape.dim[filter_value->shape.num_dims - 1]`.
   - In `resize_fully_connected_output_tensor` and `reshape_fully_connected_operator`, added dimension checks to reject `num_dims > XNN_MAX_TENSOR_DIMS` with `xnn_status_unsupported_parameter`.
2. In `test/subgraph/fully-connected.cc`:
   - Added regression test `FullyConnectedF32.rank_exceeding_max_dims_rejected` verifying that `xnn_define_fully_connected` returns `xnn_status_unsupported_parameter` when a tensor's rank exceeds `XNN_MAX_TENSOR_DIMS`.
