### PR TITLE
free partial operator on config and alloc failure in create paths

### DIFF
--- a/src/operators/resize-bilinear-nchw.c
+++ b/src/operators/resize-bilinear-nchw.c
@@ -97,7 +97,7 @@ enum xnn_status xnn_create_resize_bilinear2d_nchw(
     xnn_log_error("failed to allocate %zu bytes for %s operator descriptor",
                   sizeof(struct xnn_convolution_operator),
                   xnn_operator_type_to_string(xnn_operator_type_resize_bilinear_nchw));
-    return xnn_status_out_of_memory;
+    goto error;
   }
 
   resize_op->convolution_op->output_height = output_height;

--- a/src/operators/transpose-nd.c
+++ b/src/operators/transpose-nd.c
@@ -762,7 +762,8 @@ enum xnn_status create_depth_to_space_nchw2nhwc(
   if (!transpose_config) {
     xnn_log_error(
       "failed to create transpose config: unsupported hardware configuration");
-    return xnn_status_unsupported_hardware;
+    status = xnn_status_unsupported_hardware;
+    goto error;
   }
 
   depth_to_space_op->depth_to_space.block_size = block_size;
@@ -1038,7 +1039,8 @@ static enum xnn_status create_depth_to_space_nhwc(
   if (!transpose_config) {
     xnn_log_error(
       "failed to create transpose config: unsupported hardware configuration");
-    return xnn_status_unsupported_hardware;
+    status = xnn_status_unsupported_hardware;
+    goto error;
   }
 
   depth_to_space_op->depth_to_space.block_size = block_size;
@@ -1374,7 +1376,8 @@ static enum xnn_status create_space_to_depth_nhwc(
   if (!transpose_config) {
     xnn_log_error(
       "failed to create transpose config: unsupported hardware configuration");
-    return xnn_status_unsupported_hardware;
+    status = xnn_status_unsupported_hardware;
+    goto error;
   }
 
   space_to_depth_op->depth_to_space.block_size = block_size;

--- a/src/operators/unpooling-nhwc.c
+++ b/src/operators/unpooling-nhwc.c
@@ -86,7 +86,8 @@ enum xnn_status xnn_create_unpooling2d_nhwc_x32(
     xnn_log_error(
       "failed to create %s operator: unsupported hardware configuration",
       xnn_operator_type_to_string(xnn_operator_type_unpooling_nhwc_x32));
-    return xnn_status_unsupported_hardware;
+    status = xnn_status_unsupported_hardware;
+    goto error;
   }
 
   unpooling_op->convolution_op->padding_top = input_padding_top;


### PR DESCRIPTION
Counting allocator with a fault injected at the `convolution_op` allocation inside `xnn_create_resize_bilinear2d_nchw`:

    REPRO create_status=6 live_allocations_after=2

Status 6 is `xnn_status_out_of_memory`. Two allocations, the operator struct and its `compute` buffer, are still live after the create returns.

Tracked it down to the third of three consecutive allocation checks. The first two `goto error`, the third returns the status directly and so skips the `xnn_delete_operator` at the `error:` label. Same shape shows up on the unsupported-hardware config check in `xnn_create_unpooling2d_nhwc_x32` and in the three depth/space transpose creates (`create_depth_to_space_nchw2nhwc`, `create_depth_to_space_nhwc`, `create_space_to_depth_nhwc`): the config check sits after the allocations and returns directly, whereas the sibling `create_transpose_nd` checks the config before allocating anything.

Each faulty path now routes to the function's existing cleanup label, setting `status` first where the return value was not already `out_of_memory`. The returned status is unchanged; only the partial operator is released. With the fix `live_allocations_after` is 0.
