### PR TITLE
src/operators/reduce-nd: guard workspace size against integer overflow

### DIFF
--- a/src/operators/reduce-nd.c
+++ b/src/operators/reduce-nd.c
@@ -240,7 +240,13 @@ static XNN_NO_SANITIZE_FUNCTION enum xnn_status reshape_reduce_nd(
   size_t num_reduction_elements;
   if (normalized_reduction_axes[num_reduction_axes - 1] == num_input_dims - 1) {
     if (workspace_size != NULL) {
-      const size_t num_output_elements = normalized_input_shape[0] * normalized_input_shape[2] * normalized_input_shape[4];
+      size_t num_output_elements;
+      if (!xnn_safe_mul(normalized_input_shape[0], normalized_input_shape[2], &num_output_elements) ||
+          !xnn_safe_mul(num_output_elements, normalized_input_shape[4], &num_output_elements)) {
+        xnn_log_error("failed to reshape %s operator: workspace size overflow",
+                      xnn_operator_type_to_string_v2(reduce_op));
+        return xnn_status_out_of_memory;
+      }
       *workspace_size = (num_output_elements << log2_accumulator_element_size) + XNN_EXTRA_BYTES;
     }
     num_reduction_elements = normalized_input_shape[1] * normalized_input_shape[3] * normalized_input_shape[5];
@@ -282,7 +288,13 @@ static XNN_NO_SANITIZE_FUNCTION enum xnn_status reshape_reduce_nd(
     // Reduction along the non-innermost dimension
     const size_t channel_like_dim = normalized_input_shape[XNN_MAX_TENSOR_DIMS - 1];
     if (workspace_size != NULL) {
-      const size_t num_output_elements = normalized_input_shape[1] * normalized_input_shape[3] * normalized_input_shape[5];
+      size_t num_output_elements;
+      if (!xnn_safe_mul(normalized_input_shape[1], normalized_input_shape[3], &num_output_elements) ||
+          !xnn_safe_mul(num_output_elements, normalized_input_shape[5], &num_output_elements)) {
+        xnn_log_error("failed to reshape %s operator: workspace size overflow",
+                      xnn_operator_type_to_string_v2(reduce_op));
+        return xnn_status_out_of_memory;
+      }
       *workspace_size = (num_output_elements << log2_accumulator_element_size) + XNN_EXTRA_BYTES;
     }
     num_reduction_elements = normalized_input_shape[0] * normalized_input_shape[2] * normalized_input_shape[4];


### PR DESCRIPTION
## Problem

`xnn_reshape_reduce_nd` computes the inference-time workspace size for non-FP32 reduce operators (FP16, QS8, QU8 Sum/Mean/ReduceMin/ReduceMax/SumSquared/MeanSquared) as a bare triple product of three `size_t` shape dimensions with no overflow check:

```c
// Path 1 — reduction along the innermost dimension (line 243)
const size_t num_output_elements =
    normalized_input_shape[0] * normalized_input_shape[2] *
    normalized_input_shape[4];   // ← no overflow guard

// Path 2 — reduction along a non-innermost dimension (line 285)
const size_t num_output_elements =
    normalized_input_shape[1] * normalized_input_shape[3] *
    normalized_input_shape[5];   // ← no overflow guard
```

`xnn_normalize_reduction` only validates that the number of dimensions does not exceed `XNN_MAX_TENSOR_DIMS == 6`; it does not bound individual dimension values. When three non-reduced dimensions are each ~3,000,000, the triple product overflows `size_t` on a 64-bit host and wraps to a small residue, so `*workspace_size` is set to a tiny value (potentially as small as `XNN_EXTRA_BYTES`).

The compute kernel then iterates over `range[0] × range[1] × range[2]` using the actual (un-overflowed) dimension values stored at lines 273–275, writing accumulator data far past the end of the tiny workspace allocation — **heap out-of-bounds write**.

FP32 is not affected because `src/subgraph/static-reduce.c` passes `workspace_size = NULL` for `xnn_datatype_fp32`, skipping the computation entirely.

## Fix

Replace both bare triple products with two chained `xnn_safe_mul` calls and return `xnn_status_out_of_memory` on overflow, matching the pattern already applied to `batch-matrix-multiply-nc.c` and `fully-connected-nc.c`.