### PR TITLE
Fix a crash when a Copy's result feeds both inputs of a binary node

### DIFF
--- a/src/subgraph.c
+++ b/src/subgraph.c
@@ -1732,17 +1732,15 @@ enum xnn_status xnn_subgraph_fusion(xnn_subgraph_t subgraph) {
         assert(producer->num_inputs == 1);
         const uint32_t copy_input_id = producer->inputs[0];
         const uint32_t copy_output_id = producer->outputs[0];
+        // A node counts as a single consumer even when it uses the value for
+        // more than one input (e.g. `add(y, y)`), so rewrite every input that
+        // refers to the copy's output: the value is cleared below and any input
+        // still pointing at it would be dangling.
         bool found_consumer_input = false;
         for (size_t i = 0; i < consumer->num_inputs; i++) {
           if (consumer->inputs[i] == copy_output_id) {
             consumer->inputs[i] = copy_input_id;
-            ;
             found_consumer_input = true;
-            // TODO(b/254734644): A consumer can only consume this value once,
-            // since we asserted earlier that value has only 1 consumer, so we
-            // can break here as there will be no other consumer inputs that has
-            // the same id.
-            break;
           }
         }
         (void)found_consumer_input;  // Silence unused variable warning in

--- a/test/subgraph/fusion.cc
+++ b/test/subgraph/fusion.cc
@@ -1095,6 +1095,39 @@ TEST(UNARY_QUANTIZED_TO_LUT, binary_first) {
   EXPECT_EQ(unoptimized_output, optimized_output);
 }
 
+TEST(COPY_THEN_BINARY_WITH_REPEATED_INPUT, fusion) {
+  // add(y, y) with y = copy(x): the Copy is fused downstream and both inputs
+  // of the add have to be rewritten to x, since the Copy's output value is
+  // cleared.
+  const uint32_t input_id = 0;
+  const uint32_t output_id = 1;
+  const uint32_t copy_output_id = 2;
+  const TensorShape dims = {2, 4};
+  RuntimeTester tester(3);
+  tester.AddInputTensorF32(dims, input_id)
+      .AddDynamicTensorF32(dims, copy_output_id)
+      .AddOutputTensorF32(dims, output_id)
+      .AddCopy(input_id, copy_output_id)
+      .AddBinary(xnn_binary_add, nullptr, copy_output_id, copy_output_id,
+                 output_id);
+
+  xnnpack::Buffer<float> unoptimized_output = tester.RunWithoutFusion<float>();
+  ASSERT_EQ(tester.NumOperators(), 2);
+
+  xnnpack::Buffer<float> optimized_output = tester.RunWithFusion<float>();
+  ASSERT_EQ(tester.NumOperators(), 1);
+  const xnn_node* add_node = nullptr;
+  for (size_t i = 0; i < tester.NumNodes(); i++) {
+    if (tester.Node(i)->type == xnn_node_type_binary_elementwise) {
+      add_node = tester.Node(i);
+    }
+  }
+  ASSERT_NE(add_node, nullptr);
+  ASSERT_EQ(add_node->inputs[0], input_id);
+  ASSERT_EQ(add_node->inputs[1], input_id);
+  ASSERT_EQ(unoptimized_output, optimized_output);
+}
+
 TEST(UNARY_QUANTIZED_TO_LUT, binary_not_unary) {
   // Create the subgraph x + max(x, y)
   const uint32_t x_id = 0;


### PR DESCRIPTION
## Problem

`xnn_subgraph_fusion`'s "fuse copy downstream" block rewrites the consumer's reference to the copy's output and then clears both the Copy node and its output value, but it stops at the **first** matching input:

```c
for (size_t i = 0; i < consumer->num_inputs; i++) {
  if (consumer->inputs[i] == copy_output_id) {
    consumer->inputs[i] = copy_input_id;
    found_consumer_input = true;
    // TODO(b/254734644): A consumer can only consume this value once,
    // since we asserted earlier that value has only 1 consumer, so we
    // can break here [...]
    break;
  }
}
```

That assumption does not hold: `xnn_subgraph_analyze_consumers_and_producers` skips repeated inputs (`is_repeated_input`), so a node that uses the same value for *both* operands still counts as a single consumer and passes the `value->num_consumers == 1` gate. The second input is then left pointing at the value that `xnn_value_clear` just wiped.

So a graph as simple as `add(y, y)` with `y = copy(x)` **segfaults** in `xnn_create_runtime_v4` with the default flags:

```c
xnn_define_copy(subgraph, x_id, y_id, 0);
xnn_define_binary(subgraph, xnn_binary_add, NULL, y_id, y_id, out_id, 0);
xnn_create_runtime_v4(subgraph, NULL, NULL, NULL, /*flags=*/0, &runtime);  // SIGSEGV
```

With `XNN_FLAG_NO_OPERATOR_FUSION` the same graph runs and gives the right answer. Every binary operator is affected (`add`, `multiply`, `maximum`, `divide`, `subtract`, `atan2`, `squared_difference`, ...).

## Fix

Rewrite *every* input of the consumer that refers to the copy's output, since the value is cleared right after. One-line change plus the comment.

## Validation

- New `COPY_THEN_BINARY_WITH_REPEATED_INPUT` test in `test/subgraph/fusion.cc`: it segfaults (exit 139) on `master` and passes with this change; it also checks that both inputs of the `add` end up pointing at the Copy's input and that the fused and unfused runtimes agree.
- `broadcast`, `binary`, `fusion`, `rewrites`, `copy`, `subgraph`, `static-reshape`, `static-expand-dims`, `batch-matrix-multiply` and `split-fuse` subgraph tests all pass (Linux x86-64, Release).
- Found by a random-subgraph differential fuzzer comparing the default runtime against `XNN_FLAG_NO_OPERATOR_FUSION`, `XNN_FLAG_SLOW_CONSISTENT_ARITHMETIC` and a node-by-node chain: 7 of 4000 random graphs crashed, all of them this pattern.

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed and validated before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
