### PR TITLE
packing: fix NULL deref in KleidiAI SME conv weight packing bias substitute

### DIFF
--- a/src/reference/packing.cc
+++ b/src/reference/packing.cc
@@ -3474,6 +3474,13 @@ void xnn_pack_kai_f32_weights_and_biases_sme2(
   bool free_accumulator_init = false;
   if (accumulator_init == NULL) {
     accumulator_init = calloc(output_channels, sizeof(float));
+    if (accumulator_init == NULL) {
+      xnn_log_error(
+          "failed to allocate %zu bytes for KleidiAI SME2 bias substitute buffer",
+          output_channels * sizeof(float));
+      assert(false);
+      return;
+    }
     free_accumulator_init = true;
   }
 
@@ -3628,6 +3635,13 @@ void xnn_pack_kai_f16_conv_goki_w_sme(size_t g, size_t nc, size_t ks,
 
   if (b == NULL) {
     tmp_bias = (uint16_t*)xnn_allocate_zero_memory(g * nc * sizeof(uint16_t));
+    if (tmp_bias == NULL) {
+      xnn_log_error(
+          "failed to allocate %zu bytes for KleidiAI SME bias substitute buffer",
+          g * nc * sizeof(uint16_t));
+      assert(false);
+      return;
+    }
     b = tmp_bias;
   }
 
@@ -3692,6 +3706,13 @@ void xnn_pack_kai_qs8_conv_goki_w_sme(
 
   if (b == NULL) {
     tmp_bias = (int32_t*)xnn_allocate_zero_memory(g * nc * sizeof(int32_t));
+    if (tmp_bias == NULL) {
+      xnn_log_error(
+          "failed to allocate %zu bytes for KleidiAI SME bias substitute buffer",
+          g * nc * sizeof(int32_t));
+      assert(false);
+      return;
+    }
     b = tmp_bias;
   }
 
@@ -3759,6 +3780,13 @@ void xnn_pack_kai_pf32_conv_goki_w_sme(
 
   if (b == NULL) {
     tmp_bias = (float*) calloc(g * nc, sizeof(float));
+    if (tmp_bias == NULL) {
+      xnn_log_error(
+          "failed to allocate %zu bytes for KleidiAI SME bias substitute buffer",
+          g * nc * sizeof(float));
+      assert(false);
+      return;
+    }
     b = tmp_bias;
   }
 


### PR DESCRIPTION
`xnn_allocate_zero_memory` / `calloc` return NULL on OOM (the allocator
contract documents this: include/xnnpack.h "If allocation fails, the function
must return NULL"). The three KleidiAI SME convolution weight-packing
functions allocate a zero-initialized bias substitute when the caller passes
NULL bias — the standard configuration for bias-free convolutions — but none
check the return value. On failure the NULL pointer is assigned to `b` and
passed directly to `kai_run_rhs_imatmul_pack_*` as the bias argument; those
kernels only `KAI_ASSUME(bias != NULL)` (no runtime check) and hand the
pointer to the SME assembly kernel, which loads the packed-RHS bias rows from
it → SIGSEGV.

**Affected functions** (src/reference/packing.cc @ master `e247b29`):
- `xnn_pack_kai_f16_conv_goki_w_sme` — `tmp_bias = xnn_allocate_zero_memory(g * nc * sizeof(uint16_t))` (:3630)
- `xnn_pack_kai_qs8_conv_goki_w_sme` — `tmp_bias = xnn_allocate_zero_memory(g * nc * sizeof(int32_t))` (:3694)
- `xnn_pack_kai_pf32_conv_goki_w_sme` — `tmp_bias = calloc(g * nc, sizeof(float))` (:3761)

All three are registered as `pack_igemm_goki` in src/configs/gemm-config.c for
the SME and SME2 hardware paths (pf16 :410/:434, pf32 :502/:521, qs8 :565/:594).

This completes the two previous fixes in this family, which each covered a
different allocation and missed this one:
- #10942 guarded the `tmp_data` transpose buffer **in these same three
  functions** — its error path even releases `tmp_bias`, but nothing guarded
  `tmp_bias` itself.
- #10947 / 8e12b6f86c guarded the `accumulator_init` bias substitute in the
  three fully-connected `weights_and_biases` packers.

The failure mode that slips through both: `tmp_bias` allocation fails while
the smaller per-group `tmp_data` allocation succeeds (the substitute is sized
`g * nc` — all groups' biases at once — while `tmp_data` is a single group's
`nc * ks * kc` transpose buffer, reused per group; a deep grouped conv makes
the former orders of magnitude larger than the latter). Then no existing guard
fires and the kernel dereferences NULL.

**Deterministic repro** (needs aarch64 SME/SME2 hardware — the affected
packers are registered only on SME paths; build with KleidiAI, the ARM64
default). The public `xnn_initialize` allocator hook makes the OOM
deterministic without OS tricks:

```c
/* repro_bias_null.c — cc -std=c11 -I<repo> -I<repo>/build/kleidiai-source \
   repro_bias_null.c -L<repo>/build -lxnnpack -lpthreadpool -lm -o repro */
#include <stdio.h>
#include <stdlib.h>
#include <stddef.h>
#include "include/xnnpack.h"
#include "src/xnnpack/pack.h"
#include "kai/ukernels/matmul/pack/kai_rhs_imatmul_pack_kxn_x16p2vlx2b_x16_x16_sme.h"

static void* fail_big_allocs(void* ctx, size_t n) {
  return n >= (1u << 20) ? NULL : malloc(n);   /* bias substitute = 2 MiB -> NULL */
}
static void passthrough_free(void* ctx, void* p) { free(p); }

int main(void) {
  struct xnn_allocator a = {0};
  a.allocate = fail_big_allocs; a.deallocate = passthrough_free;
  if (xnn_initialize(&a) != xnn_status_ready) return 1;

  const size_t g = 1u << 20, nc = 1, ks = 1, kc = 1;   /* tmp_bias 2 MiB, tmp_data 2 B */
  const size_t packed_stride =
      kai_get_rhs_packed_size_rhs_imatmul_pack_kxn_x16p2vlx2b_x16_x16_sme(nc, ks, kc);
  uint16_t* packed = malloc(g * packed_stride);        /* caller side, unaffected */
  uint16_t kernel[1] = {0x3800};                        /* 0.5 in fp16 */

  xnn_pack_kai_f16_conv_goki_w_sme(g, nc, ks, kc, /*nr=*/16, /*kr=*/1, /*sr=*/1,
                                   kernel, /*b=*/NULL, /*scale=*/NULL,
                                   packed, /*extra_bytes=*/0, /*params=*/NULL);
  puts("returned from packer");
  return 0;
}
```

Behavior at master (sites re-read at `e247b29`; SIGSEGV transcript from the original session at `f7f2d30e`): SIGSEGV inside
`kai_kernel_rhs_imatmul_pack_kxn_x16p2vlx2b_x16_x16_sme` (the kernel loads the
packed-RHS bias block from the NULL `bias_ptr` on the first row — the packed
layout is `[bias | weights]` per n-block). Expected with this patch: the error
line `failed to allocate 2097152 bytes for KleidiAI SME bias substitute
buffer` in the log and a clean return ("returned from packer"). The qs8 site
is identical via the same allocator hook; the pf32 site uses raw `calloc`, so
its equivalent trigger is an OS-level allocation failure (e.g. RLIMIT_AS /
memory cgroup pressure) — same code shape, same missing check.

In-process real-world shape: a bias-free grouped convolution
(`bias = NULL` to `xnn_define_convolution2d_nhwc_*` / direct packer use) on an
SME host where the transient `g * nc` zeroed allocation fails under memory
pressure at weight-pack time — today that is a crash in the packing kernel
instead of a logged OOM.

**Fix**: add a NULL guard after each bias-substitute allocation — the exact
idiom 8e12b6f86c used for the FC packers' `accumulator_init` (nested check,
same log message) with the `assert(false); return;` convention the #10942
guards use in these same functions. Error path frees nothing (tmp_data is not
allocated yet at that point; tmp_bias is NULL) and leaks nothing.

Validation level, stated plainly: patch applies clean to master
(`git apply --check`, 28 insertions incl. the fourth site below, single file); the added lines use only
constructs already present in the same functions; not executed on hardware by
me (no SME host at hand) — the repro above is self-contained for anyone on
SME iron. The four guarded sites were re-read line by line at `e247b29` before
opening this PR; the single-file patch (28 insertions) applies clean and the
touched translation unit compiles clean against the project CMake include set
(clang, macOS x64, tests/benchmarks disabled configure). Happy to add it as a regression test if wanted.

**Addendum — fourth site, same family** (landed after the sites above were
enumerated): `xnn_pack_kai_f32_weights_and_biases_sme2`
(src/reference/packing.cc:3459-3477, merged via #10992) allocates its
bias substitute with an unchecked `calloc` at :3476:

```c
  // Some packing kernels assume that the bias is non-null. Allocate a zero
  // initialized array as a workaround if bias is null.
  bool free_accumulator_init = false;
  if (accumulator_init == NULL) {
    accumulator_init = calloc(output_channels, sizeof(float));   // unchecked
    free_accumulator_init = true;
  }
```

The result is used unconditionally — `args.operand.bias_n.ptr =
free_accumulator_init ? accumulator_init : (const float*)accumulator_init +
group * output_channels` — and handed to the KleidiAI v1.30.0 (DEPS pin)
SME pack API selected at packing.cc:3344-3352
(`kai_matmul_pack_rhs_{nxk,kxn}_x32p4vsx1bx32_x32_x32_sme`). On the KleidiAI
end the pointer is dereferenced with no NULL handling:
`kai_matmul_pack_rhs_nxk_x32p4vsx1bx32_x32_x32_sme.c` :129
`const uint8_t* bias_n_ptr = args->operand.bias_n.ptr;` → :147
`const uint8_t* bias = bias_n_ptr + start_row * BIAS_ESIZE;` → SME pack
routine. Contrast `kai_rhs_pack_nxk_qsu2cxp4vlx4_qsu2cx_neon.c`, which
explicitly handles `bias == NULL` with a zero memset — the SME packers do not.

This site sits in exactly the gap #10947 left: that PR's enumeration covers
`xnn_pack_kai_qs8_qc8w_weights_and_biases_sme`, `xnn_pack_kai_f16_weights_and_biases`,
and `xnn_pack_kai_f32_weights_and_biases` (guarded at packing.cc:2869/:3033/:3142
respectively); the `_sme2` sibling postdates it and repeats the unguarded shape.
Reachable from `xnn_define_fully_connected` / direct packer use with
`bias = NULL` on SME2 hardware (config gate: gemm-config.c:2977-2982 and :500 —
`XNN_ARCH_ARM64 && XNN_ENABLE_KLEIDIAI && (arch_flags & xnn_arch_arm_sme2)`).

**Fix**: the same idiom the three guarded siblings use (packing.cc:2865-2876):

```c
  if (accumulator_init == NULL) {
    accumulator_init = calloc(output_channels, sizeof(float));
    if (accumulator_init == NULL) {
      xnn_log_error(
          "failed to allocate %zu bytes for KleidiAI SME2 bias substitute",
          output_channels * sizeof(float));
      assert(false);
      return;
    }
    free_accumulator_init = true;
  }
```

The check goes immediately after the `calloc`, before any other allocation in
the function — the error path frees nothing and leaks nothing. OOM-conditional
NULL-deref (SIGSEGV in the SME pack routine at weight-pack time), same class
and same fix as the sites above.
