### PR TITLE
Do not rewrite min/max to clamp when the constant operand broadcasts the input

### DIFF
--- a/src/subgraph.c
+++ b/src/subgraph.c
@@ -3007,6 +3007,18 @@ static enum xnn_status optimize_common_subgraphs_min_max_to_clamp(
     // rank, so we can't replace the operator.
     return xnn_status_success;
   }
+  // `arg_value` may be a whole tensor that is merely known to be all zeros or
+  // all ones (e.g. the output of `div(x, x)`), so also make sure that it does
+  // not broadcast `input_value` up in any dimension: the `clamp` keeps
+  // `input_value`'s shape.
+  const size_t rank_diff =
+      input_value->shape.num_dims - arg_value->shape.num_dims;
+  for (size_t i = 0; i < arg_value->shape.num_dims; i++) {
+    const size_t arg_dim = arg_value->shape.dim[i];
+    if (arg_dim != 1 && arg_dim != input_value->shape.dim[i + rank_diff]) {
+      return xnn_status_success;
+    }
+  }
 
   // Extract the min/max argument.
   const float arg_as_float = (arg_value->flags & XNN_VALUE_FLAG_IS_ZERO) ? 0.0f

--- a/test/subgraph/rewrites.cc
+++ b/test/subgraph/rewrites.cc
@@ -2076,4 +2076,53 @@ INSTANTIATE_TEST_SUITE_P(Rewrite, RewriteArithmeticTest,
                          testing::Values(0, 1, 3));
 INSTANTIATE_TEST_SUITE_P(Rewrite, RewriteGemmTest, testing::Values(3, 4));
 
+TEST(RewriteMinMaxToClamp, KeepsBroadcastingConstantOperand) {
+  // minimum(w[1, 5], pow(x[4, 5], 0)): the second operand is known to be all
+  // ones, but it broadcasts `w` up to [4, 5], so the node must not be turned
+  // into a clamp of `w`, whose output would only be [1, 5].
+  ASSERT_EQ(xnn_status_success, xnn_initialize(nullptr /* allocator */));
+  const uint32_t w_id = 0;
+  const uint32_t x_id = 1;
+  const uint32_t out_id = 2;
+  const std::vector<size_t> w_shape = {1, 5};
+  const std::vector<size_t> x_shape = {4, 5};
+  SubgraphTester subgraph(3);
+  subgraph.AddInputTensor(w_shape, xnn_datatype_fp32, w_id)
+      .AddInputTensor(x_shape, xnn_datatype_fp32, x_id)
+      .AddOutputTensor(x_shape, xnn_datatype_fp32, out_id);
+  Tensor<float> zero(std::vector<size_t>{1}, xnnpack::XnnExtraBytes);
+  std::fill(zero.begin(), zero.end(), 0.0f);
+  uint32_t zero_id = XNN_INVALID_VALUE_ID;
+  subgraph.AddInternalStaticTensor({1}, xnn_datatype_fp32, &zero_id,
+                                   zero.base(), /*flags=*/0);
+  const uint32_t ones_id =
+      add_internal_dynamic_tensor<float>(subgraph, x_shape);
+  subgraph.AddBinary(xnn_binary_pow, /*params=*/nullptr, x_id, zero_id, ones_id)
+      .AddBinary(xnn_binary_minimum, /*params=*/nullptr, w_id, ones_id, out_id);
+  ASSERT_EQ(subgraph.CreateRuntime(), xnn_status_success);
+
+  Tensor<float> w(w_shape, xnnpack::XnnExtraBytes);
+  std::iota(w.begin(), w.end(), -2.0f);
+  Tensor<float> x(x_shape, xnnpack::XnnExtraBytes);
+  std::fill(x.begin(), x.end(), 3.0f);
+  subgraph.ReshapeExternalTensor(w_shape, w.base(), w_id)
+      .ReshapeExternalTensor(x_shape, x.base(), x_id)
+      .ReshapeRuntime();
+  ASSERT_EQ(subgraph.Status(), xnn_status_success);
+  ASSERT_EQ(subgraph.GetExternalTensorShape(out_id), x_shape);
+
+  Tensor<float> output(x_shape);
+  subgraph.SetupExternalTensor(output.base(), out_id)
+      .SetupRuntime()
+      .InvokeRuntime();
+  ASSERT_EQ(subgraph.Status(), xnn_status_success);
+  std::vector<float> expected;
+  for (size_t i = 0; i < x_shape[0]; i++) {
+    for (size_t j = 0; j < x_shape[1]; j++) {
+      expected.push_back(std::min(-2.0f + j, 1.0f));
+    }
+  }
+  ASSERT_THAT(output, testing::ElementsAreArray(expected));
+}
+
 }  // namespace xnnpack


### PR DESCRIPTION
## Problem

`optimize_common_subgraphs_min_max_to_clamp` replaces `minimum`/`maximum` with a unary `clamp` of the other operand when one operand is "a static scalar". It accepts as such any value that carries a propagated constant flag:

```c
const bool arg_is_static_scalar =
    xnn_value_is_const(arg_value->flags) ||            // IS_ZERO / IS_ONE
    (xnn_shape_multiply_all_dims(&arg_value->shape) == 1 &&
     xnn_value_is_static(arg_value->allocation_type));
```

`XNN_VALUE_FLAG_IS_ZERO` / `IS_ONE` are set by constant propagation on values of **any** shape, e.g. the output of `pow(x, 0)`, `prelu(1, x)`, `mul(x, 0)`, `div(x, x)`. The only shape check that follows is on the rank, so when the flagged operand is a whole tensor that is *larger* than the other operand, the rewrite silently drops the broadcast: `clamp` keeps its input's shape.

```c
p   = pow(x[4, 5], 0);          // flagged IS_ONE, shape [4, 5]
out = minimum(w[1, 5], p);      // must be [4, 5]
```

gives shape `[1, 5]` with the default flags (5 of the 20 output elements written) and `[4, 5]` under `XNN_FLAG_NO_OPERATOR_FUSION`. Same with `maximum`, with `prelu(1, x)` / `mul(x, 0)` as the flagged operand, and with the operands swapped (`minimum(1[1], pow(1, x[4]))` gives `[1]` instead of `[4]`).

## Fix

Additionally require every dimension of the constant operand to be `1` or equal to the corresponding (trailing-aligned) dimension of the input, so that the `clamp`'s output shape is the node's output shape. The existing rank guard is kept.

## Validation

- New `RewriteMinMaxToClamp.KeepsBroadcastingConstantOperand` in `test/subgraph/rewrites.cc`: fails on `master` (shape `[1, 5]`, wrong values), passes with this change.
- `broadcast`, `binary`, `fusion`, `rewrites`, `copy`, `subgraph`, `static-reshape`, `static-expand-dims`, `batch-matrix-multiply` and `split-fuse` subgraph tests all pass (Linux x86-64, Release). The existing `RewritesMinMaxWithStaticArgsToClamp` / `RewritesMaxMinWithStaticArgsToClamp` tests, which use genuine scalars, still rewrite.
- Found by a random-subgraph differential fuzzer comparing the default runtime against `XNN_FLAG_NO_OPERATOR_FUSION`, `XNN_FLAG_SLOW_CONSISTENT_ARITHMETIC` and a node-by-node chain.

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed and validated before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
