### PR TITLE
litert/tensor: guard ExpandDims/Split/OneHot/NonMaxSuppressionV5 against 0-byte constant buffer

### DIFF
--- a/litert/tensor/arithmetic.h
+++ b/litert/tensor/arithmetic.h
@@ -655,6 +655,10 @@ Tensor<Mixins...> ExpandDims(Tensor<Mixins...> input, Tensor<Mixins...> axis,
   if (axis_info.buffer) {
     LockedBufferSpan<const int32_t> axis_lock =
         axis_info.buffer->Lock().template As<const int32_t>();
+    if (axis_lock.size() < 1) {
+      return Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
+          "ExpandDims axis buffer must contain at least one element.")));
+    }
     int real_axis = axis_lock.data()[0];
     if (real_axis < 0) {
       real_axis += input_info.shape.size() + 1;
@@ -1551,6 +1555,10 @@ std::vector<Tensor<Mixins...>> Split(
   if (axis_info.buffer) {
     LockedBufferSpan<const int32_t> axis_lock =
         axis_info.buffer->Lock().As<const int32_t>();
+    if (axis_lock.size() < 1) {
+      return {Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
+          "Split axis buffer must contain at least one element.")))};
+    }
     axis_val = axis_lock.data()[0];
   } else {
     // TODO(b/269489748): Support dynamic axis for shape inference.
@@ -2299,6 +2307,10 @@ Tensor<Mixins...> OneHot(Tensor<Mixins...> indices, Tensor<Mixins...> depth,
   if (depth_info.buffer) {
     LockedBufferSpan<const int32_t> depth_lock =
         depth_info.buffer->Lock().template As<const int32_t>();
+    if (depth_lock.size() < 1) {
+      return Tensor<Mixins...>(graph::ErrorTensor(absl::InvalidArgumentError(
+          "OneHot depth buffer must contain at least one element.")));
+    }
     depth_val = depth_lock.data()[0];
   }
   if (resolved_axis < 0 ||
@@ -2543,6 +2555,14 @@ std::vector<Tensor<Mixins...>> NonMaxSuppressionV5(
           graph::GetInfo(max_output_size.GetRaw())->buffer.get()) {
     LockedBufferSpan<const int32_t> max_output_size_lock =
         max_output_size_buffer->Lock().template As<const int32_t>();
+    if (max_output_size_lock.size() < 1) {
+      auto error = absl::InvalidArgumentError(
+          "NonMaxSuppression max_output_size buffer must contain at least one "
+          "element.");
+      return {Tensor<Mixins...>(graph::ErrorTensor(error)),
+              Tensor<Mixins...>(graph::ErrorTensor(error)),
+              Tensor<Mixins...>(graph::ErrorTensor(error))};
+    }
     const int max_output_size_val = *max_output_size_lock.data();
     indices_info.shape = {max_output_size_val};
     scores_info.shape = {max_output_size_val};


### PR DESCRIPTION
## Problem

`ExpandDims`, `Split`, `OneHot`, and `NonMaxSuppressionV5` in `litert/tensor/arithmetic.h` each lock a constant tensor buffer and immediately read `data()[0]` (or `*data()`) without first checking that the span contains at least one element.

`LockedBufferSpan::data()` returns `reinterpret_cast<T*>(data_.get())`. When the buffer holds zero bytes, `data_.get()` is `nullptr`, so the read is a null pointer dereference, causing SIGSEGV at model-load time.

The existing `if (buffer)` guard only checks that the buffer object is non-null - it does not check that the buffer contains any data.

Affected code paths:

```cpp
// ExpandDims, line 658
int real_axis = axis_lock.data()[0];          // null deref if 0-byte buffer

// Split, line 1554
axis_val = axis_lock.data()[0];               // null deref if 0-byte buffer

// OneHot, line 2302
depth_val = depth_lock.data()[0];             // null deref if 0-byte buffer

// NonMaxSuppressionV5, line 2546
const int max_output_size_val = *max_output_size_lock.data();  // null deref
```

## Fix

Add a `size() < 1` guard immediately after locking each buffer.

```cpp
if (axis_lock.size() < 1) { return error; }
```