### PR TITLE
Fix the output shape of the static_broadcast lowering

### DIFF
--- a/src/subgraph.c
+++ b/src/subgraph.c
@@ -2696,6 +2696,81 @@ static enum xnn_status optimize_common_subgraphs_reduce_sum_to_square(
   return xnn_status_success;
 }
 
+// Computes the shape of the result of broadcasting `a` against `b` over all
+// but their last `num_trailing_dims` dimensions (which are left out of the
+// result). Returns false if the two are not broadcast-compatible.
+static bool broadcast_leading_dims(const struct xnn_shape* a,
+                                   const struct xnn_shape* b,
+                                   size_t num_trailing_dims,
+                                   struct xnn_shape* result) {
+  if (a->num_dims < num_trailing_dims || b->num_dims < num_trailing_dims) {
+    return false;
+  }
+  const size_t a_rank = a->num_dims - num_trailing_dims;
+  const size_t b_rank = b->num_dims - num_trailing_dims;
+  const size_t rank = max(a_rank, b_rank);
+  result->num_dims = rank;
+  for (size_t i = 0; i < rank; i++) {
+    // Broadcasting aligns the trailing dimensions; missing leading ones are 1.
+    const size_t a_dim = i + a_rank >= rank ? a->dim[i + a_rank - rank] : 1;
+    const size_t b_dim = i + b_rank >= rank ? b->dim[i + b_rank - rank] : 1;
+    if (a_dim != b_dim && a_dim != 1 && b_dim != 1) {
+      return false;
+    }
+    result->dim[i] = max(a_dim, b_dim);
+  }
+  return true;
+}
+
+// Returns true if replacing the inputs of `consumer` that refer to `output_id`
+// with `input_id` (whose value is broadcast into `output_id`) leaves the
+// consumer's result shape unchanged, i.e. the consumer's own implicit
+// broadcasting already produces the broadcast's output shape.
+static bool consumer_broadcasts_implicitly(const xnn_subgraph_t subgraph,
+                                           const struct xnn_node* consumer,
+                                           uint32_t input_id,
+                                           uint32_t output_id) {
+  if (consumer->num_inputs != 2) {
+    return false;
+  }
+  // Binary elementwise nodes broadcast all dimensions; batch_matrix_multiply
+  // only broadcasts the batch dimensions, so the broadcast must leave the
+  // matrix dimensions alone.
+  size_t num_trailing_dims = 0;
+  const struct xnn_shape* input_shape = &subgraph->values[input_id].shape;
+  const struct xnn_shape* output_shape = &subgraph->values[output_id].shape;
+  if (consumer->type == xnn_node_type_batch_matrix_multiply) {
+    if (consumer->flags & XNN_FLAG_NO_BROADCAST) {
+      return false;
+    }
+    num_trailing_dims = 2;
+    if (input_shape->num_dims < 2 || output_shape->num_dims < 2) {
+      return false;
+    }
+    for (size_t i = 0; i < 2; i++) {
+      if (input_shape->dim[input_shape->num_dims - 1 - i] !=
+          output_shape->dim[output_shape->num_dims - 1 - i]) {
+        return false;
+      }
+    }
+  } else if (consumer->type != xnn_node_type_binary_elementwise) {
+    return false;
+  }
+  const struct xnn_shape* before[2];
+  const struct xnn_shape* after[2];
+  for (size_t j = 0; j < 2; j++) {
+    before[j] = &subgraph->values[consumer->inputs[j]].shape;
+    after[j] = consumer->inputs[j] == output_id ? input_shape : before[j];
+  }
+  struct xnn_shape shape_before;
+  struct xnn_shape shape_after;
+  return broadcast_leading_dims(before[0], before[1], num_trailing_dims,
+                                &shape_before) &&
+         broadcast_leading_dims(after[0], after[1], num_trailing_dims,
+                                &shape_after) &&
+         xnn_shape_match(&shape_before, &shape_after);
+}
+
 // XNNPACK doesn't need explicit braodcasting for binary and
 // batch_matrix_multiply nodes, so check if it can be elided.
 static enum xnn_status optimize_common_subgraphs_broadcast(
@@ -2710,6 +2785,7 @@ static enum xnn_status optimize_common_subgraphs_broadcast(
 
   const uint32_t input_id = node->inputs[0];
   const uint32_t output_id = node->outputs[0];
+  const struct xnn_value* input_value = &subgraph->values[input_id];
   const struct xnn_value* output_value = &subgraph->values[output_id];
 
   // Find all consumers of the broadcast node's output.
@@ -2717,15 +2793,19 @@ static enum xnn_status optimize_common_subgraphs_broadcast(
   for (uint32_t k = node_id + 1; k < subgraph->num_nodes && num_consumers;
        k++) {
     struct xnn_node* consumer = &subgraph->nodes[k];
+    bool consumes_output = false;
     for (uint32_t j = 0; j < consumer->num_inputs; j++) {
-      if (consumer->inputs[j] == output_id) {
-        // If the consumer is known to broadcast implicitly,
-        // short-circuit it.
-        if (consumer->type == xnn_node_type_binary_elementwise ||
-            consumer->type == xnn_node_type_batch_matrix_multiply) {
-          if (!is_repeated_input(consumer, j)) {
-            num_consumers--;
-          }
+      consumes_output |= consumer->inputs[j] == output_id;
+    }
+    // If the consumer is known to broadcast implicitly, and doing so gives
+    // the same result shape as the explicit broadcast, short-circuit it. A
+    // consumer counts once no matter how many of its inputs it feeds.
+    if (consumes_output &&
+        consumer_broadcasts_implicitly(subgraph, consumer, input_id,
+                                       output_id)) {
+      num_consumers--;
+      for (uint32_t j = 0; j < consumer->num_inputs; j++) {
+        if (consumer->inputs[j] == output_id) {
           consumer->inputs[j] = input_id;
           (*changes)++;
         }
@@ -2743,15 +2823,21 @@ static enum xnn_status optimize_common_subgraphs_broadcast(
     // that, when added to the input, will result in the correct
     // output shape.
     size_t shape[XNN_MAX_TENSOR_DIMS];
-    size_t num_dims = node->params.static_reshape.new_shape.num_dims;
-    const struct xnn_value* input_value = &subgraph->values[input_id];
+    const size_t num_dims = node->params.static_reshape.new_shape.num_dims;
+    const size_t input_num_dims = input_value->shape.num_dims;
     const size_t* old_shape = input_value->shape.dim;
     const size_t* new_shape = node->params.static_reshape.new_shape.dim;
+    // The input's dimensions line up with the trailing dimensions of the
+    // output. A dimension that the input already has is broadcast against 1;
+    // the zero tensor supplies the new and the grown dimensions.
+    const size_t rank_diff =
+        num_dims > input_num_dims ? num_dims - input_num_dims : 0;
     size_t num_elements = 1;
     for (uint32_t k = 0; k < num_dims; k++) {
-      shape[k] = (new_shape[k] == 0 || new_shape[k] == old_shape[k])
-                     ? 1
-                     : new_shape[k];
+      const bool has_old_dim = k >= rank_diff;
+      const size_t old_dim = has_old_dim ? old_shape[k - rank_diff] : 1;
+      const size_t dim = new_shape[k] == 0 ? old_dim : new_shape[k];
+      shape[k] = (has_old_dim && dim == old_dim) ? 1 : dim;
       num_elements *= shape[k];
     }
 

--- a/test/subgraph/broadcast.cc
+++ b/test/subgraph/broadcast.cc
@@ -105,6 +105,90 @@ void TestImpl(size_t rank) {
   }
 }
 
+// Runs `input -> static_broadcast -> consumer -> output` with the default
+// runtime flags, so the static_broadcast is either elided into the consumer or
+// rewritten into a broadcasting add of zero, and checks the output shape and
+// values. The consumer is `add(., other)` when `other_shape` is given and
+// `abs(.)` otherwise.
+static void CheckStaticBroadcast(const std::vector<size_t>& input_shape,
+                                 const std::vector<size_t>& broadcast_shape,
+                                 const std::vector<size_t>& other_shape,
+                                 const std::vector<size_t>& expected_shape,
+                                 const std::vector<float>& expected_values) {
+  ASSERT_EQ(xnn_status_success, xnn_initialize(nullptr /* allocator */));
+  const uint32_t input_id = 0;
+  const uint32_t output_id = 1;
+  const uint32_t other_id = 2;
+  const bool binary = !other_shape.empty();
+  SubgraphTester subgraph(binary ? 3 : 2);
+  subgraph.AddInputTensor(input_shape, xnn_datatype_fp32, input_id)
+      .AddOutputTensor(expected_shape, xnn_datatype_fp32, output_id);
+  if (binary) {
+    subgraph.AddInputTensor(other_shape, xnn_datatype_fp32, other_id);
+  }
+  uint32_t broadcast_id = XNN_INVALID_VALUE_ID;
+  subgraph.AddInternalDynamicTensor(expected_shape, xnn_datatype_fp32,
+                                    &broadcast_id, /*flags=*/0);
+  subgraph.AddBroadcast(broadcast_shape, input_id, broadcast_id);
+  if (binary) {
+    subgraph.AddBinary(xnn_binary_add, /*params=*/nullptr, broadcast_id,
+                       other_id, output_id);
+  } else {
+    subgraph.AddUnary(xnn_unary_abs, /*params=*/nullptr, broadcast_id,
+                      output_id);
+  }
+  ASSERT_EQ(subgraph.CreateRuntime(), xnn_status_success);
+
+  // input = -1, -2, -3, ...; other = 10, 11, 12, ...
+  Tensor<float> input(input_shape, xnnpack::XnnExtraBytes);
+  float next_input = 0.0f;
+  input.generate([&]() { return next_input -= 1.0f; });
+  Tensor<float> other(binary ? other_shape : std::vector<size_t>{1},
+                      xnnpack::XnnExtraBytes);
+  std::iota(other.begin(), other.end(), 10.0f);
+  subgraph.ReshapeExternalTensor(input_shape, input.base(), input_id);
+  if (binary) {
+    subgraph.ReshapeExternalTensor(other_shape, other.base(), other_id);
+  }
+  subgraph.ReshapeRuntime();
+  ASSERT_EQ(subgraph.Status(), xnn_status_success);
+  ASSERT_EQ(subgraph.GetExternalTensorShape(output_id), expected_shape);
+
+  Tensor<float> output(expected_shape);
+  subgraph.SetupExternalTensor(output.base(), output_id)
+      .SetupRuntime()
+      .InvokeRuntime();
+  ASSERT_EQ(subgraph.Status(), xnn_status_success);
+  ASSERT_THAT(output, testing::ElementsAreArray(expected_values));
+}
+
+TEST(StaticBroadcastRewrite, ElidedIntoBinaryOnlyIfShapeUnchanged) {
+  // add(broadcast(s[1] -> [4, 5]), other[1, 5]): the add broadcasts only to
+  // [1, 5] on its own, so the broadcast may not be elided into it.
+  CheckStaticBroadcast(/*input_shape=*/{1}, /*broadcast_shape=*/{4, 5},
+                       /*other_shape=*/{1, 5}, /*expected_shape=*/{4, 5},
+                       {9, 10, 11, 12, 13, 9, 10, 11, 12, 13, 9, 10, 11, 12,
+                        13, 9, 10, 11, 12, 13});
+  // add(broadcast(s[1] -> [4, 5]), other[4, 5]): the add broadcasts to [4, 5]
+  // on its own, so the broadcast can be elided.
+  CheckStaticBroadcast(/*input_shape=*/{1}, /*broadcast_shape=*/{4, 5},
+                       /*other_shape=*/{4, 5}, /*expected_shape=*/{4, 5},
+                       {9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
+                        23, 24, 25, 26, 27, 28});
+}
+
+TEST(StaticBroadcastRewrite, MaterializesRankIncreasingBroadcast) {
+  // abs(broadcast(x[4] -> [4, 4])): the new leading dimension coincides with
+  // the input's only dimension, which must not be mistaken for a kept one.
+  CheckStaticBroadcast(/*input_shape=*/{4}, /*broadcast_shape=*/{4, 4},
+                       /*other_shape=*/{}, /*expected_shape=*/{4, 4},
+                       {1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4});
+  // The same, with the passed-through dimension given as 0.
+  CheckStaticBroadcast(/*input_shape=*/{3}, /*broadcast_shape=*/{4, 0},
+                       /*other_shape=*/{}, /*expected_shape=*/{4, 3},
+                       {1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3});
+}
+
 template <typename T>
 class Broadcast : public ::testing::TestWithParam<int> {};
 


### PR DESCRIPTION
## Problem

`static_broadcast` has no runtime kernel (`reshape_copy_operator` returns `xnn_status_unsupported_parameter` for it), so `optimize_common_subgraphs_broadcast` is its only implementation. Both of its paths can produce the wrong output shape.

**1. Elision into a binary / batch-matmul consumer ignores the other operand.** The pass replaces the consumer's input with the *un-broadcast* value whenever the consumer broadcasts implicitly, without checking that the consumer's own broadcasting reaches the same shape:

```c
out = add(broadcast(s[1] -> [4, 5]), w[1, 5]);   // must be [4, 5]
```

becomes `add(s[1], w[1, 5])`, i.e. `[1, 5]`: 5 of the 20 output elements are written. (For `batch_matrix_multiply` only the batch dimensions broadcast, and `XNN_FLAG_NO_BROADCAST` disables even that.)

**2. The add-of-zero fallback aligns dimensions from the front.** Broadcasting aligns *trailing* dimensions, but the zero tensor's shape is built by comparing `new_shape[k]` with `old_shape[k]` at the same index:

```c
shape[k] = (new_shape[k] == 0 || new_shape[k] == old_shape[k]) ? 1 : new_shape[k];
```

so for `abs(broadcast(x[4] -> [4, 4]))` dimension 0 is taken to be "already there" (`new_shape[0] == old_shape[0] == 4`) and the result is `[1, 4]` instead of `[4, 4]`.

Both are wrong with the default flags; `XNN_FLAG_NO_OPERATOR_FUSION` fails the graph outright (no kernel), so there is no correct path today.

## Fix

- Elide the broadcast into a consumer only when doing so leaves the consumer's result shape unchanged, computed with a small `broadcast_leading_dims` helper (`batch_matrix_multiply` excludes the two matrix dimensions, which must not change, and is skipped entirely under `XNN_FLAG_NO_BROADCAST`).
- Build the fallback's zero tensor with trailing-dim alignment, so new leading dimensions and grown dimensions are both materialised.
- Count a consumer once even when it uses the broadcast for several inputs, and then rewrite all of those inputs together.

## Validation

- New `StaticBroadcastRewrite.ElidedIntoBinaryOnlyIfShapeUnchanged` and `StaticBroadcastRewrite.MaterializesRankIncreasingBroadcast` in `test/subgraph/broadcast.cc`: both fail on `master` and pass with this change. They also cover the cases that *should* still be elided.
- The existing randomized `Broadcast` tests (all datatypes, ranks 1..`XNN_MAX_TENSOR_DIMS`) still pass, as do `binary`, `fusion`, `rewrites`, `copy`, `subgraph`, `static-reshape`, `static-expand-dims`, `batch-matrix-multiply` and `split-fuse` (Linux x86-64, Release).
- Nine further hand-written control cases (equal-rank fallbacks, scalar fallback, rank-up with a coinciding dimension, `0`-marker shapes, broadcast as either operand, a consumer using the broadcast twice) match a plain C reference implementation of numpy-style broadcasting.
- Found by a random-subgraph differential fuzzer comparing the default runtime against `XNN_FLAG_NO_OPERATOR_FUSION`, `XNN_FLAG_SLOW_CONSISTENT_ARITHMETIC` and a node-by-node chain (~35 hits).

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed and validated before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
