### PR TITLE
fix(subgraph): validate filter shape in conv, deconv, and dwconv (fixes #11118)

### DIFF
--- a/src/subgraph/convolution-2d.c
+++ b/src/subgraph/convolution-2d.c
@@ -1295,14 +1295,27 @@ enum xnn_status xnn_define_convolution_2d(
     return status;
   }
 
-  if (filter_value->shape.dim[0] != group_output_channels * groups) {
+  if (filter_value->shape.num_dims != 4) {
     xnn_log_error(
-        "failed to define %s operator with filter output channels %zu, groups "
-        "#%" PRIu32
-        " and group_output_channels %zu:mismatching shapes, filter output "
-        "channels must be equal to groups * group_output_channels.",
+        "failed to define %s operator with filter ID #%" PRIu32
+        ": unsupported number of dimensions %zu, must be 4",
         xnn_node_type_to_string(xnn_node_type_convolution_2d),
-        filter_value->shape.dim[0], groups, group_output_channels);
+        filter_id, filter_value->shape.num_dims);
+    return xnn_status_invalid_parameter;
+  }
+
+  if (filter_value->shape.dim[0] != group_output_channels * groups ||
+      filter_value->shape.dim[1] != kernel_height ||
+      filter_value->shape.dim[2] != kernel_width ||
+      filter_value->shape.dim[3] != group_input_channels) {
+    xnn_log_error(
+        "failed to define %s operator with filter shape [%zu, %zu, %zu, %zu]: "
+        "filter shape must match [%zu, %" PRIu32 ", %" PRIu32 ", %zu]",
+        xnn_node_type_to_string(xnn_node_type_convolution_2d),
+        filter_value->shape.dim[0], filter_value->shape.dim[1],
+        filter_value->shape.dim[2], filter_value->shape.dim[3],
+        group_output_channels * groups, kernel_height, kernel_width,
+        group_input_channels);
     return xnn_status_invalid_parameter;
   }
 

--- a/src/subgraph/deconvolution-2d.c
+++ b/src/subgraph/deconvolution-2d.c
@@ -899,6 +899,30 @@ enum xnn_status xnn_define_deconvolution_2d(
     return status;
   }
 
+  if (filter_value->shape.num_dims != 4) {
+    xnn_log_error(
+        "failed to define %s operator with filter ID #%" PRIu32
+        ": unsupported number of dimensions %zu, must be 4",
+        xnn_node_type_to_string(xnn_node_type_deconvolution_2d),
+        filter_id, filter_value->shape.num_dims);
+    return xnn_status_invalid_parameter;
+  }
+
+  if (filter_value->shape.dim[0] != group_output_channels * groups ||
+      filter_value->shape.dim[1] != kernel_height ||
+      filter_value->shape.dim[2] != kernel_width ||
+      filter_value->shape.dim[3] != group_input_channels) {
+    xnn_log_error(
+        "failed to define %s operator with filter shape [%zu, %zu, %zu, %zu]: "
+        "filter shape must match [%zu, %" PRIu32 ", %" PRIu32 ", %zu]",
+        xnn_node_type_to_string(xnn_node_type_deconvolution_2d),
+        filter_value->shape.dim[0], filter_value->shape.dim[1],
+        filter_value->shape.dim[2], filter_value->shape.dim[3],
+        group_output_channels * groups, kernel_height, kernel_width,
+        group_input_channels);
+    return xnn_status_invalid_parameter;
+  }
+
   switch (output_value->datatype) {
     case xnn_datatype_fp16:
     case xnn_datatype_fp32:

--- a/src/subgraph/depthwise-convolution-2d.c
+++ b/src/subgraph/depthwise-convolution-2d.c
@@ -945,6 +945,29 @@ enum xnn_status xnn_define_depthwise_convolution_2d(
     return status;
   }
 
+  if (filter_value->shape.num_dims != 4) {
+    xnn_log_error(
+        "failed to define %s operator with filter ID #%" PRIu32
+        ": unsupported number of dimensions %zu, must be 4",
+        xnn_node_type_to_string(xnn_node_type_depthwise_convolution_2d),
+        filter_id, filter_value->shape.num_dims);
+    return xnn_status_invalid_parameter;
+  }
+
+  if (filter_value->shape.dim[0] != 1 ||
+      filter_value->shape.dim[1] != kernel_height ||
+      filter_value->shape.dim[2] != kernel_width ||
+      filter_value->shape.dim[3] != input_channels * depth_multiplier) {
+    xnn_log_error(
+        "failed to define %s operator with filter shape [%zu, %zu, %zu, %zu]: "
+        "filter shape must match [1, %" PRIu32 ", %" PRIu32 ", %zu]",
+        xnn_node_type_to_string(xnn_node_type_depthwise_convolution_2d),
+        filter_value->shape.dim[0], filter_value->shape.dim[1],
+        filter_value->shape.dim[2], filter_value->shape.dim[3],
+        kernel_height, kernel_width, input_channels * depth_multiplier);
+    return xnn_status_invalid_parameter;
+  }
+
   switch (output_value->datatype) {
     case xnn_datatype_fp16:
     case xnn_datatype_fp32:

--- a/test/subgraph/convolution-2d.cc
+++ b/test/subgraph/convolution-2d.cc
@@ -417,4 +417,60 @@ TEST(Convolution2D, reshape_rejects_input_channel_mismatch) {
   EXPECT_EQ(subgraph.Status(), xnn_status_invalid_parameter);
 }
 
+// Regression test: convolution-2d must reject filter tensors whose shape
+// mismatches kernel parameters (fixes #11118).
+TEST(Convolution2D, define_rejects_filter_shape_mismatch) {
+  ASSERT_EQ(xnn_status_success, xnn_initialize(nullptr /* allocator */));
+
+  ConvolutionParams params;
+  params.padding = {0, 0, 0, 0};
+  params.kernel = {5, 5};
+  params.subsampling = {1, 1};
+  params.dilation = {1, 1};
+  params.groups = 1;
+  params.group_input_channels = 3;
+  params.group_output_channels = 32;
+
+  const uint32_t input_id = 0;
+  const uint32_t filter_id = 1;
+  const uint32_t output_id = 2;
+
+  // Filter has kernel 3x3 but conv specifies 5x5
+  Tensor<float> filter(std::vector<size_t>{32, 3, 3, 3});
+  filter.fill(0.0f);
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_status_success, xnn_create_subgraph(3, 0, &subgraph));
+
+  const size_t input_dims[4] = {1, 8, 8, 3};
+  ASSERT_EQ(xnn_status_success,
+            xnn_define_tensor_value(subgraph, xnn_datatype_fp32, 4, input_dims,
+                                    nullptr, input_id,
+                                    XNN_VALUE_FLAG_EXTERNAL_INPUT, nullptr));
+
+  const size_t filter_dims[4] = {32, 3, 3, 3};
+  ASSERT_EQ(xnn_status_success,
+            xnn_define_tensor_value(subgraph, xnn_datatype_fp32, 4, filter_dims,
+                                    filter.base(), filter_id, 0, nullptr));
+
+  const size_t output_dims[4] = {1, 4, 4, 32};
+  ASSERT_EQ(xnn_status_success,
+            xnn_define_tensor_value(subgraph, xnn_datatype_fp32, 4, output_dims,
+                                    nullptr, output_id,
+                                    XNN_VALUE_FLAG_EXTERNAL_OUTPUT, nullptr));
+
+  const xnn_status status = xnn_define_convolution_2d(
+      subgraph, params.padding.top, params.padding.right,
+      params.padding.bottom, params.padding.left, params.kernel.height,
+      params.kernel.width, params.subsampling.height, params.subsampling.width,
+      params.dilation.height, params.dilation.width, params.groups,
+      params.group_input_channels, params.group_output_channels,
+      params.output_min, params.output_max, input_id, filter_id,
+      XNN_INVALID_VALUE_ID, output_id, 0);
+
+  EXPECT_EQ(status, xnn_status_invalid_parameter);
+
+  xnn_delete_subgraph(subgraph);
+}
+
 }  // namespace xnnpack

--- a/test/subgraph/convolution-2d.cc
+++ b/test/subgraph/convolution-2d.cc
@@ -417,8 +417,6 @@ TEST(Convolution2D, reshape_rejects_input_channel_mismatch) {
   EXPECT_EQ(subgraph.Status(), xnn_status_invalid_parameter);
 }
 
-// Regression test: convolution-2d must reject filter tensors whose shape
-// mismatches kernel parameters (fixes #11118).
 TEST(Convolution2D, define_rejects_filter_shape_mismatch) {
   ASSERT_EQ(xnn_status_success, xnn_initialize(nullptr /* allocator */));
 


### PR DESCRIPTION
### Problem Description

Fixes #11118

In `xnn_define_convolution_2d`, the filter tensor was previously only validated for `filter_value->shape.dim[0] == group_output_channels * groups`. It did not validate `num_dims == 4`, `dim[1] == kernel_height`, `dim[2] == kernel_width`, or `dim[3] == group_input_channels`.

Furthermore, `xnn_define_deconvolution_2d` and `xnn_define_depthwise_convolution_2d` had no filter shape validation at all.

When a filter tensor was defined with dimensions smaller than the convolution operator's kernel parameters, subsequent weight packing (e.g. `xnn_pack_f32_conv_goki_w`) read `nc * ks * kc` elements based on the convolution parameters rather than the filter buffer's actual extent, causing a heap out-of-bounds read (CWE-125) during runtime creation.

### Solution

1. In `src/subgraph/convolution-2d.c`:
   - Validated `filter_value->shape.num_dims == 4` and matching dimensions `[groups * group_output_channels, kernel_height, kernel_width, group_input_channels]`.
2. In `src/subgraph/deconvolution-2d.c`:
   - Validated `filter_value->shape.num_dims == 4` and matching dimensions `[groups * group_output_channels, kernel_height, kernel_width, group_input_channels]`.
3. In `src/subgraph/depthwise-convolution-2d.c`:
   - Validated `filter_value->shape.num_dims == 4` and matching dimensions `[1, kernel_height, kernel_width, input_channels * depth_multiplier]`.
4. In `test/subgraph/convolution-2d.cc`:
   - Added regression test `Convolution2D.define_rejects_filter_shape_mismatch` ensuring that `xnn_define_convolution_2d` returns `xnn_status_invalid_parameter` when filter shape mismatches kernel parameters.
