### PR TITLE
Add native, WASM, and scalar F16 raddstoreexpminusmax kernels

### DIFF
--- a/cmake/gen/avx512f_microkernels.cmake
+++ b/cmake/gen/avx512f_microkernels.cmake
@@ -89,6 +89,7 @@ SET(PROD_AVX512F_MICROKERNEL_SRCS
   src/x32-packw/gen/x32-packw-x32c2-gemm-goi-avx512f-u4-prfm.c)
 
 SET(NON_PROD_AVX512F_MICROKERNEL_SRCS
+  src/f16-raddstoreexpminusmax/gen/f16-f32acc-raddstoreexpminusmax-avx512f-rr2-p5-u16.c
   src/f16-vapproxgelu/gen/f16-f32acc-vapproxgelu-avx512f-rational-6-4-nr.c
   src/f16-vlog/gen/f16-f32acc-vlog-avx512f-rational-1-3-nr.c
   src/f16-vtanh/gen/f16-f32acc-vtanh-avx512f-rational-5-4-nr.c

--- a/cmake/gen/avx512fp16_microkernels.cmake
+++ b/cmake/gen/avx512fp16_microkernels.cmake
@@ -70,6 +70,7 @@ SET(NON_PROD_AVX512FP16_MICROKERNEL_SRCS
   src/f16-igemm/gen/f16-igemm-7x32-minmax-avx512fp16-broadcast.c
   src/f16-igemm/gen/f16-igemm-7x64-minmax-avx512fp16-broadcast.c
   src/f16-igemm/gen/f16-igemm-8x64-minmax-avx512fp16-broadcast.c
+  src/f16-raddstoreexpminusmax/gen/f16-raddstoreexpminusmax-avx512fp16-rr2-p2-u32.c
   src/f16-rminmax/gen/f16-rmax-avx512fp16-u32.c
   src/f16-rminmax/gen/f16-rmax-avx512fp16-u64-acc2.c
   src/f16-rminmax/gen/f16-rmax-avx512fp16-u96-acc3.c

--- a/cmake/gen/f16c_microkernels.cmake
+++ b/cmake/gen/f16c_microkernels.cmake
@@ -63,6 +63,7 @@ SET(NON_PROD_F16C_MICROKERNEL_SRCS
   src/f16-f32acc-rsum/gen/f16-f32acc-rsum-f16c-u16-acc2.c
   src/f16-f32acc-rsum/gen/f16-f32acc-rsum-f16c-u24-acc3.c
   src/f16-f32acc-rsum/gen/f16-f32acc-rsum-f16c-u32-acc2.c
+  src/f16-raddstoreexpminusmax/gen/f16-f32acc-raddstoreexpminusmax-f16c-rr2-p5-u8.c
   src/f16-vapproxgelu/gen/f16-f32acc-vapproxgelu-f16c-rational-6-4-nr.c
   src/f16-vbinary/gen/f16-vadd-f16c-u8.c
   src/f16-vbinary/gen/f16-vaddc-f16c-u8.c

--- a/cmake/gen/scalar_microkernels.cmake
+++ b/cmake/gen/scalar_microkernels.cmake
@@ -25,6 +25,7 @@ SET(PROD_SCALAR_MICROKERNEL_SRCS
   src/f16-f32-vcvt/gen/f16-f32-vcvt-scalar-u4.c
   src/f16-qs8-vcvt/gen/f16-qs8-vcvt-scalar-imagic-u4.c
   src/f16-qu8-vcvt/gen/f16-qu8-vcvt-scalar-imagic-u4.c
+  src/f16-raddstoreexpminusmax/gen/f16-raddstoreexpminusmax-scalar-rr2-p2-u1.c
   src/f16-rdminmax/gen/f16-rdmax-2p2x-scalar-u2.c
   src/f16-rdminmax/gen/f16-rdmin-2p2x-scalar-u2.c
   src/f16-rminmax/gen/f16-rmax-scalar-u2-acc2.c

--- a/cmake/gen/wasmrelaxedsimd_microkernels.cmake
+++ b/cmake/gen/wasmrelaxedsimd_microkernels.cmake
@@ -14,6 +14,7 @@ SET(PROD_WASMRELAXEDSIMD_MICROKERNEL_SRCS
   src/f16-dwconv/gen/f16-f32acc-dwconv-9p8c-minmax-wasmrelaxedsimd.c
   src/f16-dwconv/gen/f16-f32acc-dwconv-25p8c-minmax-wasmrelaxedsimd-acc2.c
   src/f16-f32-vcvt/gen/f16-f32-vcvt-wasmrelaxedsimd-int16-u16.c
+  src/f16-raddstoreexpminusmax/gen/f16-f32acc-raddstoreexpminusmax-wasmrelaxedsimd-rr2-p5-u4.c
   src/f16-vapproxgelu/gen/f16-f32acc-vapproxgelu-wasmrelaxedsimd-rational-6-4-div.c
   src/f16-vcos/gen/f16-f32acc-vcos-wasmrelaxedsimd-poly-3.c
   src/f16-vexp/gen/f16-f32acc-vexp-wasmrelaxedsimd-poly-3.c

--- a/cmake/gen/wasmrelaxedsimdfp16_microkernels.cmake
+++ b/cmake/gen/wasmrelaxedsimdfp16_microkernels.cmake
@@ -13,6 +13,7 @@ SET(PROD_WASMRELAXEDSIMDFP16_MICROKERNEL_SRCS
   src/f16-avgpool/gen/f16-avgpool-9p-minmax-wasmrelaxedsimdfp16-u8.c
   src/f16-dwconv/gen/f16-dwconv-9p8c-minmax-wasmrelaxedsimd.c
   src/f16-dwconv/gen/f16-dwconv-25p8c-minmax-wasmrelaxedsimd-acc2.c
+  src/f16-raddstoreexpminusmax/gen/f16-raddstoreexpminusmax-wasmrelaxedsimdfp16-rr2-p2-u8.c
   src/f16-rminmax/gen/f16-rmax-wasmrelaxedsimdfp16-u32-acc2.c
   src/f16-vapproxgelu/gen/f16-vapproxgelu-wasmrelaxedsimd-rational-6-4-div.c
   src/f16-vcos/gen/f16-vcos-wasmrelaxedsimd-poly-3.c

--- a/gen/avx512f_microkernels.bzl
+++ b/gen/avx512f_microkernels.bzl
@@ -86,6 +86,7 @@ PROD_AVX512F_MICROKERNEL_SRCS = [
 ]
 
 NON_PROD_AVX512F_MICROKERNEL_SRCS = [
+    "src/f16-raddstoreexpminusmax/gen/f16-f32acc-raddstoreexpminusmax-avx512f-rr2-p5-u16.c",
     "src/f16-vapproxgelu/gen/f16-f32acc-vapproxgelu-avx512f-rational-6-4-nr.c",
     "src/f16-vlog/gen/f16-f32acc-vlog-avx512f-rational-1-3-nr.c",
     "src/f16-vtanh/gen/f16-f32acc-vtanh-avx512f-rational-5-4-nr.c",

--- a/gen/avx512fp16_microkernels.bzl
+++ b/gen/avx512fp16_microkernels.bzl
@@ -67,6 +67,7 @@ NON_PROD_AVX512FP16_MICROKERNEL_SRCS = [
     "src/f16-igemm/gen/f16-igemm-7x32-minmax-avx512fp16-broadcast.c",
     "src/f16-igemm/gen/f16-igemm-7x64-minmax-avx512fp16-broadcast.c",
     "src/f16-igemm/gen/f16-igemm-8x64-minmax-avx512fp16-broadcast.c",
+    "src/f16-raddstoreexpminusmax/gen/f16-raddstoreexpminusmax-avx512fp16-rr2-p2-u32.c",
     "src/f16-rminmax/gen/f16-rmax-avx512fp16-u32.c",
     "src/f16-rminmax/gen/f16-rmax-avx512fp16-u64-acc2.c",
     "src/f16-rminmax/gen/f16-rmax-avx512fp16-u96-acc3.c",

--- a/gen/f16c_microkernels.bzl
+++ b/gen/f16c_microkernels.bzl
@@ -60,6 +60,7 @@ NON_PROD_F16C_MICROKERNEL_SRCS = [
     "src/f16-f32acc-rsum/gen/f16-f32acc-rsum-f16c-u16-acc2.c",
     "src/f16-f32acc-rsum/gen/f16-f32acc-rsum-f16c-u24-acc3.c",
     "src/f16-f32acc-rsum/gen/f16-f32acc-rsum-f16c-u32-acc2.c",
+    "src/f16-raddstoreexpminusmax/gen/f16-f32acc-raddstoreexpminusmax-f16c-rr2-p5-u8.c",
     "src/f16-vapproxgelu/gen/f16-f32acc-vapproxgelu-f16c-rational-6-4-nr.c",
     "src/f16-vbinary/gen/f16-vadd-f16c-u8.c",
     "src/f16-vbinary/gen/f16-vaddc-f16c-u8.c",

--- a/gen/scalar_microkernels.bzl
+++ b/gen/scalar_microkernels.bzl
@@ -21,6 +21,7 @@ PROD_SCALAR_MICROKERNEL_SRCS = [
     "src/f16-f32-vcvt/gen/f16-f32-vcvt-scalar-u4.c",
     "src/f16-qs8-vcvt/gen/f16-qs8-vcvt-scalar-imagic-u4.c",
     "src/f16-qu8-vcvt/gen/f16-qu8-vcvt-scalar-imagic-u4.c",
+    "src/f16-raddstoreexpminusmax/gen/f16-raddstoreexpminusmax-scalar-rr2-p2-u1.c",
     "src/f16-rdminmax/gen/f16-rdmax-2p2x-scalar-u2.c",
     "src/f16-rdminmax/gen/f16-rdmin-2p2x-scalar-u2.c",
     "src/f16-rminmax/gen/f16-rmax-scalar-u2-acc2.c",

--- a/gen/wasmrelaxedsimd_microkernels.bzl
+++ b/gen/wasmrelaxedsimd_microkernels.bzl
@@ -10,6 +10,7 @@ PROD_WASMRELAXEDSIMD_MICROKERNEL_SRCS = [
     "src/f16-dwconv/gen/f16-f32acc-dwconv-9p8c-minmax-wasmrelaxedsimd.c",
     "src/f16-dwconv/gen/f16-f32acc-dwconv-25p8c-minmax-wasmrelaxedsimd-acc2.c",
     "src/f16-f32-vcvt/gen/f16-f32-vcvt-wasmrelaxedsimd-int16-u16.c",
+    "src/f16-raddstoreexpminusmax/gen/f16-f32acc-raddstoreexpminusmax-wasmrelaxedsimd-rr2-p5-u4.c",
     "src/f16-vapproxgelu/gen/f16-f32acc-vapproxgelu-wasmrelaxedsimd-rational-6-4-div.c",
     "src/f16-vcos/gen/f16-f32acc-vcos-wasmrelaxedsimd-poly-3.c",
     "src/f16-vexp/gen/f16-f32acc-vexp-wasmrelaxedsimd-poly-3.c",

--- a/gen/wasmrelaxedsimdfp16_microkernels.bzl
+++ b/gen/wasmrelaxedsimdfp16_microkernels.bzl
@@ -9,6 +9,7 @@ PROD_WASMRELAXEDSIMDFP16_MICROKERNEL_SRCS = [
     "src/f16-avgpool/gen/f16-avgpool-9p-minmax-wasmrelaxedsimdfp16-u8.c",
     "src/f16-dwconv/gen/f16-dwconv-9p8c-minmax-wasmrelaxedsimd.c",
     "src/f16-dwconv/gen/f16-dwconv-25p8c-minmax-wasmrelaxedsimd-acc2.c",
+    "src/f16-raddstoreexpminusmax/gen/f16-raddstoreexpminusmax-wasmrelaxedsimdfp16-rr2-p2-u8.c",
     "src/f16-rminmax/gen/f16-rmax-wasmrelaxedsimdfp16-u32-acc2.c",
     "src/f16-vapproxgelu/gen/f16-vapproxgelu-wasmrelaxedsimd-rational-6-4-div.c",
     "src/f16-vcos/gen/f16-vcos-wasmrelaxedsimd-poly-3.c",

--- a/scripts/generate-f16-raddstoreexpminusmax.sh
+++ b/scripts/generate-f16-raddstoreexpminusmax.sh
@@ -4,6 +4,12 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# Scalar
+tools/xngen src/f16-raddstoreexpminusmax/rr2-p2.c.in -D ARCH=scalar -o src/f16-raddstoreexpminusmax/gen/f16-raddstoreexpminusmax-scalar-rr2-p2-u1.c &
+
+# Portable FP16 arithmetic
+tools/xngen src/f16-raddstoreexpminusmax/rr2-p2.c.in -D ARCH=avx512fp16 -o src/f16-raddstoreexpminusmax/gen/f16-raddstoreexpminusmax-avx512fp16-rr2-p2-u32.c &
+
 # ARM NEON+FP16ARITH
 tools/xngen src/f16-raddstoreexpminusmax/neonfp16arith-rr2-p2.c.in -D BATCH_TILE=16 -D ACCUMULATORS=1 -o src/f16-raddstoreexpminusmax/gen/f16-raddstoreexpminusmax-neonfp16arith-rr2-p2-u16.c &
 tools/xngen src/f16-raddstoreexpminusmax/neonfp16arith-rr2-p2.c.in -D BATCH_TILE=16 -D ACCUMULATORS=2 -o src/f16-raddstoreexpminusmax/gen/f16-raddstoreexpminusmax-neonfp16arith-rr2-p2-u16-acc2.c &
@@ -31,3 +37,15 @@ tools/xngen src/f16-raddstoreexpminusmax/avx2-rr1-p2.c.in -D BATCH_TILE=64 -D AC
 tools/xngen src/f16-raddstoreexpminusmax/rvvfp16arith-rr2-p2.c.in -D LMUL=1 -o src/f16-raddstoreexpminusmax/gen/f16-raddstoreexpminusmax-rvvfp16arith-rr2-p2-u1v.c &
 tools/xngen src/f16-raddstoreexpminusmax/rvvfp16arith-rr2-p2.c.in -D LMUL=2 -o src/f16-raddstoreexpminusmax/gen/f16-raddstoreexpminusmax-rvvfp16arith-rr2-p2-u2v.c &
 tools/xngen src/f16-raddstoreexpminusmax/rvvfp16arith-rr2-p2.c.in -D LMUL=4 -o src/f16-raddstoreexpminusmax/gen/f16-raddstoreexpminusmax-rvvfp16arith-rr2-p2-u4v.c &
+
+# WebAssembly Relaxed SIMD FP16
+tools/xngen src/f16-raddstoreexpminusmax/rr2-p2.c.in -D ARCH=wasmrelaxedsimdfp16 -o src/f16-raddstoreexpminusmax/gen/f16-raddstoreexpminusmax-wasmrelaxedsimdfp16-rr2-p2-u8.c &
+
+# WebAssembly Relaxed SIMD with FP32 accumulation
+tools/xngen src/f16-raddstoreexpminusmax/f16-f32acc-rr2-p5.c.in -D ARCH=wasmrelaxedsimd -o src/f16-raddstoreexpminusmax/gen/f16-f32acc-raddstoreexpminusmax-wasmrelaxedsimd-rr2-p5-u4.c &
+
+# Portable FP32 accumulation
+tools/xngen src/f16-raddstoreexpminusmax/f16-f32acc-rr2-p5.c.in -D ARCH=f16c -o src/f16-raddstoreexpminusmax/gen/f16-f32acc-raddstoreexpminusmax-f16c-rr2-p5-u8.c &
+tools/xngen src/f16-raddstoreexpminusmax/f16-f32acc-rr2-p5.c.in -D ARCH=avx512f -o src/f16-raddstoreexpminusmax/gen/f16-f32acc-raddstoreexpminusmax-avx512f-rr2-p5-u16.c &
+
+wait

--- a/src/configs/raddstoreexpminusmax-config.c
+++ b/src/configs/raddstoreexpminusmax-config.c
@@ -61,7 +61,14 @@ static void init_f16_raddstoreexpminusmax_config(void) {
     if (hardware_config->arch_flags & xnn_arch_riscv_vector_fp16_arith) {
       f16_raddstoreexpminusmax_config.ukernel = XNN_INIT_RADDSTOREEXPMINUSMAX_UKERNEL(xnn_f16_raddstoreexpminusmax_ukernel__rvvfp16arith_rr2_p2_u4v);
     }
+  #elif XNN_ARCH_WASMRELAXEDSIMDFP16
+    f16_raddstoreexpminusmax_config.ukernel = XNN_INIT_RADDSTOREEXPMINUSMAX_UKERNEL(xnn_f16_raddstoreexpminusmax_ukernel__wasmrelaxedsimdfp16_rr2_p2_u8);
+  #elif XNN_ARCH_WASMRELAXEDSIMD
+    f16_raddstoreexpminusmax_config.ukernel = XNN_INIT_RADDSTOREEXPMINUSMAX_UKERNEL(xnn_f16_f32acc_raddstoreexpminusmax_ukernel__wasmrelaxedsimd_rr2_p5_u4);
   #endif
+  if (f16_raddstoreexpminusmax_config.ukernel == NULL) {
+    f16_raddstoreexpminusmax_config.ukernel = XNN_INIT_RADDSTOREEXPMINUSMAX_UKERNEL(xnn_f16_raddstoreexpminusmax_ukernel__scalar_rr2_p2_u1);
+  }
 }
 
 static void init_f32_raddstoreexpminusmax_config_impl(struct xnn_raddstoreexpminusmax_config* config, bool consistent_arithmetic) {
@@ -128,25 +135,15 @@ static void init_f32_raddstoreexpminusmax_config(void) {
   init_f32_raddstoreexpminusmax_config_impl(&f32_raddstoreexpminusmax_config[consistent_config], true);
 }
 
-static bool is_f16_compatible_config(const struct xnn_hardware_config* hardware_config) {
-  #if (XNN_ARCH_ARM && XNN_ENABLE_ARM_FP16_VECTOR && XNN_ENABLE_ARM_FP16_SCALAR) || (XNN_ENABLE_ARM_FP16_VECTOR && XNN_ARCH_ARM64)
-    return (hardware_config->arch_flags & xnn_arch_arm_neon_fp16_arith);
-  #elif XNN_ARCH_X86 || XNN_ARCH_X86_64
-    return (hardware_config->arch_flags & xnn_arch_x86_avx2);
-  #elif XNN_ARCH_RISCV && XNN_ENABLE_RISCV_FP16_VECTOR
-    return (hardware_config->arch_flags & xnn_arch_riscv_vector_fp16_arith);
-  #else
-    return false;
-  #endif
-}
-
 const struct xnn_raddstoreexpminusmax_config* xnn_init_f16_raddstoreexpminusmax_config() {
   const struct xnn_hardware_config* hardware_config = xnn_init_hardware_config();
-  if (hardware_config == NULL || !is_f16_compatible_config(hardware_config)) {
+  if (hardware_config == NULL) {
     return NULL;
   }
   XNN_INIT_ONCE(f16_raddstoreexpminusmax);
-  return &f16_raddstoreexpminusmax_config;
+  return f16_raddstoreexpminusmax_config.ukernel != NULL
+      ? &f16_raddstoreexpminusmax_config
+      : NULL;
 }
 
 const struct xnn_raddstoreexpminusmax_config* xnn_init_f32_raddstoreexpminusmax_config(uint32_t flags) {

--- a/src/f16-raddstoreexpminusmax/f16-f32acc-rr2-p5.c.in
+++ b/src/f16-raddstoreexpminusmax/f16-f32acc-rr2-p5.c.in
@@ -1,0 +1,128 @@
+// Copyright 2026 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+$SIMD_SIZE = {
+$  "wasmrelaxedsimd": 4,
+$  "f16c": 8,
+$  "avx512f": 16,
+$}[ARCH]
+#include <assert.h>
+#include <stddef.h>
+
+#include "src/xnnpack/common.h"
+#include "src/xnnpack/math.h"
+#include "src/xnnpack/raddstoreexpminusmax.h"
+
+$SIMD_ARCH = {
+$  "f16c": "avx",
+$}.get(ARCH, ARCH)
+#include "src/xnnpack/simd/f32-${SIMD_ARCH}.h"
+
+$if ARCH == "wasmrelaxedsimd":
+  #undef XNN_SIMD_HAS_NATIVE_FMA
+  #include "src/xnnpack/simd/f16-wasmrelaxedsimd.h"
+$elif ARCH not in ("f16c", "avx512f"):
+  #include "src/xnnpack/simd/f16-scalar.h"
+
+
+static XNN_INLINE xnn_simd_f32_t load_f16_f32(const xnn_float16* input) {
+  return xnn_cvt_f32_f16(xnn_loadu_f16(input));
+}
+
+static XNN_INLINE xnn_simd_f32_t load_tail_f16_f32(
+    const xnn_float16* input, size_t elements)
+{
+  return xnn_cvt_f32_f16(xnn_load_tail_f16(input, elements));
+}
+
+static XNN_INLINE xnn_simd_f32_t store_f32_f16(
+    xnn_float16* output, xnn_simd_f32_t value)
+{
+  const xnn_simd_f16_t rounded = xnn_cvt_f16_f32(value);
+  xnn_store_tail_f16(output, rounded, xnn_simd_size_f32);
+  return xnn_cvt_f32_f16(rounded);
+}
+
+static XNN_INLINE xnn_simd_f32_t store_tail_f32_f16(
+    xnn_float16* output, xnn_simd_f32_t value, size_t elements)
+{
+  const xnn_simd_f16_t rounded = xnn_cvt_f16_f32(value);
+  xnn_store_tail_f16(output, rounded, elements);
+  return xnn_cvt_f32_f16(rounded);
+}
+
+static XNN_INLINE xnn_simd_f32_t expminusmax_f32(
+    xnn_simd_f32_t vx, xnn_simd_f32_t vmax)
+{
+  XNN_SIMD_CONST_F32(vlog2e, 0x1.715476p+0f);
+  XNN_SIMD_CONST_F32(vmagic_bias, 0x1.8000FEp23f);
+  XNN_SIMD_CONST_F32(vminus_ln2_hi, -0x1.62E400p-1f);
+  XNN_SIMD_CONST_F32(vminus_ln2_lo, -0x1.7F7D1Cp-20f);
+  XNN_SIMD_CONST_F32(vc5, 0x1.0F9F9Cp-7f);
+  XNN_SIMD_CONST_F32(vc4, 0x1.573A1Ap-5f);
+  XNN_SIMD_CONST_F32(vc3, 0x1.555A80p-3f);
+  XNN_SIMD_CONST_F32(vc2, 0x1.FFFDC6p-2f);
+  XNN_SIMD_CONST_F32(vc1, 0x1.FFFFF6p-1f);
+  XNN_SIMD_CONST_F32(vdenorm_cutoff, -0x1.5D589Ep6f);
+
+  vx = xnn_max_f32(xnn_sub_f32(vx, vmax), vdenorm_cutoff);
+  xnn_simd_f32_t vn = xnn_fmadd_f32(vx, vlog2e, vmagic_bias);
+  const xnn_simd_f32_t vs = xnn_sll_f32(vn, 23);
+  vn = xnn_sub_f32(vn, vmagic_bias);
+
+  xnn_simd_f32_t vt = xnn_fmadd_f32(vn, vminus_ln2_hi, vx);
+  vt = xnn_fmadd_f32(vn, vminus_ln2_lo, vt);
+
+  xnn_simd_f32_t vp = xnn_fmadd_f32(vc5, vt, vc4);
+  vp = xnn_fmadd_f32(vp, vt, vc3);
+  vp = xnn_fmadd_f32(vp, vt, vc2);
+  vp = xnn_fmadd_f32(vp, vt, vc1);
+
+  vt = xnn_mul_f32(vt, vs);
+  return xnn_fmadd_f32(vt, vp, vs);
+}
+
+void xnn_f16_f32acc_raddstoreexpminusmax_ukernel__${ARCH}_rr2_p5_u${SIMD_SIZE}(
+    size_t batch,
+    const xnn_float16* input,
+    const xnn_float16* max,
+    xnn_float16* output,
+    float* sum,
+    const void* params)
+{
+  assert(batch != 0);
+  assert(batch % sizeof(xnn_float16) == 0);
+  assert(input != NULL);
+  assert(max != NULL);
+  assert(output != NULL);
+  assert(sum != NULL);
+
+  const xnn_simd_f32_t vmax = xnn_set1_f32(xnn_float16_to_float(*max));
+  xnn_simd_f32_t vacc = xnn_zero_f32();
+  for (; batch >= ${SIMD_SIZE} * sizeof(xnn_float16);
+       batch -= ${SIMD_SIZE} * sizeof(xnn_float16)) {
+    const xnn_simd_f32_t vf = expminusmax_f32(load_f16_f32(input), vmax);
+    input += ${SIMD_SIZE};
+    vacc = xnn_add_f32(vacc, store_f32_f16(output, vf));
+    output += ${SIMD_SIZE};
+  }
+
+  float vsum = xnn_reduce_add_f32(vacc);
+  $if SIMD_SIZE > 1:
+    if XNN_UNLIKELY(batch != 0) {
+      const size_t num_elements = batch / sizeof(xnn_float16);
+      const xnn_simd_f32_t vf =
+          expminusmax_f32(load_tail_f16_f32(input, num_elements), vmax);
+      const xnn_simd_f32_t rounded =
+          store_tail_f32_f16(output, vf, num_elements);
+
+      XNN_ALIGN(128) float values[xnn_simd_size_f32];
+      xnn_storeu_f32(values, rounded);
+      for (size_t i = 0; i < num_elements; i++) {
+        vsum += values[i];
+      }
+    }
+  *sum = vsum;
+}

--- a/src/f16-raddstoreexpminusmax/gen/f16-f32acc-raddstoreexpminusmax-avx512f-rr2-p5-u16.c
+++ b/src/f16-raddstoreexpminusmax/gen/f16-f32acc-raddstoreexpminusmax-avx512f-rr2-p5-u16.c
@@ -1,0 +1,119 @@
+// clang-format off
+// Auto-generated file. Do not edit!
+//   Template: src/f16-raddstoreexpminusmax/f16-f32acc-rr2-p5.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2026 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+#include <stddef.h>
+
+#include "src/xnnpack/common.h"
+#include "src/xnnpack/math.h"
+#include "src/xnnpack/raddstoreexpminusmax.h"
+
+#include "src/xnnpack/simd/f32-avx512f.h"
+
+
+
+static XNN_INLINE xnn_simd_f32_t load_f16_f32(const xnn_float16* input) {
+  return xnn_cvt_f32_f16(xnn_loadu_f16(input));
+}
+
+static XNN_INLINE xnn_simd_f32_t load_tail_f16_f32(
+    const xnn_float16* input, size_t elements)
+{
+  return xnn_cvt_f32_f16(xnn_load_tail_f16(input, elements));
+}
+
+static XNN_INLINE xnn_simd_f32_t store_f32_f16(
+    xnn_float16* output, xnn_simd_f32_t value)
+{
+  const xnn_simd_f16_t rounded = xnn_cvt_f16_f32(value);
+  xnn_store_tail_f16(output, rounded, xnn_simd_size_f32);
+  return xnn_cvt_f32_f16(rounded);
+}
+
+static XNN_INLINE xnn_simd_f32_t store_tail_f32_f16(
+    xnn_float16* output, xnn_simd_f32_t value, size_t elements)
+{
+  const xnn_simd_f16_t rounded = xnn_cvt_f16_f32(value);
+  xnn_store_tail_f16(output, rounded, elements);
+  return xnn_cvt_f32_f16(rounded);
+}
+
+static XNN_INLINE xnn_simd_f32_t expminusmax_f32(
+    xnn_simd_f32_t vx, xnn_simd_f32_t vmax)
+{
+  XNN_SIMD_CONST_F32(vlog2e, 0x1.715476p+0f);
+  XNN_SIMD_CONST_F32(vmagic_bias, 0x1.8000FEp23f);
+  XNN_SIMD_CONST_F32(vminus_ln2_hi, -0x1.62E400p-1f);
+  XNN_SIMD_CONST_F32(vminus_ln2_lo, -0x1.7F7D1Cp-20f);
+  XNN_SIMD_CONST_F32(vc5, 0x1.0F9F9Cp-7f);
+  XNN_SIMD_CONST_F32(vc4, 0x1.573A1Ap-5f);
+  XNN_SIMD_CONST_F32(vc3, 0x1.555A80p-3f);
+  XNN_SIMD_CONST_F32(vc2, 0x1.FFFDC6p-2f);
+  XNN_SIMD_CONST_F32(vc1, 0x1.FFFFF6p-1f);
+  XNN_SIMD_CONST_F32(vdenorm_cutoff, -0x1.5D589Ep6f);
+
+  vx = xnn_max_f32(xnn_sub_f32(vx, vmax), vdenorm_cutoff);
+  xnn_simd_f32_t vn = xnn_fmadd_f32(vx, vlog2e, vmagic_bias);
+  const xnn_simd_f32_t vs = xnn_sll_f32(vn, 23);
+  vn = xnn_sub_f32(vn, vmagic_bias);
+
+  xnn_simd_f32_t vt = xnn_fmadd_f32(vn, vminus_ln2_hi, vx);
+  vt = xnn_fmadd_f32(vn, vminus_ln2_lo, vt);
+
+  xnn_simd_f32_t vp = xnn_fmadd_f32(vc5, vt, vc4);
+  vp = xnn_fmadd_f32(vp, vt, vc3);
+  vp = xnn_fmadd_f32(vp, vt, vc2);
+  vp = xnn_fmadd_f32(vp, vt, vc1);
+
+  vt = xnn_mul_f32(vt, vs);
+  return xnn_fmadd_f32(vt, vp, vs);
+}
+
+void xnn_f16_f32acc_raddstoreexpminusmax_ukernel__avx512f_rr2_p5_u16(
+    size_t batch,
+    const xnn_float16* input,
+    const xnn_float16* max,
+    xnn_float16* output,
+    float* sum,
+    const void* params)
+{
+  assert(batch != 0);
+  assert(batch % sizeof(xnn_float16) == 0);
+  assert(input != NULL);
+  assert(max != NULL);
+  assert(output != NULL);
+  assert(sum != NULL);
+
+  const xnn_simd_f32_t vmax = xnn_set1_f32(xnn_float16_to_float(*max));
+  xnn_simd_f32_t vacc = xnn_zero_f32();
+  for (; batch >= 16 * sizeof(xnn_float16);
+       batch -= 16 * sizeof(xnn_float16)) {
+    const xnn_simd_f32_t vf = expminusmax_f32(load_f16_f32(input), vmax);
+    input += 16;
+    vacc = xnn_add_f32(vacc, store_f32_f16(output, vf));
+    output += 16;
+  }
+
+  float vsum = xnn_reduce_add_f32(vacc);
+  if XNN_UNLIKELY(batch != 0) {
+    const size_t num_elements = batch / sizeof(xnn_float16);
+    const xnn_simd_f32_t vf =
+        expminusmax_f32(load_tail_f16_f32(input, num_elements), vmax);
+    const xnn_simd_f32_t rounded =
+        store_tail_f32_f16(output, vf, num_elements);
+
+    XNN_ALIGN(128) float values[xnn_simd_size_f32];
+    xnn_storeu_f32(values, rounded);
+    for (size_t i = 0; i < num_elements; i++) {
+      vsum += values[i];
+    }
+  }
+  *sum = vsum;
+}

--- a/src/f16-raddstoreexpminusmax/gen/f16-f32acc-raddstoreexpminusmax-f16c-rr2-p5-u8.c
+++ b/src/f16-raddstoreexpminusmax/gen/f16-f32acc-raddstoreexpminusmax-f16c-rr2-p5-u8.c
@@ -1,0 +1,119 @@
+// clang-format off
+// Auto-generated file. Do not edit!
+//   Template: src/f16-raddstoreexpminusmax/f16-f32acc-rr2-p5.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2026 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+#include <stddef.h>
+
+#include "src/xnnpack/common.h"
+#include "src/xnnpack/math.h"
+#include "src/xnnpack/raddstoreexpminusmax.h"
+
+#include "src/xnnpack/simd/f32-avx.h"
+
+
+
+static XNN_INLINE xnn_simd_f32_t load_f16_f32(const xnn_float16* input) {
+  return xnn_cvt_f32_f16(xnn_loadu_f16(input));
+}
+
+static XNN_INLINE xnn_simd_f32_t load_tail_f16_f32(
+    const xnn_float16* input, size_t elements)
+{
+  return xnn_cvt_f32_f16(xnn_load_tail_f16(input, elements));
+}
+
+static XNN_INLINE xnn_simd_f32_t store_f32_f16(
+    xnn_float16* output, xnn_simd_f32_t value)
+{
+  const xnn_simd_f16_t rounded = xnn_cvt_f16_f32(value);
+  xnn_store_tail_f16(output, rounded, xnn_simd_size_f32);
+  return xnn_cvt_f32_f16(rounded);
+}
+
+static XNN_INLINE xnn_simd_f32_t store_tail_f32_f16(
+    xnn_float16* output, xnn_simd_f32_t value, size_t elements)
+{
+  const xnn_simd_f16_t rounded = xnn_cvt_f16_f32(value);
+  xnn_store_tail_f16(output, rounded, elements);
+  return xnn_cvt_f32_f16(rounded);
+}
+
+static XNN_INLINE xnn_simd_f32_t expminusmax_f32(
+    xnn_simd_f32_t vx, xnn_simd_f32_t vmax)
+{
+  XNN_SIMD_CONST_F32(vlog2e, 0x1.715476p+0f);
+  XNN_SIMD_CONST_F32(vmagic_bias, 0x1.8000FEp23f);
+  XNN_SIMD_CONST_F32(vminus_ln2_hi, -0x1.62E400p-1f);
+  XNN_SIMD_CONST_F32(vminus_ln2_lo, -0x1.7F7D1Cp-20f);
+  XNN_SIMD_CONST_F32(vc5, 0x1.0F9F9Cp-7f);
+  XNN_SIMD_CONST_F32(vc4, 0x1.573A1Ap-5f);
+  XNN_SIMD_CONST_F32(vc3, 0x1.555A80p-3f);
+  XNN_SIMD_CONST_F32(vc2, 0x1.FFFDC6p-2f);
+  XNN_SIMD_CONST_F32(vc1, 0x1.FFFFF6p-1f);
+  XNN_SIMD_CONST_F32(vdenorm_cutoff, -0x1.5D589Ep6f);
+
+  vx = xnn_max_f32(xnn_sub_f32(vx, vmax), vdenorm_cutoff);
+  xnn_simd_f32_t vn = xnn_fmadd_f32(vx, vlog2e, vmagic_bias);
+  const xnn_simd_f32_t vs = xnn_sll_f32(vn, 23);
+  vn = xnn_sub_f32(vn, vmagic_bias);
+
+  xnn_simd_f32_t vt = xnn_fmadd_f32(vn, vminus_ln2_hi, vx);
+  vt = xnn_fmadd_f32(vn, vminus_ln2_lo, vt);
+
+  xnn_simd_f32_t vp = xnn_fmadd_f32(vc5, vt, vc4);
+  vp = xnn_fmadd_f32(vp, vt, vc3);
+  vp = xnn_fmadd_f32(vp, vt, vc2);
+  vp = xnn_fmadd_f32(vp, vt, vc1);
+
+  vt = xnn_mul_f32(vt, vs);
+  return xnn_fmadd_f32(vt, vp, vs);
+}
+
+void xnn_f16_f32acc_raddstoreexpminusmax_ukernel__f16c_rr2_p5_u8(
+    size_t batch,
+    const xnn_float16* input,
+    const xnn_float16* max,
+    xnn_float16* output,
+    float* sum,
+    const void* params)
+{
+  assert(batch != 0);
+  assert(batch % sizeof(xnn_float16) == 0);
+  assert(input != NULL);
+  assert(max != NULL);
+  assert(output != NULL);
+  assert(sum != NULL);
+
+  const xnn_simd_f32_t vmax = xnn_set1_f32(xnn_float16_to_float(*max));
+  xnn_simd_f32_t vacc = xnn_zero_f32();
+  for (; batch >= 8 * sizeof(xnn_float16);
+       batch -= 8 * sizeof(xnn_float16)) {
+    const xnn_simd_f32_t vf = expminusmax_f32(load_f16_f32(input), vmax);
+    input += 8;
+    vacc = xnn_add_f32(vacc, store_f32_f16(output, vf));
+    output += 8;
+  }
+
+  float vsum = xnn_reduce_add_f32(vacc);
+  if XNN_UNLIKELY(batch != 0) {
+    const size_t num_elements = batch / sizeof(xnn_float16);
+    const xnn_simd_f32_t vf =
+        expminusmax_f32(load_tail_f16_f32(input, num_elements), vmax);
+    const xnn_simd_f32_t rounded =
+        store_tail_f32_f16(output, vf, num_elements);
+
+    XNN_ALIGN(128) float values[xnn_simd_size_f32];
+    xnn_storeu_f32(values, rounded);
+    for (size_t i = 0; i < num_elements; i++) {
+      vsum += values[i];
+    }
+  }
+  *sum = vsum;
+}

--- a/src/f16-raddstoreexpminusmax/gen/f16-f32acc-raddstoreexpminusmax-wasmrelaxedsimd-rr2-p5-u4.c
+++ b/src/f16-raddstoreexpminusmax/gen/f16-f32acc-raddstoreexpminusmax-wasmrelaxedsimd-rr2-p5-u4.c
@@ -1,0 +1,121 @@
+// clang-format off
+// Auto-generated file. Do not edit!
+//   Template: src/f16-raddstoreexpminusmax/f16-f32acc-rr2-p5.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2026 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+#include <stddef.h>
+
+#include "src/xnnpack/common.h"
+#include "src/xnnpack/math.h"
+#include "src/xnnpack/raddstoreexpminusmax.h"
+
+#include "src/xnnpack/simd/f32-wasmrelaxedsimd.h"
+
+#undef XNN_SIMD_HAS_NATIVE_FMA
+#include "src/xnnpack/simd/f16-wasmrelaxedsimd.h"
+
+
+static XNN_INLINE xnn_simd_f32_t load_f16_f32(const xnn_float16* input) {
+  return xnn_cvt_f32_f16(xnn_loadu_f16(input));
+}
+
+static XNN_INLINE xnn_simd_f32_t load_tail_f16_f32(
+    const xnn_float16* input, size_t elements)
+{
+  return xnn_cvt_f32_f16(xnn_load_tail_f16(input, elements));
+}
+
+static XNN_INLINE xnn_simd_f32_t store_f32_f16(
+    xnn_float16* output, xnn_simd_f32_t value)
+{
+  const xnn_simd_f16_t rounded = xnn_cvt_f16_f32(value);
+  xnn_store_tail_f16(output, rounded, xnn_simd_size_f32);
+  return xnn_cvt_f32_f16(rounded);
+}
+
+static XNN_INLINE xnn_simd_f32_t store_tail_f32_f16(
+    xnn_float16* output, xnn_simd_f32_t value, size_t elements)
+{
+  const xnn_simd_f16_t rounded = xnn_cvt_f16_f32(value);
+  xnn_store_tail_f16(output, rounded, elements);
+  return xnn_cvt_f32_f16(rounded);
+}
+
+static XNN_INLINE xnn_simd_f32_t expminusmax_f32(
+    xnn_simd_f32_t vx, xnn_simd_f32_t vmax)
+{
+  XNN_SIMD_CONST_F32(vlog2e, 0x1.715476p+0f);
+  XNN_SIMD_CONST_F32(vmagic_bias, 0x1.8000FEp23f);
+  XNN_SIMD_CONST_F32(vminus_ln2_hi, -0x1.62E400p-1f);
+  XNN_SIMD_CONST_F32(vminus_ln2_lo, -0x1.7F7D1Cp-20f);
+  XNN_SIMD_CONST_F32(vc5, 0x1.0F9F9Cp-7f);
+  XNN_SIMD_CONST_F32(vc4, 0x1.573A1Ap-5f);
+  XNN_SIMD_CONST_F32(vc3, 0x1.555A80p-3f);
+  XNN_SIMD_CONST_F32(vc2, 0x1.FFFDC6p-2f);
+  XNN_SIMD_CONST_F32(vc1, 0x1.FFFFF6p-1f);
+  XNN_SIMD_CONST_F32(vdenorm_cutoff, -0x1.5D589Ep6f);
+
+  vx = xnn_max_f32(xnn_sub_f32(vx, vmax), vdenorm_cutoff);
+  xnn_simd_f32_t vn = xnn_fmadd_f32(vx, vlog2e, vmagic_bias);
+  const xnn_simd_f32_t vs = xnn_sll_f32(vn, 23);
+  vn = xnn_sub_f32(vn, vmagic_bias);
+
+  xnn_simd_f32_t vt = xnn_fmadd_f32(vn, vminus_ln2_hi, vx);
+  vt = xnn_fmadd_f32(vn, vminus_ln2_lo, vt);
+
+  xnn_simd_f32_t vp = xnn_fmadd_f32(vc5, vt, vc4);
+  vp = xnn_fmadd_f32(vp, vt, vc3);
+  vp = xnn_fmadd_f32(vp, vt, vc2);
+  vp = xnn_fmadd_f32(vp, vt, vc1);
+
+  vt = xnn_mul_f32(vt, vs);
+  return xnn_fmadd_f32(vt, vp, vs);
+}
+
+void xnn_f16_f32acc_raddstoreexpminusmax_ukernel__wasmrelaxedsimd_rr2_p5_u4(
+    size_t batch,
+    const xnn_float16* input,
+    const xnn_float16* max,
+    xnn_float16* output,
+    float* sum,
+    const void* params)
+{
+  assert(batch != 0);
+  assert(batch % sizeof(xnn_float16) == 0);
+  assert(input != NULL);
+  assert(max != NULL);
+  assert(output != NULL);
+  assert(sum != NULL);
+
+  const xnn_simd_f32_t vmax = xnn_set1_f32(xnn_float16_to_float(*max));
+  xnn_simd_f32_t vacc = xnn_zero_f32();
+  for (; batch >= 4 * sizeof(xnn_float16);
+       batch -= 4 * sizeof(xnn_float16)) {
+    const xnn_simd_f32_t vf = expminusmax_f32(load_f16_f32(input), vmax);
+    input += 4;
+    vacc = xnn_add_f32(vacc, store_f32_f16(output, vf));
+    output += 4;
+  }
+
+  float vsum = xnn_reduce_add_f32(vacc);
+  if XNN_UNLIKELY(batch != 0) {
+    const size_t num_elements = batch / sizeof(xnn_float16);
+    const xnn_simd_f32_t vf =
+        expminusmax_f32(load_tail_f16_f32(input, num_elements), vmax);
+    const xnn_simd_f32_t rounded =
+        store_tail_f32_f16(output, vf, num_elements);
+
+    XNN_ALIGN(128) float values[xnn_simd_size_f32];
+    xnn_storeu_f32(values, rounded);
+    for (size_t i = 0; i < num_elements; i++) {
+      vsum += values[i];
+    }
+  }
+  *sum = vsum;
+}

--- a/src/f16-raddstoreexpminusmax/gen/f16-raddstoreexpminusmax-avx512fp16-rr2-p2-u32.c
+++ b/src/f16-raddstoreexpminusmax/gen/f16-raddstoreexpminusmax-avx512fp16-rr2-p2-u32.c
@@ -1,0 +1,92 @@
+// clang-format off
+// Auto-generated file. Do not edit!
+//   Template: src/f16-raddstoreexpminusmax/rr2-p2.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2026 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+#include <stddef.h>
+
+#include "src/xnnpack/common.h"
+#include "src/xnnpack/math.h"
+#include "src/xnnpack/raddstoreexpminusmax.h"
+#include "src/xnnpack/simd/f16-avx512fp16.h"
+
+
+static XNN_INLINE xnn_simd_f16_t setexp_f16(xnn_simd_f16_t vx) {
+  XNN_SIMD_CONST_F16_FROM_FLOAT(vmagic, 1039.0f);
+  return xnn_sll_f16(xnn_add_f16(vx, vmagic), 10);
+}
+
+static XNN_INLINE xnn_simd_f16_t qd_round_f16(xnn_simd_f16_t vx) {
+  XNN_SIMD_CONST_F16_FROM_FLOAT(vmagic, 1536.0f);
+  return xnn_sub_f16(xnn_add_f16(vmagic, vx), vmagic);
+}
+
+static XNN_INLINE xnn_simd_f16_t expminusmax_f16(
+    xnn_simd_f16_t vx, xnn_simd_f16_t vmax)
+{
+  XNN_SIMD_CONST_F16_FROM_FLOAT(valpha_1, 0.6933594f);
+  XNN_SIMD_CONST_F16_FROM_FLOAT(valpha_2, 0.24255371f);
+  XNN_SIMD_CONST_F16_FROM_FLOAT(valpha_3, 0.05517578f);
+  XNN_SIMD_CONST_F16_FROM_FLOAT(vlog2e, 1.4423828f);
+  XNN_SIMD_CONST_F16_FROM_FLOAT(v16, 16.0f);
+  XNN_SIMD_CONST_F16_FROM_FLOAT(vm15, -15.0f);
+  XNN_SIMD_CONST_F16_FROM_FLOAT(vone, 1.0f);
+
+  vx = xnn_sub_f16(vx, vmax);
+  xnn_simd_f16_t vz_prime = xnn_mul_f16(vx, vlog2e);
+  vz_prime = xnn_min_f16(xnn_max_f16(vz_prime, vm15), v16);
+  const xnn_simd_f16_t vz = qd_round_f16(vz_prime);
+  const xnn_simd_f16_t vr = xnn_sub_f16(vz_prime, vz);
+  const xnn_simd_f16_t v2z = setexp_f16(vz);
+
+  xnn_simd_f16_t v2r = xnn_fmadd_f16(vr, valpha_3, valpha_2);
+  v2r = xnn_fmadd_f16(vr, v2r, valpha_1);
+  v2r = xnn_fmadd_f16(vr, v2r, vone);
+  return xnn_mul_f16(v2z, v2r);
+}
+
+void xnn_f16_raddstoreexpminusmax_ukernel__avx512fp16_rr2_p2_u32(
+    size_t batch,
+    const xnn_float16* input,
+    const xnn_float16* max,
+    xnn_float16* output,
+    float* sum,
+    const void* params)
+{
+  assert(batch != 0);
+  assert(batch % sizeof(xnn_float16) == 0);
+  assert(input != NULL);
+  assert(max != NULL);
+  assert(output != NULL);
+  assert(sum != NULL);
+
+  const xnn_simd_f16_t vmax = xnn_set1_f16(*max);
+  float vsum = 0.0f;
+  for (; batch >= xnn_simd_bytes_f16; batch -= xnn_simd_bytes_f16) {
+    const xnn_simd_f16_t vf = expminusmax_f16(xnn_loadu_f16(input), vmax);
+    input += xnn_simd_size_f16;
+    xnn_storeu_f16(output, vf);
+    output += xnn_simd_size_f16;
+    vsum += xnn_reduce_add_f16(vf);
+  }
+
+  if XNN_UNLIKELY(batch != 0) {
+    const size_t num_elements = batch / sizeof(xnn_float16);
+    const xnn_simd_f16_t vf =
+        expminusmax_f16(xnn_load_tail_f16(input, num_elements), vmax);
+    xnn_store_tail_f16(output, vf, num_elements);
+
+    XNN_ALIGN(64) xnn_float16 values[xnn_simd_size_f16];
+    xnn_storeu_f16(values, vf);
+    for (size_t i = 0; i < num_elements; i++) {
+      vsum += xnn_float16_to_float(values[i]);
+    }
+  }
+  *sum = vsum;
+}

--- a/src/f16-raddstoreexpminusmax/gen/f16-raddstoreexpminusmax-scalar-rr2-p2-u1.c
+++ b/src/f16-raddstoreexpminusmax/gen/f16-raddstoreexpminusmax-scalar-rr2-p2-u1.c
@@ -1,0 +1,80 @@
+// clang-format off
+// Auto-generated file. Do not edit!
+//   Template: src/f16-raddstoreexpminusmax/rr2-p2.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2026 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+#include <stddef.h>
+
+#include "src/xnnpack/common.h"
+#include "src/xnnpack/math.h"
+#include "src/xnnpack/raddstoreexpminusmax.h"
+#include "src/xnnpack/simd/f16-scalar.h"
+
+
+static XNN_INLINE xnn_simd_f16_t setexp_f16(xnn_simd_f16_t vx) {
+  XNN_SIMD_CONST_F16_FROM_FLOAT(vmagic, 1039.0f);
+  return xnn_sll_f16(xnn_add_f16(vx, vmagic), 10);
+}
+
+static XNN_INLINE xnn_simd_f16_t qd_round_f16(xnn_simd_f16_t vx) {
+  XNN_SIMD_CONST_F16_FROM_FLOAT(vmagic, 1536.0f);
+  return xnn_sub_f16(xnn_add_f16(vmagic, vx), vmagic);
+}
+
+static XNN_INLINE xnn_simd_f16_t expminusmax_f16(
+    xnn_simd_f16_t vx, xnn_simd_f16_t vmax)
+{
+  XNN_SIMD_CONST_F16_FROM_FLOAT(valpha_1, 0.6933594f);
+  XNN_SIMD_CONST_F16_FROM_FLOAT(valpha_2, 0.24255371f);
+  XNN_SIMD_CONST_F16_FROM_FLOAT(valpha_3, 0.05517578f);
+  XNN_SIMD_CONST_F16_FROM_FLOAT(vlog2e, 1.4423828f);
+  XNN_SIMD_CONST_F16_FROM_FLOAT(v16, 16.0f);
+  XNN_SIMD_CONST_F16_FROM_FLOAT(vm15, -15.0f);
+  XNN_SIMD_CONST_F16_FROM_FLOAT(vone, 1.0f);
+
+  vx = xnn_sub_f16(vx, vmax);
+  xnn_simd_f16_t vz_prime = xnn_mul_f16(vx, vlog2e);
+  vz_prime = xnn_min_f16(xnn_max_f16(vz_prime, vm15), v16);
+  const xnn_simd_f16_t vz = qd_round_f16(vz_prime);
+  const xnn_simd_f16_t vr = xnn_sub_f16(vz_prime, vz);
+  const xnn_simd_f16_t v2z = setexp_f16(vz);
+
+  xnn_simd_f16_t v2r = xnn_fmadd_f16(vr, valpha_3, valpha_2);
+  v2r = xnn_fmadd_f16(vr, v2r, valpha_1);
+  v2r = xnn_fmadd_f16(vr, v2r, vone);
+  return xnn_mul_f16(v2z, v2r);
+}
+
+void xnn_f16_raddstoreexpminusmax_ukernel__scalar_rr2_p2_u1(
+    size_t batch,
+    const xnn_float16* input,
+    const xnn_float16* max,
+    xnn_float16* output,
+    float* sum,
+    const void* params)
+{
+  assert(batch != 0);
+  assert(batch % sizeof(xnn_float16) == 0);
+  assert(input != NULL);
+  assert(max != NULL);
+  assert(output != NULL);
+  assert(sum != NULL);
+
+  const xnn_simd_f16_t vmax = xnn_set1_f16(*max);
+  float vsum = 0.0f;
+  for (; batch >= xnn_simd_bytes_f16; batch -= xnn_simd_bytes_f16) {
+    const xnn_simd_f16_t vf = expminusmax_f16(xnn_loadu_f16(input), vmax);
+    input += xnn_simd_size_f16;
+    xnn_storeu_f16(output, vf);
+    output += xnn_simd_size_f16;
+    vsum += xnn_reduce_add_f16(vf);
+  }
+
+  *sum = vsum;
+}

--- a/src/f16-raddstoreexpminusmax/gen/f16-raddstoreexpminusmax-wasmrelaxedsimdfp16-rr2-p2-u8.c
+++ b/src/f16-raddstoreexpminusmax/gen/f16-raddstoreexpminusmax-wasmrelaxedsimdfp16-rr2-p2-u8.c
@@ -1,0 +1,92 @@
+// clang-format off
+// Auto-generated file. Do not edit!
+//   Template: src/f16-raddstoreexpminusmax/rr2-p2.c.in
+//   Generator: tools/xngen
+//
+// Copyright 2026 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <assert.h>
+#include <stddef.h>
+
+#include "src/xnnpack/common.h"
+#include "src/xnnpack/math.h"
+#include "src/xnnpack/raddstoreexpminusmax.h"
+#include "src/xnnpack/simd/f16-wasmrelaxedsimd.h"
+
+
+static XNN_INLINE xnn_simd_f16_t setexp_f16(xnn_simd_f16_t vx) {
+  XNN_SIMD_CONST_F16_FROM_FLOAT(vmagic, 1039.0f);
+  return xnn_sll_f16(xnn_add_f16(vx, vmagic), 10);
+}
+
+static XNN_INLINE xnn_simd_f16_t qd_round_f16(xnn_simd_f16_t vx) {
+  XNN_SIMD_CONST_F16_FROM_FLOAT(vmagic, 1536.0f);
+  return xnn_sub_f16(xnn_add_f16(vmagic, vx), vmagic);
+}
+
+static XNN_INLINE xnn_simd_f16_t expminusmax_f16(
+    xnn_simd_f16_t vx, xnn_simd_f16_t vmax)
+{
+  XNN_SIMD_CONST_F16_FROM_FLOAT(valpha_1, 0.6933594f);
+  XNN_SIMD_CONST_F16_FROM_FLOAT(valpha_2, 0.24255371f);
+  XNN_SIMD_CONST_F16_FROM_FLOAT(valpha_3, 0.05517578f);
+  XNN_SIMD_CONST_F16_FROM_FLOAT(vlog2e, 1.4423828f);
+  XNN_SIMD_CONST_F16_FROM_FLOAT(v16, 16.0f);
+  XNN_SIMD_CONST_F16_FROM_FLOAT(vm15, -15.0f);
+  XNN_SIMD_CONST_F16_FROM_FLOAT(vone, 1.0f);
+
+  vx = xnn_sub_f16(vx, vmax);
+  xnn_simd_f16_t vz_prime = xnn_mul_f16(vx, vlog2e);
+  vz_prime = xnn_min_f16(xnn_max_f16(vz_prime, vm15), v16);
+  const xnn_simd_f16_t vz = qd_round_f16(vz_prime);
+  const xnn_simd_f16_t vr = xnn_sub_f16(vz_prime, vz);
+  const xnn_simd_f16_t v2z = setexp_f16(vz);
+
+  xnn_simd_f16_t v2r = xnn_fmadd_f16(vr, valpha_3, valpha_2);
+  v2r = xnn_fmadd_f16(vr, v2r, valpha_1);
+  v2r = xnn_fmadd_f16(vr, v2r, vone);
+  return xnn_mul_f16(v2z, v2r);
+}
+
+void xnn_f16_raddstoreexpminusmax_ukernel__wasmrelaxedsimdfp16_rr2_p2_u8(
+    size_t batch,
+    const xnn_float16* input,
+    const xnn_float16* max,
+    xnn_float16* output,
+    float* sum,
+    const void* params)
+{
+  assert(batch != 0);
+  assert(batch % sizeof(xnn_float16) == 0);
+  assert(input != NULL);
+  assert(max != NULL);
+  assert(output != NULL);
+  assert(sum != NULL);
+
+  const xnn_simd_f16_t vmax = xnn_set1_f16(*max);
+  float vsum = 0.0f;
+  for (; batch >= xnn_simd_bytes_f16; batch -= xnn_simd_bytes_f16) {
+    const xnn_simd_f16_t vf = expminusmax_f16(xnn_loadu_f16(input), vmax);
+    input += xnn_simd_size_f16;
+    xnn_storeu_f16(output, vf);
+    output += xnn_simd_size_f16;
+    vsum += xnn_reduce_add_f16(vf);
+  }
+
+  if XNN_UNLIKELY(batch != 0) {
+    const size_t num_elements = batch / sizeof(xnn_float16);
+    const xnn_simd_f16_t vf =
+        expminusmax_f16(xnn_load_tail_f16(input, num_elements), vmax);
+    xnn_store_tail_f16(output, vf, num_elements);
+
+    XNN_ALIGN(64) xnn_float16 values[xnn_simd_size_f16];
+    xnn_storeu_f16(values, vf);
+    for (size_t i = 0; i < num_elements; i++) {
+      vsum += xnn_float16_to_float(values[i]);
+    }
+  }
+  *sum = vsum;
+}

--- a/src/f16-raddstoreexpminusmax/rr2-p2.c.in
+++ b/src/f16-raddstoreexpminusmax/rr2-p2.c.in
@@ -1,0 +1,96 @@
+// Copyright 2026 Google LLC
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+$SIMD_ARCH = {
+$  "wasmrelaxedsimdfp16": "wasmrelaxedsimd",
+$}.get(ARCH, ARCH)
+$SIMD_SIZE = {
+$  "scalar": 1,
+$  "wasmrelaxedsimdfp16": 8,
+$  "avx512fp16": 32,
+$}[ARCH]
+#include <assert.h>
+#include <stddef.h>
+
+#include "src/xnnpack/common.h"
+#include "src/xnnpack/math.h"
+#include "src/xnnpack/raddstoreexpminusmax.h"
+#include "src/xnnpack/simd/f16-${SIMD_ARCH}.h"
+
+
+static XNN_INLINE xnn_simd_f16_t setexp_f16(xnn_simd_f16_t vx) {
+  XNN_SIMD_CONST_F16_FROM_FLOAT(vmagic, 1039.0f);
+  return xnn_sll_f16(xnn_add_f16(vx, vmagic), 10);
+}
+
+static XNN_INLINE xnn_simd_f16_t qd_round_f16(xnn_simd_f16_t vx) {
+  XNN_SIMD_CONST_F16_FROM_FLOAT(vmagic, 1536.0f);
+  return xnn_sub_f16(xnn_add_f16(vmagic, vx), vmagic);
+}
+
+static XNN_INLINE xnn_simd_f16_t expminusmax_f16(
+    xnn_simd_f16_t vx, xnn_simd_f16_t vmax)
+{
+  XNN_SIMD_CONST_F16_FROM_FLOAT(valpha_1, 0.6933594f);
+  XNN_SIMD_CONST_F16_FROM_FLOAT(valpha_2, 0.24255371f);
+  XNN_SIMD_CONST_F16_FROM_FLOAT(valpha_3, 0.05517578f);
+  XNN_SIMD_CONST_F16_FROM_FLOAT(vlog2e, 1.4423828f);
+  XNN_SIMD_CONST_F16_FROM_FLOAT(v16, 16.0f);
+  XNN_SIMD_CONST_F16_FROM_FLOAT(vm15, -15.0f);
+  XNN_SIMD_CONST_F16_FROM_FLOAT(vone, 1.0f);
+
+  vx = xnn_sub_f16(vx, vmax);
+  xnn_simd_f16_t vz_prime = xnn_mul_f16(vx, vlog2e);
+  vz_prime = xnn_min_f16(xnn_max_f16(vz_prime, vm15), v16);
+  const xnn_simd_f16_t vz = qd_round_f16(vz_prime);
+  const xnn_simd_f16_t vr = xnn_sub_f16(vz_prime, vz);
+  const xnn_simd_f16_t v2z = setexp_f16(vz);
+
+  xnn_simd_f16_t v2r = xnn_fmadd_f16(vr, valpha_3, valpha_2);
+  v2r = xnn_fmadd_f16(vr, v2r, valpha_1);
+  v2r = xnn_fmadd_f16(vr, v2r, vone);
+  return xnn_mul_f16(v2z, v2r);
+}
+
+void xnn_f16_raddstoreexpminusmax_ukernel__${ARCH}_rr2_p2_u${SIMD_SIZE}(
+    size_t batch,
+    const xnn_float16* input,
+    const xnn_float16* max,
+    xnn_float16* output,
+    float* sum,
+    const void* params)
+{
+  assert(batch != 0);
+  assert(batch % sizeof(xnn_float16) == 0);
+  assert(input != NULL);
+  assert(max != NULL);
+  assert(output != NULL);
+  assert(sum != NULL);
+
+  const xnn_simd_f16_t vmax = xnn_set1_f16(*max);
+  float vsum = 0.0f;
+  for (; batch >= xnn_simd_bytes_f16; batch -= xnn_simd_bytes_f16) {
+    const xnn_simd_f16_t vf = expminusmax_f16(xnn_loadu_f16(input), vmax);
+    input += xnn_simd_size_f16;
+    xnn_storeu_f16(output, vf);
+    output += xnn_simd_size_f16;
+    vsum += xnn_reduce_add_f16(vf);
+  }
+
+  $if SIMD_SIZE > 1:
+    if XNN_UNLIKELY(batch != 0) {
+      const size_t num_elements = batch / sizeof(xnn_float16);
+      const xnn_simd_f16_t vf =
+          expminusmax_f16(xnn_load_tail_f16(input, num_elements), vmax);
+      xnn_store_tail_f16(output, vf, num_elements);
+
+      XNN_ALIGN(64) xnn_float16 values[xnn_simd_size_f16];
+      xnn_storeu_f16(values, vf);
+      for (size_t i = 0; i < num_elements; i++) {
+        vsum += xnn_float16_to_float(values[i]);
+      }
+    }
+  *sum = vsum;
+}

--- a/src/xnnpack/raddstoreexpminusmax.h
+++ b/src/xnnpack/raddstoreexpminusmax.h
@@ -22,6 +22,9 @@ extern "C" {
                             float* sum, const void* params);
 
 DECLARE_F16_RADDSTOREEXPMINUSMAX_UKERNEL_FUNCTION(
+    xnn_f16_raddstoreexpminusmax_ukernel__scalar_rr2_p2_u1)
+
+DECLARE_F16_RADDSTOREEXPMINUSMAX_UKERNEL_FUNCTION(
     xnn_f16_raddstoreexpminusmax_ukernel__avx2_rr1_p2_u16)
 DECLARE_F16_RADDSTOREEXPMINUSMAX_UKERNEL_FUNCTION(
     xnn_f16_raddstoreexpminusmax_ukernel__avx2_rr1_p2_u16_acc2)
@@ -67,6 +70,17 @@ DECLARE_F16_RADDSTOREEXPMINUSMAX_UKERNEL_FUNCTION(
     xnn_f16_raddstoreexpminusmax_ukernel__rvvfp16arith_rr2_p2_u2v)
 DECLARE_F16_RADDSTOREEXPMINUSMAX_UKERNEL_FUNCTION(
     xnn_f16_raddstoreexpminusmax_ukernel__rvvfp16arith_rr2_p2_u4v)
+
+DECLARE_F16_RADDSTOREEXPMINUSMAX_UKERNEL_FUNCTION(
+    xnn_f16_raddstoreexpminusmax_ukernel__wasmrelaxedsimdfp16_rr2_p2_u8)
+DECLARE_F16_RADDSTOREEXPMINUSMAX_UKERNEL_FUNCTION(
+    xnn_f16_f32acc_raddstoreexpminusmax_ukernel__wasmrelaxedsimd_rr2_p5_u4)
+DECLARE_F16_RADDSTOREEXPMINUSMAX_UKERNEL_FUNCTION(
+    xnn_f16_raddstoreexpminusmax_ukernel__avx512fp16_rr2_p2_u32)
+DECLARE_F16_RADDSTOREEXPMINUSMAX_UKERNEL_FUNCTION(
+    xnn_f16_f32acc_raddstoreexpminusmax_ukernel__f16c_rr2_p5_u8)
+DECLARE_F16_RADDSTOREEXPMINUSMAX_UKERNEL_FUNCTION(
+    xnn_f16_f32acc_raddstoreexpminusmax_ukernel__avx512f_rr2_p5_u16)
 
 #define DECLARE_F32_RADDSTOREEXPMINUSMAX_UKERNEL_FUNCTION(fn_name)          \
   XNN_INTERNAL void fn_name(size_t n, const float* input, const float* max, \

--- a/src/xnnpack/simd/f16-avx512fp16.h
+++ b/src/xnnpack/simd/f16-avx512fp16.h
@@ -197,6 +197,22 @@ static XNN_INLINE xnn_simd_f16_t xnn_set1_f16(xnn_float16 v) {
 #endif  // XNN_HAVE_FLOAT16
 }
 
+static XNN_INLINE float xnn_reduce_add_f16(xnn_simd_f16_t a) {
+  const __m256h a_lo = _mm512_castph512_ph256(a);
+  const __m256h a_hi =
+      _mm256_castpd_ph(_mm512_extractf64x4_pd(_mm512_castph_pd(a), 1));
+  const __m512 a_f32 =
+      _mm512_add_ps(_mm512_cvtxph_ps(a_lo), _mm512_cvtxph_ps(a_hi));
+  const __m256 a256 = _mm256_add_ps(
+      _mm512_castps512_ps256(a_f32),
+      _mm256_castpd_ps(_mm512_extractf64x4_pd(_mm512_castps_pd(a_f32), 1)));
+  __m128 a128 =
+      _mm_add_ps(_mm256_castps256_ps128(a256), _mm256_extractf128_ps(a256, 1));
+  a128 = _mm_add_ps(a128, _mm_movehl_ps(a128, a128));
+  a128 = _mm_add_ss(a128, _mm_movehdup_ps(a128));
+  return _mm_cvtss_f32(a128);
+}
+
 // Tail load/store operations.
 static XNN_INLINE xnn_simd_f16_t xnn_load_tail_f16(const xnn_float16* input,
                                                    size_t num_elements) {

--- a/src/xnnpack/simd/f16-scalar.h
+++ b/src/xnnpack/simd/f16-scalar.h
@@ -245,6 +245,10 @@ static XNN_INLINE void xnn_store_f16(xnn_simd_f16_t *ptr, xnn_simd_f16_t v) {
 
 static XNN_INLINE xnn_simd_f16_t xnn_set1_f16(xnn_simd_f16_t v) { return v; }
 
+static XNN_INLINE float xnn_reduce_add_f16(xnn_simd_f16_t a) {
+  return xnn_float16_to_float(a);
+}
+
 // Tail load/store operations.
 static XNN_INLINE xnn_simd_f16_t xnn_load_tail_f16(const xnn_simd_f16_t *input,
                                                    size_t num_elements) {

--- a/src/xnnpack/simd/f16-wasmrelaxedsimd.h
+++ b/src/xnnpack/simd/f16-wasmrelaxedsimd.h
@@ -279,4 +279,13 @@ static XNN_INLINE v128_t xnn_cvt_f16_f32(v128_t f) {
       0, 0, 0, 0);
 }
 
+static XNN_INLINE float xnn_reduce_add_f16(xnn_simd_f16_t a) {
+  v128_t vacc = xnn_cvt_f32_f16(a);
+  vacc = wasm_f32x4_add(
+      vacc, xnn_cvt_f32_f16(wasm_v64x2_shuffle(a, a, 1, 1)));
+  vacc = wasm_f32x4_add(vacc, wasm_v64x2_shuffle(vacc, vacc, 1, 1));
+  return wasm_f32x4_extract_lane(vacc, 0) +
+         wasm_f32x4_extract_lane(vacc, 1);
+}
+
 #endif  // XNNPACK_SRC_XNNPACK_SIMD_F16_WASMRELAXEDSIMD_H_

--- a/test/f16-raddstoreexpminusmax.cc
+++ b/test/f16-raddstoreexpminusmax.cc
@@ -17,6 +17,133 @@
 #include "test/raddstoreexpminusmax-microkernel-tester.h"
 
 
+TEST(F16_RADDSTOREEXPMINUSMAX__SCALAR_RR2_P2_U1, elements_eq_1) {
+  TEST_REQUIRES_ARCH_FLAGS(0);
+  RAddStoreExpMinusMaxMicrokernelTester()
+    .elements(1)
+    .Test(xnn_f16_raddstoreexpminusmax_ukernel__scalar_rr2_p2_u1, nullptr);
+}
+
+TEST(F16_RADDSTOREEXPMINUSMAX__SCALAR_RR2_P2_U1, elements_gt_1) {
+  TEST_REQUIRES_ARCH_FLAGS(0);
+  for (size_t elements = 2; elements < 10; elements++) {
+    RAddStoreExpMinusMaxMicrokernelTester()
+      .elements(elements)
+      .Test(xnn_f16_raddstoreexpminusmax_ukernel__scalar_rr2_p2_u1, nullptr);
+  }
+}
+
+#if XNN_ENABLE_AVX512FP16 && (XNN_ARCH_X86 || XNN_ARCH_X86_64)
+  TEST(F16_RADDSTOREEXPMINUSMAX__AVX512FP16_RR2_P2_U32, elements_eq_32) {
+    TEST_REQUIRES_ARCH_FLAGS(xnn_arch_x86_avx512fp16);
+    RAddStoreExpMinusMaxMicrokernelTester()
+      .elements(32)
+      .Test(xnn_f16_raddstoreexpminusmax_ukernel__avx512fp16_rr2_p2_u32, nullptr);
+  }
+
+  TEST(F16_RADDSTOREEXPMINUSMAX__AVX512FP16_RR2_P2_U32, elements_div_32) {
+    TEST_REQUIRES_ARCH_FLAGS(xnn_arch_x86_avx512fp16);
+    for (size_t elements = 64; elements < 320; elements += 32) {
+      RAddStoreExpMinusMaxMicrokernelTester()
+        .elements(elements)
+        .Test(xnn_f16_raddstoreexpminusmax_ukernel__avx512fp16_rr2_p2_u32, nullptr);
+    }
+  }
+
+  TEST(F16_RADDSTOREEXPMINUSMAX__AVX512FP16_RR2_P2_U32, elements_lt_32) {
+    TEST_REQUIRES_ARCH_FLAGS(xnn_arch_x86_avx512fp16);
+    for (size_t elements = 1; elements < 32; elements++) {
+      RAddStoreExpMinusMaxMicrokernelTester()
+        .elements(elements)
+        .Test(xnn_f16_raddstoreexpminusmax_ukernel__avx512fp16_rr2_p2_u32, nullptr);
+    }
+  }
+
+  TEST(F16_RADDSTOREEXPMINUSMAX__AVX512FP16_RR2_P2_U32, elements_gt_32) {
+    TEST_REQUIRES_ARCH_FLAGS(xnn_arch_x86_avx512fp16);
+    for (size_t elements = 33; elements < 64; elements++) {
+      RAddStoreExpMinusMaxMicrokernelTester()
+        .elements(elements)
+        .Test(xnn_f16_raddstoreexpminusmax_ukernel__avx512fp16_rr2_p2_u32, nullptr);
+    }
+  }
+#endif  // XNN_ENABLE_AVX512FP16 && (XNN_ARCH_X86 || XNN_ARCH_X86_64)
+
+
+#if XNN_ENABLE_F16C && (XNN_ARCH_X86 || XNN_ARCH_X86_64)
+  TEST(F16_F32ACC_RADDSTOREEXPMINUSMAX__F16C_RR2_P5_U8, elements_eq_8) {
+    TEST_REQUIRES_ARCH_FLAGS(xnn_arch_x86_f16c);
+    RAddStoreExpMinusMaxMicrokernelTester()
+      .elements(8)
+      .Test(xnn_f16_f32acc_raddstoreexpminusmax_ukernel__f16c_rr2_p5_u8, nullptr);
+  }
+
+  TEST(F16_F32ACC_RADDSTOREEXPMINUSMAX__F16C_RR2_P5_U8, elements_div_8) {
+    TEST_REQUIRES_ARCH_FLAGS(xnn_arch_x86_f16c);
+    for (size_t elements = 16; elements < 80; elements += 8) {
+      RAddStoreExpMinusMaxMicrokernelTester()
+        .elements(elements)
+        .Test(xnn_f16_f32acc_raddstoreexpminusmax_ukernel__f16c_rr2_p5_u8, nullptr);
+    }
+  }
+
+  TEST(F16_F32ACC_RADDSTOREEXPMINUSMAX__F16C_RR2_P5_U8, elements_lt_8) {
+    TEST_REQUIRES_ARCH_FLAGS(xnn_arch_x86_f16c);
+    for (size_t elements = 1; elements < 8; elements++) {
+      RAddStoreExpMinusMaxMicrokernelTester()
+        .elements(elements)
+        .Test(xnn_f16_f32acc_raddstoreexpminusmax_ukernel__f16c_rr2_p5_u8, nullptr);
+    }
+  }
+
+  TEST(F16_F32ACC_RADDSTOREEXPMINUSMAX__F16C_RR2_P5_U8, elements_gt_8) {
+    TEST_REQUIRES_ARCH_FLAGS(xnn_arch_x86_f16c);
+    for (size_t elements = 9; elements < 16; elements++) {
+      RAddStoreExpMinusMaxMicrokernelTester()
+        .elements(elements)
+        .Test(xnn_f16_f32acc_raddstoreexpminusmax_ukernel__f16c_rr2_p5_u8, nullptr);
+    }
+  }
+#endif  // XNN_ENABLE_F16C && (XNN_ARCH_X86 || XNN_ARCH_X86_64)
+
+
+#if XNN_ENABLE_AVX512F && (XNN_ARCH_X86 || XNN_ARCH_X86_64)
+  TEST(F16_F32ACC_RADDSTOREEXPMINUSMAX__AVX512F_RR2_P5_U16, elements_eq_16) {
+    TEST_REQUIRES_ARCH_FLAGS(xnn_arch_x86_avx512f);
+    RAddStoreExpMinusMaxMicrokernelTester()
+      .elements(16)
+      .Test(xnn_f16_f32acc_raddstoreexpminusmax_ukernel__avx512f_rr2_p5_u16, nullptr);
+  }
+
+  TEST(F16_F32ACC_RADDSTOREEXPMINUSMAX__AVX512F_RR2_P5_U16, elements_div_16) {
+    TEST_REQUIRES_ARCH_FLAGS(xnn_arch_x86_avx512f);
+    for (size_t elements = 32; elements < 160; elements += 16) {
+      RAddStoreExpMinusMaxMicrokernelTester()
+        .elements(elements)
+        .Test(xnn_f16_f32acc_raddstoreexpminusmax_ukernel__avx512f_rr2_p5_u16, nullptr);
+    }
+  }
+
+  TEST(F16_F32ACC_RADDSTOREEXPMINUSMAX__AVX512F_RR2_P5_U16, elements_lt_16) {
+    TEST_REQUIRES_ARCH_FLAGS(xnn_arch_x86_avx512f);
+    for (size_t elements = 1; elements < 16; elements++) {
+      RAddStoreExpMinusMaxMicrokernelTester()
+        .elements(elements)
+        .Test(xnn_f16_f32acc_raddstoreexpminusmax_ukernel__avx512f_rr2_p5_u16, nullptr);
+    }
+  }
+
+  TEST(F16_F32ACC_RADDSTOREEXPMINUSMAX__AVX512F_RR2_P5_U16, elements_gt_16) {
+    TEST_REQUIRES_ARCH_FLAGS(xnn_arch_x86_avx512f);
+    for (size_t elements = 17; elements < 32; elements++) {
+      RAddStoreExpMinusMaxMicrokernelTester()
+        .elements(elements)
+        .Test(xnn_f16_f32acc_raddstoreexpminusmax_ukernel__avx512f_rr2_p5_u16, nullptr);
+    }
+  }
+#endif  // XNN_ENABLE_AVX512F && (XNN_ARCH_X86 || XNN_ARCH_X86_64)
+
+
 #if XNN_ENABLE_ARM_FP16_VECTOR && (XNN_ARCH_ARM || XNN_ARCH_ARM64)
   TEST(F16_RADDSTOREEXPMINUSMAX__NEONFP16ARITH_RR2_P2_U16, elements_eq_16) {
     TEST_REQUIRES_ARCH_FLAGS(xnn_arch_arm_neon_fp16_arith);
@@ -847,3 +974,77 @@
     }
   }
 #endif  // XNN_ENABLE_RISCV_FP16_VECTOR && XNN_ARCH_RISCV
+
+
+#if XNN_ENABLE_WASMRELAXEDSIMDFP16 && XNN_ARCH_WASMRELAXEDSIMD
+  TEST(F16_RADDSTOREEXPMINUSMAX__WASMRELAXEDSIMDFP16_RR2_P2_U8, elements_eq_8) {
+    TEST_REQUIRES_ARCH_FLAGS(0);
+    RAddStoreExpMinusMaxMicrokernelTester()
+      .elements(8)
+      .Test(xnn_f16_raddstoreexpminusmax_ukernel__wasmrelaxedsimdfp16_rr2_p2_u8, nullptr);
+  }
+
+  TEST(F16_RADDSTOREEXPMINUSMAX__WASMRELAXEDSIMDFP16_RR2_P2_U8, elements_div_8) {
+    TEST_REQUIRES_ARCH_FLAGS(0);
+    for (size_t elements = 16; elements < 80; elements += 8) {
+      RAddStoreExpMinusMaxMicrokernelTester()
+        .elements(elements)
+        .Test(xnn_f16_raddstoreexpminusmax_ukernel__wasmrelaxedsimdfp16_rr2_p2_u8, nullptr);
+    }
+  }
+
+  TEST(F16_RADDSTOREEXPMINUSMAX__WASMRELAXEDSIMDFP16_RR2_P2_U8, elements_lt_8) {
+    TEST_REQUIRES_ARCH_FLAGS(0);
+    for (size_t elements = 1; elements < 8; elements++) {
+      RAddStoreExpMinusMaxMicrokernelTester()
+        .elements(elements)
+        .Test(xnn_f16_raddstoreexpminusmax_ukernel__wasmrelaxedsimdfp16_rr2_p2_u8, nullptr);
+    }
+  }
+
+  TEST(F16_RADDSTOREEXPMINUSMAX__WASMRELAXEDSIMDFP16_RR2_P2_U8, elements_gt_8) {
+    TEST_REQUIRES_ARCH_FLAGS(0);
+    for (size_t elements = 9; elements < 16; elements++) {
+      RAddStoreExpMinusMaxMicrokernelTester()
+        .elements(elements)
+        .Test(xnn_f16_raddstoreexpminusmax_ukernel__wasmrelaxedsimdfp16_rr2_p2_u8, nullptr);
+    }
+  }
+#endif  // XNN_ENABLE_WASMRELAXEDSIMDFP16 && XNN_ARCH_WASMRELAXEDSIMD
+
+
+#if XNN_ENABLE_WASMRELAXEDSIMD && XNN_ARCH_WASMRELAXEDSIMD
+  TEST(F16_F32ACC_RADDSTOREEXPMINUSMAX__WASMRELAXEDSIMD_RR2_P5_U4, elements_eq_4) {
+    TEST_REQUIRES_ARCH_FLAGS(0);
+    RAddStoreExpMinusMaxMicrokernelTester()
+      .elements(4)
+      .Test(xnn_f16_f32acc_raddstoreexpminusmax_ukernel__wasmrelaxedsimd_rr2_p5_u4, nullptr);
+  }
+
+  TEST(F16_F32ACC_RADDSTOREEXPMINUSMAX__WASMRELAXEDSIMD_RR2_P5_U4, elements_div_4) {
+    TEST_REQUIRES_ARCH_FLAGS(0);
+    for (size_t elements = 8; elements < 40; elements += 4) {
+      RAddStoreExpMinusMaxMicrokernelTester()
+        .elements(elements)
+        .Test(xnn_f16_f32acc_raddstoreexpminusmax_ukernel__wasmrelaxedsimd_rr2_p5_u4, nullptr);
+    }
+  }
+
+  TEST(F16_F32ACC_RADDSTOREEXPMINUSMAX__WASMRELAXEDSIMD_RR2_P5_U4, elements_lt_4) {
+    TEST_REQUIRES_ARCH_FLAGS(0);
+    for (size_t elements = 1; elements < 4; elements++) {
+      RAddStoreExpMinusMaxMicrokernelTester()
+        .elements(elements)
+        .Test(xnn_f16_f32acc_raddstoreexpminusmax_ukernel__wasmrelaxedsimd_rr2_p5_u4, nullptr);
+    }
+  }
+
+  TEST(F16_F32ACC_RADDSTOREEXPMINUSMAX__WASMRELAXEDSIMD_RR2_P5_U4, elements_gt_4) {
+    TEST_REQUIRES_ARCH_FLAGS(0);
+    for (size_t elements = 5; elements < 8; elements++) {
+      RAddStoreExpMinusMaxMicrokernelTester()
+        .elements(elements)
+        .Test(xnn_f16_f32acc_raddstoreexpminusmax_ukernel__wasmrelaxedsimd_rr2_p5_u4, nullptr);
+    }
+  }
+#endif  // XNN_ENABLE_WASMRELAXEDSIMD && XNN_ARCH_WASMRELAXEDSIMD

--- a/test/f16-raddstoreexpminusmax.yaml
+++ b/test/f16-raddstoreexpminusmax.yaml
@@ -3,6 +3,16 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# Scalar
+- name: xnn_f16_raddstoreexpminusmax_ukernel__scalar_rr2_p2_u1
+
+# Portable FP16 arithmetic
+- name: xnn_f16_raddstoreexpminusmax_ukernel__avx512fp16_rr2_p2_u32
+
+# Portable FP32 accumulation
+- name: xnn_f16_f32acc_raddstoreexpminusmax_ukernel__f16c_rr2_p5_u8
+- name: xnn_f16_f32acc_raddstoreexpminusmax_ukernel__avx512f_rr2_p5_u16
+
 # ARM NEON+FP16ARITH
 - name: xnn_f16_raddstoreexpminusmax_ukernel__neonfp16arith_rr2_p2_u16
 - name: xnn_f16_raddstoreexpminusmax_ukernel__neonfp16arith_rr2_p2_u16_acc2
@@ -30,3 +40,9 @@
 - name: xnn_f16_raddstoreexpminusmax_ukernel__rvvfp16arith_rr2_p2_u1v
 - name: xnn_f16_raddstoreexpminusmax_ukernel__rvvfp16arith_rr2_p2_u2v
 - name: xnn_f16_raddstoreexpminusmax_ukernel__rvvfp16arith_rr2_p2_u4v
+
+# WebAssembly Relaxed SIMD FP16
+- name: xnn_f16_raddstoreexpminusmax_ukernel__wasmrelaxedsimdfp16_rr2_p2_u8
+
+# WebAssembly Relaxed SIMD with FP32 accumulation
+- name: xnn_f16_f32acc_raddstoreexpminusmax_ukernel__wasmrelaxedsimd_rr2_p5_u4

--- a/tools/generate-raddstoreexpminusmax-test.py
+++ b/tools/generate-raddstoreexpminusmax-test.py
@@ -39,7 +39,7 @@ parser.set_defaults(defines=list())
 
 def split_ukernel_name(name):
   match = re.fullmatch(
-      r"xnn_(f16|f32)_raddstoreexpminusmax_ukernel__(.+)_u(\d+)(v)?(_acc(\d+))?",
+      r"xnn_(f16(?:_f32acc)?|f32)_raddstoreexpminusmax_ukernel__(.+)_u(\d+)(v)?(_acc(\d+))?",
       name,
   )
   if match is None:


### PR DESCRIPTION
- Adds FP16 `raddstoreexpminusmax` kernels for scalar, x86, and wasm
- Implemented the required `reduce_add_f16` operations
- Required for making wasm mobilenet f16 variants work